### PR TITLE
Ignore source files in vendor subdir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ else
 include ./Makefile.lnx
 endif
 SOURCE_DIR=.
-SOURCES := $(shell find $(SOURCE_DIR) -name '*.go')
+SOURCES := $(shell find $(SOURCE_DIR) -name '*.go' -not -path $(SOURCE_DIR)/vendor/*)
 DESIGN_DIR=design
-DESIGNS := $(shell find $(DESIGN_DIR) -name '*.go')
+DESIGNS := $(shell find $(DESIGN_DIR) -name '*.go' -not -path $(SOURCE_DIR)/vendor/*)
 
 # Used as target and binary output names... defined in includes
 CLIENT_DIR=tool/alm-cli


### PR DESCRIPTION
When finding all source and design *.go files, make sure the vendor subdirectory is ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/26)
<!-- Reviewable:end -->
