### PR TITLE
Expand Issue attributes to consider status and ID.

### DIFF
--- a/models/issue_tracker.go
+++ b/models/issue_tracker.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+
 	"golang.org/x/net/context"
 )
 
@@ -14,13 +15,19 @@ type Configuration struct {
 
 // Issue gives information of every single issue of the issue trackers.
 type Issue struct {
+	ID string
 	Title       string
 	Description string
+	Status      string
 }
 
+
+
 func PrintIssue(issue Issue) {
+	fmt.Println("ID: ", issue.ID)
 	fmt.Println("title: ", issue.Title)
 	fmt.Println("issue: ", issue.Description)
+	fmt.Println("status: ", issue.Status)
 	fmt.Println("")
 }
 


### PR DESCRIPTION
For remote issue trackers we are currently concerned with 3 things only namely,
title, description and status. Opening this PR individually before the code changes are made for the larger issue of mapping remote issues with work item.

As part of this PR:
The ```Issue``` will have 
- ID
- title
- description
- status

dependency  #131 

Signed-off-by: Shoubhik <shoubhik@dhcp35-156.lab.eng.blr.redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/139)
<!-- Reviewable:end -->
