### PR TITLE
Explain to windows users how to use the readme.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -9,6 +9,13 @@ image:https://godoc.org/github.com/almighty/almighty-core?status.png[GoDoc,link=
 
 You need to install `go` (>= v1.6) and `git` and `mercurial`.
 
+NOTE: For those trying to build on Windows. This readme uses posix
+style paths (`/src/github`) and environment variable references
+(`$GOPATH`).  If using Windows shells please manually convert paths and
+variables to the right format, i.e. `\src\github\` and for environment variables on
+PowerShell use `$env:GOPATH` and cmd.exe use `%GOPATH%`). 
+
+
 ==== Check your Go version [[check-go-version]]
 
 Run the following command to find out your Go version.


### PR DESCRIPTION
If we have to repeat every command in a format that works on all 
Windows shell dialects we will run out of space or sanity.

Added upfront note for Windows users on how to use the commands in the readme file.

Replacement for https://github.com/almighty/almighty-core/pull/75

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/76)
<!-- Reviewable:end -->
