### PR TITLE
Lets use CentOS Linux 7

### DIFF
--- a/jenkins/linux/Dockerfile
+++ b/jenkins/linux/Dockerfile
@@ -1,10 +1,10 @@
-FROM fedora:24
+FROM centos:7
 MAINTAINER "Konrad Kleine <kkleine@redhat.com>"
 ENV LANG=en_US.utf8
 
 # Some packages might seem weird but they are required by the
 # RVM installer
-RUN dnf install -y \
+RUN yum install -y \
       findutils \
       git \
       golang \
@@ -14,7 +14,7 @@ RUN dnf install -y \
       tar \
       wget \
       which \
-    && dnf clean all
+    && yum clean all
 
 # Get glide for Go package management
 RUN cd /tmp \


### PR DESCRIPTION
the rest of the infra coming up, and the integration points with the other efforts are all based on and around CentOS Linux 7/x86_64 - can we then use that for the container build here as well ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/118)
<!-- Reviewable:end -->
