### PR TITLE
updated the datatype during marshalling from Byte to String

### DIFF
--- a/models/field_definition.go
+++ b/models/field_definition.go
@@ -118,7 +118,7 @@ func (self *FieldDefinition) UnmarshalJSON(bytes []byte) error {
 func (self FieldDefinition) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
 	buf.WriteString("{ \"type\": {")
-	buf.WriteString(fmt.Sprintf("\"kind\": %d", self.Type.GetKind()))
+	buf.WriteString(fmt.Sprintf("\"kind\": \"%s\"", self.Type.GetKind()))
 	switch complexType := self.Type.(type) {
 	case ListType:
 		buf.WriteString(", \"extra\": ")


### PR DESCRIPTION
As part of #79 the datatype of Kind was changed from Byte to String. That broke the marshalling format string where we were using %d
Changing the format string to have "%s" fixed the issue. Tested by running the test inside models/

Fixes #113

Signed-off-by: Shoubhik <shoubhik@dhcp35-156.lab.eng.blr.redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/114)
<!-- Reviewable:end -->
