### PR TITLE
Jenkins scripts

### DIFF
--- a/app/contexts.go
+++ b/app/contexts.go
@@ -22,22 +22,23 @@ type AuthorizeLoginContext struct {
 	context.Context
 	*goa.ResponseData
 	*goa.RequestData
-	Service *goa.Service
 }
 
 // NewAuthorizeLoginContext parses the incoming request URL and body, performs validations and creates the
 // context used by the login controller authorize action.
 func NewAuthorizeLoginContext(ctx context.Context, service *goa.Service) (*AuthorizeLoginContext, error) {
 	var err error
+	resp := goa.ContextResponse(ctx)
+	resp.Service = service
 	req := goa.ContextRequest(ctx)
-	rctx := AuthorizeLoginContext{Context: ctx, ResponseData: goa.ContextResponse(ctx), RequestData: req, Service: service}
+	rctx := AuthorizeLoginContext{Context: ctx, ResponseData: resp, RequestData: req}
 	return &rctx, err
 }
 
 // OK sends a HTTP response with status code 200.
 func (ctx *AuthorizeLoginContext) OK(r *AuthToken) error {
 	ctx.ResponseData.Header().Set("Content-Type", "application/vnd.authtoken+json")
-	return ctx.Service.Send(ctx.Context, 200, r)
+	return ctx.ResponseData.Service.Send(ctx.Context, 200, r)
 }
 
 // Unauthorized sends a HTTP response with status code 401.
@@ -51,22 +52,23 @@ type GenerateLoginContext struct {
 	context.Context
 	*goa.ResponseData
 	*goa.RequestData
-	Service *goa.Service
 }
 
 // NewGenerateLoginContext parses the incoming request URL and body, performs validations and creates the
 // context used by the login controller generate action.
 func NewGenerateLoginContext(ctx context.Context, service *goa.Service) (*GenerateLoginContext, error) {
 	var err error
+	resp := goa.ContextResponse(ctx)
+	resp.Service = service
 	req := goa.ContextRequest(ctx)
-	rctx := GenerateLoginContext{Context: ctx, ResponseData: goa.ContextResponse(ctx), RequestData: req, Service: service}
+	rctx := GenerateLoginContext{Context: ctx, ResponseData: resp, RequestData: req}
 	return &rctx, err
 }
 
 // OK sends a HTTP response with status code 200.
 func (ctx *GenerateLoginContext) OK(r AuthTokenCollection) error {
 	ctx.ResponseData.Header().Set("Content-Type", "application/vnd.authtoken+json; type=collection")
-	return ctx.Service.Send(ctx.Context, 200, r)
+	return ctx.ResponseData.Service.Send(ctx.Context, 200, r)
 }
 
 // Unauthorized sends a HTTP response with status code 401.
@@ -80,20 +82,21 @@ type ShowVersionContext struct {
 	context.Context
 	*goa.ResponseData
 	*goa.RequestData
-	Service *goa.Service
 }
 
 // NewShowVersionContext parses the incoming request URL and body, performs validations and creates the
 // context used by the version controller show action.
 func NewShowVersionContext(ctx context.Context, service *goa.Service) (*ShowVersionContext, error) {
 	var err error
+	resp := goa.ContextResponse(ctx)
+	resp.Service = service
 	req := goa.ContextRequest(ctx)
-	rctx := ShowVersionContext{Context: ctx, ResponseData: goa.ContextResponse(ctx), RequestData: req, Service: service}
+	rctx := ShowVersionContext{Context: ctx, ResponseData: resp, RequestData: req}
 	return &rctx, err
 }
 
 // OK sends a HTTP response with status code 200.
 func (ctx *ShowVersionContext) OK(r *Version) error {
 	ctx.ResponseData.Header().Set("Content-Type", "application/vnd.version+json")
-	return ctx.Service.Send(ctx.Context, 200, r)
+	return ctx.ResponseData.Service.Send(ctx.Context, 200, r)
 }

--- a/app/test/login.go
+++ b/app/test/login.go
@@ -13,13 +13,15 @@ import (
 	"testing"
 )
 
-// AuthorizeLoginOK test setup
-func AuthorizeLoginOK(t *testing.T, ctrl app.LoginController) *app.AuthToken {
-	return AuthorizeLoginOKCtx(t, context.Background(), ctrl)
+// AuthorizeLoginOK Authorize runs the method Authorize of the given controller with the given parameters.
+// It returns the response writer so it's possible to inspect the response headers and the media type struct written to the response.
+func AuthorizeLoginOK(t *testing.T, ctrl app.LoginController) (http.ResponseWriter, *app.AuthToken) {
+	return AuthorizeLoginOKWithContext(t, context.Background(), ctrl)
 }
 
-// AuthorizeLoginOKCtx test setup
-func AuthorizeLoginOKCtx(t *testing.T, ctx context.Context, ctrl app.LoginController) *app.AuthToken {
+// AuthorizeLoginOKWithContext Authorize runs the method Authorize of the given controller with the given parameters.
+// It returns the response writer so it's possible to inspect the response headers and the media type struct written to the response.
+func AuthorizeLoginOKWithContext(t *testing.T, ctx context.Context, ctrl app.LoginController) (http.ResponseWriter, *app.AuthToken) {
 	var logBuf bytes.Buffer
 	var resp interface{}
 	respSetter := func(r interface{}) { resp = r }
@@ -41,31 +43,34 @@ func AuthorizeLoginOKCtx(t *testing.T, ctx context.Context, ctrl app.LoginContro
 	if err != nil {
 		t.Fatalf("controller returned %s, logs:\n%s", err, logBuf.String())
 	}
-
-	a, ok := resp.(*app.AuthToken)
-	if !ok {
-		t.Errorf("invalid response media: got %+v, expected instance of app.AuthToken", resp)
-	}
-
 	if rw.Code != 200 {
 		t.Errorf("invalid response status code: got %+v, expected 200", rw.Code)
 	}
-
-	err = a.Validate()
-	if err != nil {
-		t.Errorf("invalid response payload: got %v", err)
+	var mt *app.AuthToken
+	if resp != nil {
+		var ok bool
+		mt, ok = resp.(*app.AuthToken)
+		if !ok {
+			t.Errorf("invalid response media: got %+v, expected instance of app.AuthToken", resp)
+		}
+		err = mt.Validate()
+		if err != nil {
+			t.Errorf("invalid response media type: %s", err)
+		}
 	}
-	return a
 
+	return rw, mt
 }
 
-// AuthorizeLoginUnauthorized test setup
-func AuthorizeLoginUnauthorized(t *testing.T, ctrl app.LoginController) {
-	AuthorizeLoginUnauthorizedCtx(t, context.Background(), ctrl)
+// AuthorizeLoginUnauthorized Authorize runs the method Authorize of the given controller with the given parameters.
+// It returns the response writer so it's possible to inspect the response headers.
+func AuthorizeLoginUnauthorized(t *testing.T, ctrl app.LoginController) http.ResponseWriter {
+	return AuthorizeLoginUnauthorizedWithContext(t, context.Background(), ctrl)
 }
 
-// AuthorizeLoginUnauthorizedCtx test setup
-func AuthorizeLoginUnauthorizedCtx(t *testing.T, ctx context.Context, ctrl app.LoginController) {
+// AuthorizeLoginUnauthorizedWithContext Authorize runs the method Authorize of the given controller with the given parameters.
+// It returns the response writer so it's possible to inspect the response headers.
+func AuthorizeLoginUnauthorizedWithContext(t *testing.T, ctx context.Context, ctrl app.LoginController) http.ResponseWriter {
 	var logBuf bytes.Buffer
 	var resp interface{}
 	respSetter := func(r interface{}) { resp = r }
@@ -87,20 +92,22 @@ func AuthorizeLoginUnauthorizedCtx(t *testing.T, ctx context.Context, ctrl app.L
 	if err != nil {
 		t.Fatalf("controller returned %s, logs:\n%s", err, logBuf.String())
 	}
-
 	if rw.Code != 401 {
 		t.Errorf("invalid response status code: got %+v, expected 401", rw.Code)
 	}
 
+	return rw
 }
 
-// GenerateLoginOK test setup
-func GenerateLoginOK(t *testing.T, ctrl app.LoginController) *app.AuthTokenCollection {
-	return GenerateLoginOKCtx(t, context.Background(), ctrl)
+// GenerateLoginOK Generate runs the method Generate of the given controller with the given parameters.
+// It returns the response writer so it's possible to inspect the response headers and the media type struct written to the response.
+func GenerateLoginOK(t *testing.T, ctrl app.LoginController) (http.ResponseWriter, *app.AuthTokenCollection) {
+	return GenerateLoginOKWithContext(t, context.Background(), ctrl)
 }
 
-// GenerateLoginOKCtx test setup
-func GenerateLoginOKCtx(t *testing.T, ctx context.Context, ctrl app.LoginController) *app.AuthTokenCollection {
+// GenerateLoginOKWithContext Generate runs the method Generate of the given controller with the given parameters.
+// It returns the response writer so it's possible to inspect the response headers and the media type struct written to the response.
+func GenerateLoginOKWithContext(t *testing.T, ctx context.Context, ctrl app.LoginController) (http.ResponseWriter, *app.AuthTokenCollection) {
 	var logBuf bytes.Buffer
 	var resp interface{}
 	respSetter := func(r interface{}) { resp = r }
@@ -122,31 +129,34 @@ func GenerateLoginOKCtx(t *testing.T, ctx context.Context, ctrl app.LoginControl
 	if err != nil {
 		t.Fatalf("controller returned %s, logs:\n%s", err, logBuf.String())
 	}
-
-	a, ok := resp.(*app.AuthTokenCollection)
-	if !ok {
-		t.Errorf("invalid response media: got %+v, expected instance of app.AuthTokenCollection", resp)
-	}
-
 	if rw.Code != 200 {
 		t.Errorf("invalid response status code: got %+v, expected 200", rw.Code)
 	}
-
-	err = a.Validate()
-	if err != nil {
-		t.Errorf("invalid response payload: got %v", err)
+	var mt *app.AuthTokenCollection
+	if resp != nil {
+		var ok bool
+		mt, ok = resp.(*app.AuthTokenCollection)
+		if !ok {
+			t.Errorf("invalid response media: got %+v, expected instance of app.AuthTokenCollection", resp)
+		}
+		err = mt.Validate()
+		if err != nil {
+			t.Errorf("invalid response media type: %s", err)
+		}
 	}
-	return a
 
+	return rw, mt
 }
 
-// GenerateLoginUnauthorized test setup
-func GenerateLoginUnauthorized(t *testing.T, ctrl app.LoginController) {
-	GenerateLoginUnauthorizedCtx(t, context.Background(), ctrl)
+// GenerateLoginUnauthorized Generate runs the method Generate of the given controller with the given parameters.
+// It returns the response writer so it's possible to inspect the response headers.
+func GenerateLoginUnauthorized(t *testing.T, ctrl app.LoginController) http.ResponseWriter {
+	return GenerateLoginUnauthorizedWithContext(t, context.Background(), ctrl)
 }
 
-// GenerateLoginUnauthorizedCtx test setup
-func GenerateLoginUnauthorizedCtx(t *testing.T, ctx context.Context, ctrl app.LoginController) {
+// GenerateLoginUnauthorizedWithContext Generate runs the method Generate of the given controller with the given parameters.
+// It returns the response writer so it's possible to inspect the response headers.
+func GenerateLoginUnauthorizedWithContext(t *testing.T, ctx context.Context, ctrl app.LoginController) http.ResponseWriter {
 	var logBuf bytes.Buffer
 	var resp interface{}
 	respSetter := func(r interface{}) { resp = r }
@@ -168,9 +178,9 @@ func GenerateLoginUnauthorizedCtx(t *testing.T, ctx context.Context, ctrl app.Lo
 	if err != nil {
 		t.Fatalf("controller returned %s, logs:\n%s", err, logBuf.String())
 	}
-
 	if rw.Code != 401 {
 		t.Errorf("invalid response status code: got %+v, expected 401", rw.Code)
 	}
 
+	return rw
 }

--- a/app/test/version.go
+++ b/app/test/version.go
@@ -13,13 +13,15 @@ import (
 	"testing"
 )
 
-// ShowVersionOK test setup
-func ShowVersionOK(t *testing.T, ctrl app.VersionController) *app.Version {
-	return ShowVersionOKCtx(t, context.Background(), ctrl)
+// ShowVersionOK Show runs the method Show of the given controller with the given parameters.
+// It returns the response writer so it's possible to inspect the response headers and the media type struct written to the response.
+func ShowVersionOK(t *testing.T, ctrl app.VersionController) (http.ResponseWriter, *app.Version) {
+	return ShowVersionOKWithContext(t, context.Background(), ctrl)
 }
 
-// ShowVersionOKCtx test setup
-func ShowVersionOKCtx(t *testing.T, ctx context.Context, ctrl app.VersionController) *app.Version {
+// ShowVersionOKWithContext Show runs the method Show of the given controller with the given parameters.
+// It returns the response writer so it's possible to inspect the response headers and the media type struct written to the response.
+func ShowVersionOKWithContext(t *testing.T, ctx context.Context, ctrl app.VersionController) (http.ResponseWriter, *app.Version) {
 	var logBuf bytes.Buffer
 	var resp interface{}
 	respSetter := func(r interface{}) { resp = r }
@@ -41,20 +43,21 @@ func ShowVersionOKCtx(t *testing.T, ctx context.Context, ctrl app.VersionControl
 	if err != nil {
 		t.Fatalf("controller returned %s, logs:\n%s", err, logBuf.String())
 	}
-
-	a, ok := resp.(*app.Version)
-	if !ok {
-		t.Errorf("invalid response media: got %+v, expected instance of app.Version", resp)
-	}
-
 	if rw.Code != 200 {
 		t.Errorf("invalid response status code: got %+v, expected 200", rw.Code)
 	}
-
-	err = a.Validate()
-	if err != nil {
-		t.Errorf("invalid response payload: got %v", err)
+	var mt *app.Version
+	if resp != nil {
+		var ok bool
+		mt, ok = resp.(*app.Version)
+		if !ok {
+			t.Errorf("invalid response media: got %+v, expected instance of app.Version", resp)
+		}
+		err = mt.Validate()
+		if err != nil {
+			t.Errorf("invalid response media type: %s", err)
+		}
 	}
-	return a
 
+	return rw, mt
 }

--- a/jenkins/linux/Dockerfile
+++ b/jenkins/linux/Dockerfile
@@ -1,0 +1,24 @@
+FROM fedora:23
+MAINTAINER "Konrad Kleine <kkleine@redhat.com>"
+ENV LANG=en_US.utf8
+
+# Some packages might seem weird but they are required by the
+# RVM installer
+RUN dnf install -y \
+      findutils \
+      git \ 
+      golang \
+      make \
+      mercurial \
+      procps-ng \
+      which \
+    && dnf clean all
+
+#----------------------------------------------------------
+# Misc.
+#----------------------------------------------------------
+
+# Mount source and build folders to these locations to get persitency
+VOLUME ["/source", "/build"]
+
+ENTRYPOINT ["/bin/bash"]

--- a/jenkins/linux/Makefile
+++ b/jenkins/linux/Makefile
@@ -1,0 +1,84 @@
+SOURCE_DIR := $(shell pwd)/../..
+DOCKER_IMAGE_CORE := almighty-core
+
+# If running in Jenkins we don't allow for interactively running the container
+ifneq ($(BUILD_TAG),)
+	DOCKER_RUN_INTERACTIVE_SWITCH :=
+else 
+	DOCKER_RUN_INTERACTIVE_SWITCH := -i
+endif
+
+# The workspace environment is set by Jenkins and defaults to /tmp if not set
+WORKSPACE ?= /tmp
+BUILD_DIR := $(WORKSPACE)/almighty-core-linux-build
+
+# The BUILD_TAG environment variable will be set by jenkins
+# to reflect jenkins-${JOB_NAME}-${BUILD_NUMBER}
+BUILD_TAG ?= almighty-core-local-build
+DOCKER_CONTAINER_NAME := $(BUILD_TAG)
+
+.PHONY: all
+# Triggers the "build" target
+all: build
+
+.PHONY: help
+# Shows all the commands and their description
+help:
+	@echo ""
+	@echo "Make file commands"
+	@echo "------------------"
+	@grep -Pzo "(?s)\.PHONY:(\N*)(.*)(^\1)" Makefile | grep -v Makefile | grep -o "\(.PHONY:.*\|^#.*\)" | sed -s 's/.PHONY:\s*/\n- /g' |sed -s 's/#/\t/g'
+
+.PHONY: docker-image-core
+# Builds the docker image used to build the software
+docker-image-core:
+	@echo "Building docker image $(DOCKER_IMAGE_CORE)"
+	docker build -t $(DOCKER_IMAGE_CORE) .
+
+.PHONY: build-dir
+# Creates the build directory
+build-dir:
+	@echo "Creating build directory $(BUILD_DIR)"
+	mkdir -p $(BUILD_DIR)
+
+.PHONY: clean-docker-container
+# Removes any existing container used to build the software (if any)
+clean-docker-container:
+	@echo "Removing container named \"$(DOCKER_CONTAINER_NAME)\" (if any)"
+ifneq ($(strip $(shell docker ps -qa --filter "name=$(DOCKER_CONTAINER_NAME)")),) 
+	docker rm -f $(DOCKER_CONTAINER_NAME)
+else
+	@echo "No container named \"$(DOCKER_CONTAINER_NAME)\" to remove"
+endif
+
+.PHONY: clean-build-dir
+# Removes the build directory
+clean-build-dir:
+	@echo "Cleaning build directory $(BUILD_DIR)"
+	rm -rf $(BUILD_DIR)
+
+.PHONY: clean
+# Triggers
+#  - clean-docker-container and
+#  - clean-build-dir
+clean: clean-docker-container clean-build-dir
+	
+.PHONY: build
+# Triggers 
+#  - build-dir and
+#  - docker-image-core
+# and then spawns a docker container to build the software
+build: build-dir docker-image-core
+	@echo "Building with container $(DOCKER_CONTAINER_NAME) inside of $(BUILD_DIR)"
+	docker run \
+		-t \
+		$(DOCKER_RUN_INTERACTIVE_SWITCH) \
+		--rm \
+		--name="$(DOCKER_CONTAINER_NAME)" \
+		-v $(SOURCE_DIR):/source-dir:ro \
+		-v $(BUILD_DIR):/build-dir:rw \
+		-e USER=$(USER) \
+		-e USERID=$(shell id -u $(USER)) \
+		$(DOCKER_IMAGE_CORE) \
+		/source-dir/jenkins/linux/build.sh /source-dir /build-dir
+

--- a/jenkins/linux/build.sh
+++ b/jenkins/linux/build.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Show all command prior to executing them
+set -x
+
+# Exit if a command fails
+set -e
+
+# Create user with same UID and name as the user that
+# started the container
+echo "Creating new user \"$USER\" with UID \"$USERID\""
+useradd -m ${USER} -u ${USERID}
+
+# Where the source is stored?
+# Take the value of the first and second argument or default
+# to /source and /build
+source_dir=${1:-/source}
+build_dir=${2:-/build}
+
+# Give all rights to users outside of the container
+function almighty_clean_up {
+  chown -R $USER ${build_dir} 
+}
+trap 'echo "SIGNAL received. Will clean up."; almighty_clean_up' SIGUSR1 SIGTERM SIGINT EXIT
+
+su $USER --command=" \
+mkdir -pv ${build_dir}/go/bin \
+&& mkdir -pv ${build_dir}/go/pkg \
+&& mkdir -pv ${build_dir}/go/src/github.com/almighty/almighty-core \
+&& export GOPATH=${build_dir}/go \
+&& export PATH=\$PATH:${build_dir}/go/bin \
+&& cd ${source_dir} \
+&& cp -Rfp . ${build_dir}/go/src/github.com/almighty/almighty-core \
+&& chown -Rf $USER ${build_dir} \
+&& cd ${build_dir}/go/src/github.com/almighty/almighty-core \
+&& make deps \
+&& make generate \
+&& make \
+"
+

--- a/tool/alm-cli/main.go
+++ b/tool/alm-cli/main.go
@@ -19,12 +19,13 @@ func main() {
 	}
 
 	// Create client struct
-	c := client.New(newHTTPClient())
+	httpClient := newHTTPClient()
+	c := client.New(httpClient)
 
 	// Register global flags
 	app.PersistentFlags().StringVarP(&c.Scheme, "scheme", "s", "", "Set the requests scheme")
 	app.PersistentFlags().StringVarP(&c.Host, "host", "H", "almighty.io", "API hostname")
-	app.PersistentFlags().DurationVarP(&c.Timeout, "timeout", "t", time.Duration(20)*time.Second, "Set the request timeout")
+	app.PersistentFlags().DurationVarP(&httpClient.Timeout, "timeout", "t", time.Duration(20)*time.Second, "Set the request timeout")
 	app.PersistentFlags().BoolVar(&c.Dump, "dump", false, "Dump HTTP request and response.")
 
 	// Register signer flags


### PR DESCRIPTION
This adds the ability for jenkins (or any other user) to build the software in an (semi-)reproducible environment (docker container) by running `cd jenkins/linux/ && make`.

Currently this fails with this reason:

```
go-bindata-assetfs -debug assets/...
godep get
go build -ldflags "-X main.Commit=`git rev-parse HEAD` -X main.BuildTime=`date -u '+%Y-%m-%d_%I:%M:%S%p'`" -o alm
cd tool/alm-cli && go build -o ../../alm-cli
# github.com/almighty/almighty-core/tool/alm-cli
./main.go:27: c.Timeout undefined (type *"github.com/almighty/almighty-core/client".Client has no field or method Timeout)
Makefile:32: recipe for target 'alm-cli' failed
make: *** [alm-cli] Error 2
+ echo 'SIGNAL received. Will clean up.'
SIGNAL received. Will clean up.
+ almighty_clean_up
+ chown -R kkleine /build-dir
Makefile:76: recipe for target 'build' failed
make: *** [build] Error 2
```