### PR TITLE
Add Content-Type and X-Request-Id as allowed CORS headers

### DIFF
--- a/design/api.go
+++ b/design/api.go
@@ -21,6 +21,7 @@ var _ = API("alm", func() {
 	})
 	Origin("*", func() {
 		Methods("GET", "POST", "PUT", "PATCH", "DELETE")
+		Headers("X-Request-Id", "Content-Type")
 		MaxAge(600)
 		Credentials()
 	})


### PR DESCRIPTION
The UI will use Content-Type and might use X-Request-Id
when communicating with the backend. These headers should
be allowed to pass the CORS Policy.


@joshuawilson This should fix your CORS issue with 'create workitem'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/146)
<!-- Reviewable:end -->
