### PR TITLE
WorkItem Update should use the ID passed in URL

### DIFF
--- a/design/resources.go
+++ b/design/resources.go
@@ -58,10 +58,13 @@ var _ = Resource("workitem", func() {
 	})
 	Action("update", func() {
 		Routing(
-			PUT(""),
+			PUT("/:id"),
 		)
-		Description("update the given work item.")
-		Payload(WorkItem)
+		Description("update the given work item with given id.")
+		Params(func() {
+			Param("id", String, "id")
+		})
+		Payload(UpdateWorkItemPayload)
 		Response(OK, func() {
 			Media(WorkItem)
 		})

--- a/design/user_types.go
+++ b/design/user_types.go
@@ -11,3 +11,14 @@ var CreateWorkItemPayload = Type("CreateWorkItemPayload", func() {
 	Attribute("fields", HashOf(String, Any), "The field values, must conform to the type")
 	Required("type", "name", "fields")
 })
+
+// UpdateWorkItemPayload has been added because the design.WorkItem could
+// not be used since it mand, wi.IDated the presence of the ID in the payload
+// which ideally should be optional. The ID should be passed on to REST URL.
+var UpdateWorkItemPayload = Type("UpdateWorkItemPayload", func() {
+	Attribute("type", String, "The type of the newly created work item")
+	Attribute("name", String, "User Readable Name of this item")
+	Attribute("fields", HashOf(String, Any), "The field values, must conform to the type")
+	Attribute("version", Integer, "Version for optimistic concurrency control")
+	Required("type", "name", "fields", "version")
+})

--- a/workitem.go
+++ b/workitem.go
@@ -82,7 +82,7 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 	return transaction.Do(c.ts, func() error {
 
 		toSave := app.WorkItem{
-			ID:      ctx.Payload.ID,
+			ID:      ctx.ID,
 			Name:    ctx.Payload.Name,
 			Type:    ctx.Payload.Type,
 			Version: ctx.Payload.Version,

--- a/workitem_test.go
+++ b/workitem_test.go
@@ -59,13 +59,12 @@ func TestGetWorkItem(t *testing.T) {
 
 	wi.Fields["system.owner"] = "thomas"
 	payload2 := app.UpdateWorkitemPayload{
-		ID:      wi.ID,
 		Name:    wi.Name,
 		Type:    wi.Type,
 		Version: wi.Version,
 		Fields:  wi.Fields,
 	}
-	_, updated := test.UpdateWorkitemOK(t, nil, nil, &controller, &payload2)
+	_, updated := test.UpdateWorkitemOK(t, nil, nil, &controller, wi.ID, &payload2)
 	if updated.Version != result.Version+1 {
 		t.Errorf("expected version %d, but got %d", result.Version+1, updated.Version)
 	}


### PR DESCRIPTION
The WorkItem to be updated should be referred by its ID in the URL as a api/workitem/:ID and the code should not be reading it from the payload since ID not an editable field. 

~~The same applies for the `version` attribute in the payload. The version need not be passed as part of the payload while updating the workitem.~~

This changed required a change in the goa design code. 
The `make` task autogenerates sources inside the app/ dir

Fixes #95 #47 

Signed-off-by: Shoubhik <shoubhik@dhcp35-156.lab.eng.blr.redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/125)
<!-- Reviewable:end -->
