### PR TITLE
Create model for remote issues

### DIFF
--- a/models/remote_issue.go
+++ b/models/remote_issue.go
@@ -1,0 +1,36 @@
+package models
+
+// RemoteIssue defines the additional attributes an issue from a remote provider would have.
+type RemoteIssue struct {
+	Issue
+	sourceURL string
+}
+
+// GithubIssue defines how an issue from Github would look like.
+type GithubIssue struct {
+	RemoteIssue
+}
+
+// JiraIssue defines how an issue from Jira would look like
+type JiraIssue struct {
+	RemoteIssue
+}
+
+// IssueMapper creates the contract that derivatives of RemoteIssue needs to implement.
+type IssueMapper interface {
+	toLocalIssue() WorkItem
+}
+
+/*
+
+// TODO: Implement the IssueMapper method(s)
+
+func (issue *GithubIssue) toLocalIssue() WorkItem {
+	// Add code to convert the Github Issue to an ALM WorkItem
+}
+
+func (issue *JiraIssue) toLocalIssue() WorkItem {
+	// Add code to convert the Jira Issue to an ALM WorkItem
+}
+
+*/


### PR DESCRIPTION
Added new derived types for remote issues. Provider specific types are derived from RemoteIssue. Every type derived from RemoteIssue needs to implement its own mapper method ( to map from remote issue to local work item ).

Fixes #143

Signed-off-by: Shoubhik <shoubhik@dhcp35-156.lab.eng.blr.redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/144)
<!-- Reviewable:end -->
