### PR TITLE
removed models dir from list of autogenerated directories since it is…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -172,7 +172,6 @@ These files and directory are generated:
  * `./app/`
  * `./assets/js/`
  * `./client/`
- * `./models/`
  * `./swagger/`
  * `./tool/cli/`
  * `./bindata_asstfs.go`


### PR DESCRIPTION
Signed-off-by: Shoubhik <shoubhik@dhcp35-156.lab.eng.blr.redhat.com>

WHY:
models is not autogenerated by corma in our project - hence we should take out the models directory from list of autogenerated directories. Just confuses developers :( 

WHAT:
Updated readme

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/93)
<!-- Reviewable:end -->
