### PR TITLE
Runs docker container in the background so make dev can start ALM server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ generate: $(DESIGNS) $(GOAGEN_BIN) $(GO_BINDATA_ASSETFS_BIN) $(GO_BINDATA_BIN)
 
 .PHONY: dev
 dev: $(FRESH_BIN)
-	docker-compose up
+	docker-compose up -d
 	$(FRESH_BIN)
 
 .PHONY: test-all


### PR DESCRIPTION
Previously it was simply starting postgres instance and blocking on this step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/58)
<!-- Reviewable:end -->
