### PR TITLE
Renamed models.NewRepository to models.NewWorkItemRepository

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func main() {
 
 	// Mount "workitem" controller
 	ts := models.NewGormTransactionSupport(db)
-	repo := models.NewRepository(ts)
+	repo := models.NewWorkItemRepository(ts)
 	c3 := NewWorkitemController(service, repo, ts)
 	app.MountWorkitemController(service, c3)
 

--- a/models/gorm_repository.go
+++ b/models/gorm_repository.go
@@ -16,7 +16,7 @@ type GormWorkItemRepository struct {
 }
 
 // NewRepository constructs a WorkItemRepository
-func NewRepository(ts *GormTransactionSupport) *GormWorkItemRepository {
+func NewWorkItemRepository(ts *GormTransactionSupport) *GormWorkItemRepository {
 	return &GormWorkItemRepository{ts}
 }
 

--- a/workitem_test.go
+++ b/workitem_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 
 func TestGetWorkItem(t *testing.T) {
 	ts := models.NewGormTransactionSupport(db)
-	repo := models.NewRepository(ts)
+	repo := models.NewWorkItemRepository(ts)
 	controller := WorkitemController{ts: ts, wiRepository: repo}
 	payload := app.CreateWorkitemPayload{
 		Name: "foobar",
@@ -81,7 +81,7 @@ func TestGetWorkItem(t *testing.T) {
 
 func TestCreateWI(t *testing.T) {
 	ts := models.NewGormTransactionSupport(db)
-	repo := models.NewRepository(ts)
+	repo := models.NewWorkItemRepository(ts)
 	controller := WorkitemController{ts: ts, wiRepository: repo}
 	payload := app.CreateWorkitemPayload{
 		Name: "some name",


### PR DESCRIPTION
Since we would be continuing with a flat model package
the work item repository constructor is renamed to something more
specific that was present ( NewRepository )

Fixes #119

How:
Updated the model constructor and the corresponding test. 
Local build was a success.

Signed-off-by: Shoubhik <shoubhik@dhcp35-156.lab.eng.blr.redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/124)
<!-- Reviewable:end -->
