### PR TITLE
Add seperation between unit and integration test using build tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,4 +89,8 @@ dev: $(FRESH_BIN)
 
 .PHONY: test
 test:
-	go test $(go list ./... | grep -v vendor) -dbhost localhost
+	go test $(go list ./... | grep -v vendor) -v
+
+.PHONY: test-integration
+test-integration:
+	go test $(go list ./... | grep -v vendor) -v -dbhost localhost -tags=integration

--- a/version_test.go
+++ b/version_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package main
 
 import (
@@ -17,7 +19,7 @@ func TestAuthorizeLoginOK(t *testing.T) {
 
 func TestShowVersionOK(t *testing.T) {
 	controller := VersionController{}
-	_, res := test.ShowVersionOK(t, nil, nil, &controller) 
+	_, res := test.ShowVersionOK(t, nil, nil, &controller)
 
 	if res.Commit != "0" {
 		t.Error("Commit not found")

--- a/workitem_test.go
+++ b/workitem_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (


### PR DESCRIPTION
Tests marked with // +build integration will only run when 'make test-integration' is called.

Tests marked with // +build !integration will not run when 'make test-integration' is called.

Makefile:

* make test
  Runs all non integraton tests
* make test-integration
  Runs all integration tests. Requires a DB

fixes #38

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/42)
<!-- Reviewable:end -->
