### PR TITLE
#79 changed work item type constants from Byte to String for better readability

### DIFF
--- a/models/field_definition.go
+++ b/models/field_definition.go
@@ -8,20 +8,20 @@ import (
 
 // constants for describing possible field types
 const (
-	KindString            Kind = 1
-	KindInteger           Kind = 2
-	KindFloat             Kind = 3
-	KindInstant           Kind = 4
-	KindDuration          Kind = 5
-	KindURL               Kind = 6
-	KindWorkitemReference Kind = 7
-	KindUser              Kind = 8
-	KindEnum              Kind = 9
-	KindList              Kind = 10
+	KindString            Kind = "string"
+	KindInteger           Kind = "integer"
+	KindFloat             Kind = "float"
+	KindInstant           Kind = "instant"
+	KindDuration          Kind = "duration"
+	KindURL               Kind = "url"
+	KindWorkitemReference Kind = "workitem"
+	KindUser              Kind = "user"
+	KindEnum              Kind = "enum"
+	KindList              Kind = "list"
 )
 
 // Kind is the kind of field type
-type Kind byte
+type Kind string
 
 /*
 FieldType describes the possible values of a FieldDefinition


### PR DESCRIPTION
#79 changed work item type constants from Byte to String for better readability by user-facing systems

WHY:
Because user-facing systems referring to byte constants would technically be doing the same thing if string constants are used. Readability is better if string constants like "integer" , "work_item_reference" is used.

WHAT:
Updated the constants' mapping to replace byte values of 1,2,3...  to meaningful names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/96)
<!-- Reviewable:end -->
