### PR TITLE
Fix #62: Show test coverage with makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,5 @@ tool/cli/
 bin/
 
 # Ignore Go coverage files
-**/coverage-unit.out
-**/coverage-integration.out
+**/coverage-*.out
+**/coverage-*.out

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,3 @@ tool/cli/
 
 # Ignore artifacts directory
 bin/
-
-# Ignore Go coverage files
-**/coverage-*.out
-**/coverage-*.out

--- a/.make/Makefile.lnx
+++ b/.make/Makefile.lnx
@@ -6,6 +6,7 @@ GO_BINDATA_BIN=$(VENDOR_DIR)/github.com/jteeuwen/go-bindata/go-bindata/go-bindat
 GO_BINDATA_ASSETFS_BIN=$(VENDOR_DIR)/github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs/go-bindata-assetfs
 FRESH_BIN=$(VENDOR_DIR)/github.com/pilu/fresh/fresh
 EXTRA_PATH=$(shell dirname $(GO_BINDATA_BIN))
+GOCOV_BIN=$(VENDOR_DIR)/github.com/axw/gocov/gocov/gocov
 
 GIT_BIN_NAME := git
 GLIDE_BIN_NAME := glide

--- a/.make/Makefile.win
+++ b/.make/Makefile.win
@@ -7,6 +7,7 @@ GO_BINDATA_DIR=$(VENDOR_DIR)/github.com/jteeuwen/go-bindata/go-bindata/
 GO_BINDATA_ASSETFS_BIN=$(VENDOR_DIR)/github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs/go-bindata-assetfs.exe
 FRESH_BIN=$(VENDOR_DIR)/github.com/pilu/fresh/fresh.exe
 EXTRA_PATH=$(shell cygpath --unix '$(GO_BINDATA_DIR)')
+GOCOV_BIN=$(VENDOR_DIR)/github.com/axw/gocov/gocov/gocov.exe
 
 GIT_BIN_NAME := git.exe
 GLIDE_BIN_NAME := glide.exe

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -27,7 +27,7 @@
 #
 # To output coverage profile information for each function, type
 #
-#     $ make show-coverage-unit-func
+#     $ make show-coverage-unit
 #
 # To generate HTML representation of coverage profile (opens a browser), type
 #
@@ -81,22 +81,22 @@ test-integration: prebuild-check clean-test-artifacts-integration $(COVERAGE_INT
 
 #-------------------------------------------------------------------------------
 # Inspect coverage of unit tests or integration tests in either pure
-# console mode (*-func) or in a browser (*-html).
+# console mode or in a browser (*-html).
 #
 # If the test coverage files to be evaluated already exist, then no new
 # tests are executed. If they don't exist, we first run the tests.
 #-------------------------------------------------------------------------------
 
-.PHONY: show-coverage-unit-func
-show-coverage-unit-func: prebuild-check $(COVERAGE_UNIT_PATH)
+.PHONY: show-coverage-unit
+show-coverage-unit: prebuild-check $(COVERAGE_UNIT_PATH)
 	go tool cover -func=$(COVERAGE_UNIT_PATH)
 
 .PHONY: show-coverage-unit-html
 show-coverage-unit-html: prebuild-check $(COVERAGE_UNIT_PATH)
 	go tool cover -html=$(COVERAGE_UNIT_PATH)
 
-.PHONY: show-coverage-integration-func
-show-coverage-integration-func: prebuild-check $(COVERAGE_INTEGRATION_PATH)
+.PHONY: show-coverage-integration
+show-coverage-integration: prebuild-check $(COVERAGE_INTEGRATION_PATH)
 	go tool cover -func=$(COVERAGE_INTEGRATION_PATH)
 
 .PHONY: show-coverage-integration-html

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -71,15 +71,15 @@ COVERAGE_INTEGRATION_PATH=$(TMP_PATH)/coverage-integration-mode-$(COVERAGE_MODE)
 #-------------------------------------------------------------------------------
 
 .PHONY: test-all
-## Runs test-unit and test-integration targets
+## Runs test-unit and test-integration targets.
 test-all: prebuild-check test-unit test-integration
 
 .PHONY: test-unit
-## Runs the unit tests and produces a coverage file
+## Runs the unit tests and produces a coverage file.
 test-unit: prebuild-check clean-test-artifacts-unit $(COVERAGE_UNIT_PATH)
 
 .PHONY: test-integration
-## Runs the integration tests and produces a coverage file
+## Runs the integration tests and produces a coverage file.
 test-integration: prebuild-check clean-test-artifacts-integration $(COVERAGE_INTEGRATION_PATH)
 
 #-------------------------------------------------------------------------------

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -1,0 +1,125 @@
+#===============================================================================
+# Testing has become a rather big and interconnected topic and that's why it
+# has arrived in it's own file.
+#
+# We have to types of tests available:
+#
+#  1. unit tests and
+#  2. integration tests.
+#
+# While the unit tests can be executed fairly simply be running `go test`, the
+# integration tests have a little bit more setup going on. That's why they are
+# split up in to tests.
+#
+# Usage
+# -----
+# If you want to run the unit tests, type
+#
+#     $ make test-unit
+#
+# To run the integration tests, type
+#
+#     $ make test-integration
+#
+# To run both tests, type
+#
+#     $ make test-all
+#
+# To show unit test coverage in a terminal, type
+#
+#     $ make show-coverage-unit-func
+#
+# To show unit test coverage in a browser, type
+#
+#     $ make show-coverage-unit-html
+#
+# If you replace the "unit" with "integration" you get the same for integration
+# tests.
+#
+# Artifacts and coverage modes
+# ----------------------------
+# We execute tests with coverage output by default. The files live in the
+# root folder and look something like `coverage-unit-mode-set.out` or
+# `coverage-integration-mode-count.out`.
+#
+# Each filename indicates whether it is for unit or integration tests and
+# what the coverage mode was used.
+#
+# These are possible coverage modes (see https://blog.golang.org/cover):
+#
+# 	set: did each statement run? (default)
+# 	count: how many times did each statement run?
+# 	atomic: like count, but counts precisely in parallel programs
+#
+# To choose another coverage mode, simply prefix the invovation of `make`:
+#
+#     $ COVERAGE_MODE=count make test-unit
+#===============================================================================
+
+COVERAGE_MODE ?= set
+COVERAGE_UNIT_PATH=coverage-unit-mode-$(COVERAGE_MODE).out
+COVERAGE_INTEGRATION_PATH=coverage-integration-mode-$(COVERAGE_MODE).out
+
+#-------------------------------------------------------------------------------
+# Normal test targets
+#
+# These test targets are the ones that will be invoked from the outside. If
+# they are called and the artifacts already exist, then the artifacts will
+# first be cleaned and recreated. This ensures that the tests are always
+# executed.
+#-------------------------------------------------------------------------------
+
+.PHONY: test-all
+test-all: prebuild-check test-unit test-integration
+
+.PHONY: test-unit
+test-unit: prebuild-check clean-test-artifacts-unit $(COVERAGE_UNIT_PATH)
+
+.PHONY: test-integration
+test-integration: prebuild-check clean-test-artifacts-integration $(COVERAGE_INTEGRATION_PATH)
+
+#-------------------------------------------------------------------------------
+# Inspect coverage of unit tests or integration tests in either pure
+# console mode (*-func) or in a browser (*-html).
+#
+# If the test coverage files to be evaluated already exist, then no new
+# tests are executed. If they don't exist, we first run the tests.
+#-------------------------------------------------------------------------------
+
+.PHONY: show-coverage-unit-func
+show-coverage-unit-func: prebuild-check $(COVERAGE_UNIT_PATH)
+	go tool cover -func=$(COVERAGE_UNIT_PATH)
+
+.PHONY: show-coverage-unit-html
+show-coverage-unit-html: prebuild-check $(COVERAGE_UNIT_PATH)
+	go tool cover -html=$(COVERAGE_UNIT_PATH)
+
+.PHONY: show-coverage-integration-func
+show-coverage-integration-func: prebuild-check $(COVERAGE_INTEGRATION_PATH)
+	go tool cover -func=$(COVERAGE_UNIT_PATH)
+
+.PHONY: show-coverage-integration-html
+show-coverage-integration-html: prebuild-check $(COVERAGE_INTEGRATION_PATH)
+	go tool cover -html=$(COVERAGE_INTEGRATION_PATH)
+
+#-------------------------------------------------------------------------------
+# Test artifacts are two coverage files for unit and integration tests.
+#-------------------------------------------------------------------------------
+
+$(COVERAGE_UNIT_PATH):
+	go test $(go list ./... | grep -v vendor) -v -coverprofile $(COVERAGE_UNIT_PATH) -covermode=$(COVERAGE_MODE)
+
+$(COVERAGE_INTEGRATION_PATH):
+	go test $(go list ./... | grep -v vendor) -v -dbhost localhost -coverprofile $(COVERAGE_INTEGRATION_PATH) -covermode=$(COVERAGE_MODE) -tags=integration
+
+#-------------------------------------------------------------------------------
+# Clean targets
+#-------------------------------------------------------------------------------
+
+.PHONY: clean-test-artifacts-unit
+clean-test-artifacts-unit:
+	rm -f $(COVERAGE_UNIT_PATH)
+
+.PHONY: clean-test-artifacts-integration
+clean-test-artifacts-integration:
+	rm -f $(COVERAGE_INTEGRATION_PATH)

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -25,11 +25,11 @@
 #
 #     $ make test-all
 #
-# To show unit test coverage in a terminal, type
+# To output coverage profile information for each function, type
 #
 #     $ make show-coverage-unit-func
 #
-# To show unit test coverage in a browser, type
+# To generate HTML representation of coverage profile (opens a browser), type
 #
 #     $ make show-coverage-unit-html
 #
@@ -56,9 +56,10 @@
 #     $ COVERAGE_MODE=count make test-unit
 #===============================================================================
 
+# mode can be: set, count, or atomic
 COVERAGE_MODE ?= set
-COVERAGE_UNIT_PATH=coverage-unit-mode-$(COVERAGE_MODE).out
-COVERAGE_INTEGRATION_PATH=coverage-integration-mode-$(COVERAGE_MODE).out
+COVERAGE_UNIT_PATH=$(TMP_PATH)/coverage-unit-mode-$(COVERAGE_MODE).out
+COVERAGE_INTEGRATION_PATH=$(TMP_PATH)/coverage-integration-mode-$(COVERAGE_MODE).out
 
 #-------------------------------------------------------------------------------
 # Normal test targets

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -71,12 +71,15 @@ COVERAGE_INTEGRATION_PATH=$(TMP_PATH)/coverage-integration-mode-$(COVERAGE_MODE)
 #-------------------------------------------------------------------------------
 
 .PHONY: test-all
+## Runs test-unit and test-integration targets
 test-all: prebuild-check test-unit test-integration
 
 .PHONY: test-unit
+## Runs the unit tests and produces a coverage file
 test-unit: prebuild-check clean-test-artifacts-unit $(COVERAGE_UNIT_PATH)
 
 .PHONY: test-integration
+## Runs the integration tests and produces a coverage file
 test-integration: prebuild-check clean-test-artifacts-integration $(COVERAGE_INTEGRATION_PATH)
 
 #-------------------------------------------------------------------------------
@@ -88,35 +91,47 @@ test-integration: prebuild-check clean-test-artifacts-integration $(COVERAGE_INT
 #-------------------------------------------------------------------------------
 
 .PHONY: show-coverage-unit
+## Output coverage profile information for each function (based on unit-tests).
+## This target only runs the tests if the coverage file does exist.
 show-coverage-unit: prebuild-check $(COVERAGE_UNIT_PATH)
 	go tool cover -func=$(COVERAGE_UNIT_PATH)
 
 .PHONY: show-coverage-unit-html
+## Generate HTML representation (and show in browser) of coverage profile (based on unit tests).
+## This target only runs the tests if the coverage file does exist.
 show-coverage-unit-html: prebuild-check $(COVERAGE_UNIT_PATH)
 	go tool cover -html=$(COVERAGE_UNIT_PATH)
 
 .PHONY: show-coverage-integration
+## Output coverage profile information for each function (based on integration tests).
+## This target only runs the tests if the coverage file does exist.
 show-coverage-integration: prebuild-check $(COVERAGE_INTEGRATION_PATH)
 	go tool cover -func=$(COVERAGE_INTEGRATION_PATH)
 
 .PHONY: show-coverage-integration-html
+## Generate HTML representation (and show in browser) of coverage profile (based on integration tests).
+## This target only runs the tests if the coverage file does exist.
 show-coverage-integration-html: prebuild-check $(COVERAGE_INTEGRATION_PATH)
 	go tool cover -html=$(COVERAGE_INTEGRATION_PATH)
 
 .PHONY: gocov-unit-annotate
+## (EXPERIMENTAL) Show actual code and how it is covered with unit tests.
+##                This target only runs the tests if the coverage file does exist.
 gocov-unit-annotate: prebuild-check $(GOCOV_BIN) $(COVERAGE_UNIT_PATH)
 	$(GOCOV_BIN) convert $(COVERAGE_UNIT_PATH) | $(GOCOV_BIN) annotate -
 
-.PHONY: gocov-unit-report
-gocov-unit-report: prebuild-check $(GOCOV_BIN) $(COVERAGE_UNIT_PATH)
+.PHONY: .gocov-unit-report
+.gocov-unit-report: prebuild-check $(GOCOV_BIN) $(COVERAGE_UNIT_PATH)
 	$(GOCOV_BIN) convert $(COVERAGE_UNIT_PATH) | $(GOCOV_BIN) report
 
 .PHONY: gocov-integration-annotate
+## (EXPERIMENTAL) Show actual code and how it is covered with integration tests.
+##                This target only runs the tests if the coverage file does exist.
 gocov-integration-annotate: prebuild-check $(GOCOV_BIN) $(COVERAGE_INTEGRATION_PATH)
 	$(GOCOV_BIN) convert $(COVERAGE_INTEGRATION_PATH) | $(GOCOV_BIN) annotate -
 
-.PHONY: gocov-integration-report
-gocov-integration-report: prebuild-check $(GOCOV_BIN) $(COVERAGE_INTEGRATION_PATH)
+.PHONY: .gocov-integration-report
+.gocov-integration-report: prebuild-check $(GOCOV_BIN) $(COVERAGE_INTEGRATION_PATH)
 	$(GOCOV_BIN) convert $(COVERAGE_INTEGRATION_PATH) | $(GOCOV_BIN) report
 
 #-------------------------------------------------------------------------------
@@ -142,10 +157,12 @@ $(GOCOV_BIN): prebuild-check
 
 CLEAN_TARGETS += clean-test-artifacts-unit
 .PHONY: clean-test-artifacts-unit
+## Removes the coverage file for unit tests
 clean-test-artifacts-unit:
 	rm -f $(COVERAGE_UNIT_PATH)
 
 CLEAN_TARGETS += clean-test-artifacts-integration
 .PHONY: clean-test-artifacts-integration
+## Removes the coverage file for integration tests
 clean-test-artifacts-integration:
 	rm -f $(COVERAGE_INTEGRATION_PATH)

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -96,7 +96,7 @@ show-coverage-unit-html: prebuild-check $(COVERAGE_UNIT_PATH)
 
 .PHONY: show-coverage-integration-func
 show-coverage-integration-func: prebuild-check $(COVERAGE_INTEGRATION_PATH)
-	go tool cover -func=$(COVERAGE_UNIT_PATH)
+	go tool cover -func=$(COVERAGE_INTEGRATION_PATH)
 
 .PHONY: show-coverage-integration-html
 show-coverage-integration-html: prebuild-check $(COVERAGE_INTEGRATION_PATH)

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -102,15 +102,38 @@ show-coverage-integration-func: prebuild-check $(COVERAGE_INTEGRATION_PATH)
 show-coverage-integration-html: prebuild-check $(COVERAGE_INTEGRATION_PATH)
 	go tool cover -html=$(COVERAGE_INTEGRATION_PATH)
 
+.PHONY: gocov-unit-annotate
+gocov-unit-annotate: prebuild-check $(GOCOV_BIN) $(COVERAGE_UNIT_PATH)
+	$(GOCOV_BIN) convert $(COVERAGE_UNIT_PATH) | $(GOCOV_BIN) annotate -
+
+.PHONY: gocov-unit-report
+gocov-unit-report: prebuild-check $(GOCOV_BIN) $(COVERAGE_UNIT_PATH)
+	$(GOCOV_BIN) convert $(COVERAGE_UNIT_PATH) | $(GOCOV_BIN) report
+
+.PHONY: gocov-integration-annotate
+gocov-integration-annotate: prebuild-check $(GOCOV_BIN) $(COVERAGE_INTEGRATION_PATH)
+	$(GOCOV_BIN) convert $(COVERAGE_INTEGRATION_PATH) | $(GOCOV_BIN) annotate -
+
+.PHONY: gocov-integration-report
+gocov-integration-report: prebuild-check $(GOCOV_BIN) $(COVERAGE_INTEGRATION_PATH)
+	$(GOCOV_BIN) convert $(COVERAGE_INTEGRATION_PATH) | $(GOCOV_BIN) report
+
 #-------------------------------------------------------------------------------
 # Test artifacts are two coverage files for unit and integration tests.
 #-------------------------------------------------------------------------------
 
-$(COVERAGE_UNIT_PATH):
+$(COVERAGE_UNIT_PATH): prebuild-check
 	go test $(go list ./... | grep -v vendor) -v -coverprofile $(COVERAGE_UNIT_PATH) -covermode=$(COVERAGE_MODE)
 
-$(COVERAGE_INTEGRATION_PATH):
+$(COVERAGE_INTEGRATION_PATH): prebuild-check
 	go test $(go list ./... | grep -v vendor) -v -dbhost localhost -coverprofile $(COVERAGE_INTEGRATION_PATH) -covermode=$(COVERAGE_MODE) -tags=integration
+
+#-------------------------------------------------------------------------------
+# Additional tools
+#-------------------------------------------------------------------------------
+
+$(GOCOV_BIN): prebuild-check
+	cd $(VENDOR_DIR)/github.com/axw/gocov/gocov/ && go build -v
 
 #-------------------------------------------------------------------------------
 # Clean targets

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -140,10 +140,12 @@ $(GOCOV_BIN): prebuild-check
 # Clean targets
 #-------------------------------------------------------------------------------
 
+CLEAN_TARGETS += clean-test-artifacts-unit
 .PHONY: clean-test-artifacts-unit
 clean-test-artifacts-unit:
 	rm -f $(COVERAGE_UNIT_PATH)
 
+CLEAN_TARGETS += clean-test-artifacts-integration
 .PHONY: clean-test-artifacts-integration
 clean-test-artifacts-integration:
 	rm -f $(COVERAGE_INTEGRATION_PATH)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ SOURCES := $(shell find $(SOURCE_DIR) -path $(SOURCE_DIR)/vendor -prune -o -name
 DESIGN_DIR=design
 DESIGNS := $(shell find $(SOURCE_DIR)/$(DESIGN_DIR) -path $(SOURCE_DIR)/vendor -prune -o -name '*.go' -print)
 
-
 # Find all required tools:
 GIT_BIN := $(shell command -v $(GIT_BIN_NAME) 2> /dev/null)
 GLIDE_BIN := $(shell command -v $(GLIDE_BIN_NAME) 2> /dev/null)
@@ -53,7 +52,7 @@ $(FRESH_BIN): prebuild-check
 	cd $(VENDOR_DIR)/github.com/pilu/fresh && go build -v
 
 .PHONY: clean
-clean: clean-artifacts clean-object-files clean-generated clean-vendor clean-glide-cache
+clean: clean-artifacts clean-object-files clean-generated clean-vendor clean-glide-cache clean-test-artifacts-unit clean-test-artifacts-integration
 
 .PHONY: clean-artifacts
 clean-artifacts:
@@ -97,16 +96,7 @@ dev: prebuild-check $(FRESH_BIN)
 	docker-compose up -d
 	$(FRESH_BIN)
 
-.PHONY: test-all
-test-all: prebuild-check test-unit test-integration
-
-.PHONY: test-unit
-test-unit: prebuild-check
-	go test $(go list ./... | grep -v vendor) -v -coverprofile coverage-unit.out
-
-.PHONY: test-integration
-test-integration: prebuild-check
-	go test $(go list ./... | grep -v vendor) -v -dbhost localhost -coverprofile coverage-integration.out -tags=integration
+include ./.make/test.mk
 
 $(INSTALL_PREFIX):
 # Build artifacts dir

--- a/Makefile
+++ b/Makefile
@@ -39,19 +39,20 @@ all: prebuild-check deps generate build
 
 .PHONY: help
 # Based on https://gist.github.com/rcmachado/af3db315e31383502660
-## Display this help text
-help:
+## Display this help text.
+help:/
 	$(info Available targets)
+	$(info -----------------)
 	@awk '/^[a-zA-Z\-\_0-9]+:/ { \
 		helpMessage = match(lastLine, /^## (.*)/); \
 		helpCommand = substr($$1, 0, index($$1, ":")-1); \
 		if (helpMessage) { \
 			helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
-			gsub(/##/, "\n                    ", helpMessage); \
+			gsub(/##/, "\n                                     ", helpMessage); \
 		} else { \
-			helpMessage = "No documentation."; \
+			helpMessage = "(No documentation)"; \
 		} \
-		printf "%-20s %s\n", helpCommand, helpMessage; \
+		printf "%-35s - %s\n", helpCommand, helpMessage; \
 		lastLine = "" \
 	} \
 	{ hasComment = match(lastLine, /^## (.*)/); \
@@ -64,7 +65,7 @@ help:
         }' $(MAKEFILE_LIST)
 
 .PHONY: build
-## Build server and client
+## Build server and client.
 build: prebuild-check $(BINARY_SERVER_BIN) $(BINARY_CLIENT_BIN) # do the build
 
 $(BINARY_SERVER_BIN): prebuild-check $(SOURCES)
@@ -83,25 +84,21 @@ $(GO_BINDATA_ASSETFS_BIN): prebuild-check
 $(FRESH_BIN): prebuild-check
 	cd $(VENDOR_DIR)/github.com/pilu/fresh && go build -v
 
-<<<<<<< HEAD
 CLEAN_TARGETS += clean-artifacts
-=======
-.PHONY: clean
-## Removes all downloaded dependencies, all generated code and compiled artifacts.
-clean: clean-artifacts clean-object-files clean-generated clean-vendor clean-glide-cache
-
->>>>>>> master
 .PHONY: clean-artifacts
+## Removes the ./bin directory.
 clean-artifacts:
 	rm -rf $(INSTALL_PREFIX)
 
 CLEAN_TARGETS += clean-object-files
 .PHONY: clean-object-files
+## Runs go clean to remove any executables or other object files.
 clean-object-files:
 	go clean ./...
 
 CLEAN_TARGETS += clean-generated
 .PHONY: clean-generated
+## Removes all generated code.
 clean-generated:
 	rm -rfv ./app
 	rm -rfv ./assets/js
@@ -112,16 +109,18 @@ clean-generated:
 
 CLEAN_TARGETS += clean-vendor
 .PHONY: clean-vendor
+## Removes the ./vendor directory.
 clean-vendor:
 	rm -rf $(VENDOR_DIR)
 
 CLEAN_TARGETS += clean-glide-cache
 .PHONY: clean-glide-cache
+## Removes the ./glide directory.
 clean-glide-cache:
 	rm -rf ./.glide
 
 .PHONY: deps
-## Download build dependencies
+## Download build dependencies.
 deps: prebuild-check
 	$(GLIDE_BIN) install
 
@@ -169,4 +168,5 @@ endif
 
 # Keep this "clean" target here at the bottom
 .PHONY: clean
+## Runs all clean-* targets.
 clean: $(CLEAN_TARGETS)

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ LDFLAGS=-ldflags "-X main.Commit=${COMMIT} -X main.BuildTime=${BUILD_TIME}"
 
 # If nothing was specified, run all targets as if in a fresh clone
 .PHONY: all
-## Default target - fetch dependencies, generate code and build
+## Default target - fetch dependencies, generate code and build.
 all: prebuild-check deps generate build
 
 .PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ BUILD_TIME=`date -u '+%Y-%m-%d_%I:%M:%S%p'`
 
 PACKAGE_NAME:=github.com/almighty/almighty-core
 
+# For the global "clean" target all targets in this variable will be executed
+CLEAN_TARGETS =
+
 # Pass in build time variables to main
 LDFLAGS=-ldflags "-X main.Commit=${COMMIT} -X main.BuildTime=${BUILD_TIME}"
 
@@ -53,16 +56,19 @@ $(FRESH_BIN): prebuild-check
 	cd $(VENDOR_DIR)/github.com/pilu/fresh && go build -v
 
 .PHONY: clean
-clean: clean-artifacts clean-object-files clean-generated clean-vendor clean-glide-cache clean-test-artifacts-unit clean-test-artifacts-integration
+clean: $(CLEAN_TARGETS)
 
+CLEAN_TARGETS += clean-artifacts
 .PHONY: clean-artifacts
 clean-artifacts:
 	rm -rf $(INSTALL_PREFIX)
 
+CLEAN_TARGETS += clean-object-files
 .PHONY: clean-object-files
 clean-object-files:
 	go clean ./...
 
+CLEAN_TARGETS += clean-generated
 .PHONY: clean-generated
 clean-generated:
 	rm -rfv ./app
@@ -72,10 +78,12 @@ clean-generated:
 	rm -rfv ./tool/cli/
 	rm -fv ./bindata_assetfs.go
 
+CLEAN_TARGETS += clean-vendor
 .PHONY: clean-vendor
 clean-vendor:
 	rm -rf $(VENDOR_DIR)
 
+CLEAN_TARGETS += clean-glide-cache
 .PHONY: clean-glide-cache
 clean-glide-cache:
 	rm -rf ./.glide

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 CUR_DIR=$(shell pwd)
+TMP_PATH=$(CUR_DIR)/tmp
 INSTALL_PREFIX=$(CUR_DIR)/bin
 VENDOR_DIR=vendor
 ifeq ($(OS),Windows_NT)
@@ -102,8 +103,11 @@ $(INSTALL_PREFIX):
 # Build artifacts dir
 	mkdir -pv $(INSTALL_PREFIX)
 
+$(TMP_PATH):
+	mkdir -pv $(TMP_PATH)
+
 .PHONY: prebuild-check
-prebuild-check: $(INSTALL_PREFIX) $(CHECK_GOPATH_BIN)
+prebuild-check: $(TMP_PATH) $(INSTALL_PREFIX) $(CHECK_GOPATH_BIN)
 # Check that all tools where found
 ifndef GIT_BIN
 	$(error The "$(GIT_BIN_NAME)" executable could not be found in your PATH)

--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,6 @@ $(GO_BINDATA_ASSETFS_BIN): prebuild-check
 $(FRESH_BIN): prebuild-check
 	cd $(VENDOR_DIR)/github.com/pilu/fresh && go build -v
 
-.PHONY: clean
-clean: $(CLEAN_TARGETS)
-
 CLEAN_TARGETS += clean-artifacts
 .PHONY: clean-artifacts
 clean-artifacts:
@@ -133,3 +130,7 @@ ifndef GO_BIN
 	$(error The "$(GO_BIN_NAME)" executable could not be found in your PATH)
 endif
 	go build -o $(CHECK_GOPATH_BIN) .make/check-gopath.go
+
+# Keep this "clean" target here at the bottom
+.PHONY: clean
+clean: $(CLEAN_TARGETS)

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,14 @@
-hash: 3b5f30fa361f5f7beda674444bef185f6cb28936afeacbc7ece69f533c239db9
-updated: 2016-08-02T12:42:21.983224768+02:00
+hash: 36c2204f43f77bbff3766ab60737169c9239f2ea903c2fd7e85f4309323cc820
+updated: 2016-08-02T14:48:37.043081154+02:00
 imports:
 - name: bitbucket.org/pkg/inflect
   version: 8961c3750a47b8c0b3e118d52513b97adf85a7e8
 - name: github.com/armon/go-metrics
   version: fbf75676ee9c0a3a23eb0a4d9220a3612cfbd1ed
+- name: github.com/axw/gocov
+  version: 54b98cfcac0c63fb3f9bd8e7ad241b724d4e985b
+  subpackages:
+  - gocov
 - name: github.com/dgrijalva/jwt-go
   version: d2709f9f1f31ebcda9651b03077758c1f3a0018c
 - name: github.com/dimfeld/httppath

--- a/glide.yaml
+++ b/glide.yaml
@@ -47,3 +47,6 @@ import:
   version: ^1.0.0
 - package: github.com/mattn/go-isatty
   version: ^0.0.1
+- package: github.com/axw/gocov
+  subpackages:
+  - gocov


### PR DESCRIPTION
Testing has become a rather big and interconnected topic and that's why it
has arrived in it's own file.

We have to types of tests available:

  1. unit tests and
  2. integration tests.

 While the unit tests can be executed fairly simply be running `go test`, the
 integration tests have a little bit more setup going on. That's why they are
split up in two tests.

# Usage

If you want to run the unit tests, type

    $ make test-unit

To run the integration tests, type

     $ make test-integration

 To run both tests, type

     $ make test-all

 To show unit test coverage in a terminal, type

     $ make show-coverage-unit

 To show unit test coverage in a browser, type

     $ make show-coverage-unit-html

 If you replace the "unit" with "integration" you get the same for integration
 tests.

 # Artifacts and coverage modes

 We execute tests with coverage output by default. The files live in the
 root folder and look something like `coverage-unit-mode-set.out` or
 `coverage-integration-mode-count.out`.

 Each filename indicates whether it is for unit or integration tests and
 what the coverage mode was used.

 These are possible coverage modes (see https://blog.golang.org/cover):

 	set: did each statement run? (default)
 	count: how many times did each statement run?
 	atomic: like count, but counts precisely in parallel programs

 To choose another coverage mode, simply prefix the invovation of `make`:

     $ COVERAGE_MODE=count make test-unit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/64)
<!-- Reviewable:end -->
