### PR TITLE
docker-start target configured to relabel volume

### DIFF
--- a/.make/docker.mk
+++ b/.make/docker.mk
@@ -73,7 +73,7 @@ else
 		-t \
 		$(DOCKER_RUN_INTERACTIVE_SWITCH) \
 		--name="$(DOCKER_CONTAINER_NAME)" \
-		-v $(CUR_DIR):$(PACKAGE_PATH):rw \
+		-v $(CUR_DIR):$(PACKAGE_PATH):Z \
 		-u $(shell id -u $(USER)):$(shell id -g $(USER)) \
 		-e GOPATH=$(GOPATH_IN_CONTAINER) \
 		-w $(PACKAGE_PATH) \


### PR DESCRIPTION
Docker-based build doesn't work with SELinux enabled:

    sudo make docker-start
    sudo make docker-deps

result:

    docker exec -t -i "almighty-core-local-build" make deps
    make: stat: Makefile: Permission denied
    make: *** No rule to make target `deps'.  Stop.
    make: *** [docker-deps] Error 2

See [Docker docs](https://docs.docker.com/engine/tutorials/dockervolumes/#/volume-labels) for explanation of change made

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/156)
<!-- Reviewable:end -->
