### PR TITLE
Re-use user:group of caller in jenkins automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,5 +121,4 @@ $(CHECK_GOPATH_BIN): .make/check-gopath.go
 ifndef GO_BIN
 	$(error The "$(GO_BIN_NAME)" executable could not be found in your PATH)
 endif
-	# Check that the code is located in $GOPATH/src/github.com/almighty/almighty-core
 	go build .make/check-gopath.go

--- a/jenkins/linux/Makefile
+++ b/jenkins/linux/Makefile
@@ -17,6 +17,10 @@ BUILD_DIR := $(WORKSPACE)/almighty-core-linux-build
 BUILD_TAG ?= almighty-core-local-build
 DOCKER_CONTAINER_NAME := $(BUILD_TAG)
 
+# Where is the GOPATH inside the build container?
+GOPATH=/tmp/go
+PACKAGE_PATH=$(GOPATH)/src/github.com/almighty/almighty-core
+
 .PHONY: all
 # Triggers the "build" target
 all: build
@@ -75,10 +79,9 @@ build: build-dir docker-image-core
 		$(DOCKER_RUN_INTERACTIVE_SWITCH) \
 		--rm \
 		--name="$(DOCKER_CONTAINER_NAME)" \
-		-v $(SOURCE_DIR):/source-dir:ro \
-		-v $(BUILD_DIR):/build-dir:rw \
-		-e USER=$(USER) \
-		-e USERID=$(shell id -u $(USER)) \
+		-v $(SOURCE_DIR):$(PACKAGE_PATH):rw \
+		-u $(shell id -u $(USER)):$(shell id -g $(USER)) \
+		-w $(PACKAGE_PATH) \
 		$(DOCKER_IMAGE_CORE) \
-		/source-dir/jenkins/linux/build.sh /source-dir /build-dir
+		$(PACKAGE_PATH)/jenkins/linux/build.sh
 

--- a/jenkins/linux/Makefile
+++ b/jenkins/linux/Makefile
@@ -18,8 +18,8 @@ BUILD_TAG ?= almighty-core-local-build
 DOCKER_CONTAINER_NAME := $(BUILD_TAG)
 
 # Where is the GOPATH inside the build container?
-GOPATH=/tmp/go
-PACKAGE_PATH=$(GOPATH)/src/github.com/almighty/almighty-core
+GOPATH_IN_CONTAINER=/tmp/go
+PACKAGE_PATH=$(GOPATH_IN_CONTAINER)/src/github.com/almighty/almighty-core
 
 .PHONY: all
 # Triggers the "build" target
@@ -81,6 +81,7 @@ build: build-dir docker-image-core
 		--name="$(DOCKER_CONTAINER_NAME)" \
 		-v $(SOURCE_DIR):$(PACKAGE_PATH):rw \
 		-u $(shell id -u $(USER)):$(shell id -g $(USER)) \
+		-e GOPATH=$(GOPATH_IN_CONTAINER) \
 		-w $(PACKAGE_PATH) \
 		$(DOCKER_IMAGE_CORE) \
 		$(PACKAGE_PATH)/jenkins/linux/build.sh

--- a/jenkins/linux/build.sh
+++ b/jenkins/linux/build.sh
@@ -13,7 +13,7 @@ make deps
 
 make generate 
 
-make 
+make build
 
 make test-unit 
 

--- a/jenkins/linux/build.sh
+++ b/jenkins/linux/build.sh
@@ -6,7 +6,6 @@ set -x
 # Exit if a command fails
 set -e
 
-export GOPATH=/tmp/go
 export PATH=$PATH:${GOPATH}/bin
 export GO15VENDOREXPERIMENT=1 
 

--- a/jenkins/linux/build.sh
+++ b/jenkins/linux/build.sh
@@ -6,38 +6,16 @@ set -x
 # Exit if a command fails
 set -e
 
-# Create user with same UID and name as the user that
-# started the container
-echo "Creating new user \"$USER\" with UID \"$USERID\""
-useradd -m ${USER} -u ${USERID}
+export GOPATH=/tmp/go
+export PATH=$PATH:${GOPATH}/bin
+export GO15VENDOREXPERIMENT=1 
 
-# Where the source is stored?
-# Take the value of the first and second argument or default
-# to /source and /build
-source_dir=${1:-/source}
-build_dir=${2:-/build}
+make deps 
 
-# Give all rights to users outside of the container
-function almighty_clean_up {
-  chown -R $USER ${build_dir} 
-}
-trap 'echo "SIGNAL received. Will clean up."; almighty_clean_up' SIGUSR1 SIGTERM SIGINT EXIT
+make generate 
 
-su $USER --command=" \
-mkdir -pv ${build_dir}/go/bin \
-&& mkdir -pv ${build_dir}/go/pkg \
-&& mkdir -pv ${build_dir}/go/src/github.com/almighty/almighty-core \
-&& export GOPATH=${build_dir}/go \
-&& export PATH=\$PATH:${build_dir}/go/bin \
-&& export GO15VENDOREXPERIMENT=1 \
-&& go env \
-&& cd ${source_dir} \
-&& cp -Rfp . ${build_dir}/go/src/github.com/almighty/almighty-core \
-&& chown -Rf $USER ${build_dir} \
-&& cd ${build_dir}/go/src/github.com/almighty/almighty-core \
-&& make deps \
-&& make generate \
-&& make \
-&& make test-unit \
-"
+make 
+
+make test-unit 
+
 


### PR DESCRIPTION
Previously I determined the username and group ID of the user that started the jenkins build script and created a user with the exact same ID inside the container.

This is not needed due to the "-u" switch on the "docker run" command.

This change greatly simplifies the build on a linux machine.

The build now runs in source and no longer out-of-source.

This greatly simplifies the way we build on a jenkins machine in terms of user-management and archiving artifacts that were built inside a container with proper permissions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/51)
<!-- Reviewable:end -->
