### PR TITLE
Fix Makefile find command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ else
 include ./Makefile.lnx
 endif
 SOURCE_DIR=.
-SOURCES := $(shell find $(SOURCE_DIR) -name '*.go' -not -path $(SOURCE_DIR)/vendor/*)
+SOURCES := $(shell find $(SOURCE_DIR) -path $(SOURCE_DIR)/vendor -prune -o -name '*.go' -print)
 DESIGN_DIR=design
-DESIGNS := $(shell find $(DESIGN_DIR) -name '*.go' -not -path $(SOURCE_DIR)/vendor/*)
+DESIGNS := $(shell find $(DESIGN_DIR) -path $(SOURCE_DIR)/vendor -prune -o -name '*.go' -print)
 
 # Used as target and binary output names... defined in includes
 CLIENT_DIR=tool/alm-cli


### PR DESCRIPTION
Fixes this error, when running in Cygwin:

````
$ find / -name "*.go" -not -path /usr/*
find: paths must precede expression: /usr/include
Usage: find [-H] [-L] [-P] [-Olevel] [-D help|tree|search|stat|rates|opt|exec] [path...] [expression]
````

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/27)
<!-- Reviewable:end -->
