### PR TITLE
Run alm deploy container under a non-root user/group

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,14 +1,22 @@
 FROM centos:7
 MAINTAINER "Konrad Kleine <kkleine@redhat.com>"
 ENV LANG=en_US.utf8
+ENV ALMIGHTY_INSTALL_PREFIX=/usr/local/alm
 
-COPY bin/alm /usr/bin/alm
+# Create a non-root user and a group with the same name: "almighty"
+ENV ALMIGHTY_USER_NAME=almighty
+RUN useradd --no-create-home -s /bin/bash ${ALMIGHTY_USER_NAME}
+
+COPY bin/alm ${ALMIGHTY_INSTALL_PREFIX}/bin/alm
 
 # This script waits for a port to be open before it continues to execute what's
 # behind the two dashes "--". See docker-compose.yaml for the place where we use this.
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /usr/local/bin/wait-for-it.sh
 RUN chmod +x /usr/local/bin/wait-for-it.sh
 
-ENTRYPOINT [ "/usr/bin/alm" ]
+# From here onwards, any RUN, CMD, or ENTRYPOINT will be run under the following user
+USER ${ALMIGHTY_USER_NAME}
+
+ENTRYPOINT [ "${ALMIGHTY_INSTALL_PREFIX}/bin/alm" ]
 
 EXPOSE 8080

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/user"
 
 	"github.com/jinzhu/gorm"
 	_ "github.com/lib/pq"
@@ -28,6 +29,8 @@ var (
 )
 
 func main() {
+	printUserInfo()
+
 	var dbHost string
 
 	flag.BoolVar(&Development, "dev", false, "Enable development related features, e.g. token generation endpoint")
@@ -96,4 +99,17 @@ func main() {
 		service.LogError("startup", "err", err)
 	}
 
+}
+
+func printUserInfo() {
+	u, err := user.Current()
+	if err != nil {
+		panic("Failed to get current user: " + err.Error())
+	}
+	fmt.Printf("Running as user name \"%s\" with UID %s.\n", u.Username, u.Uid)
+	g, err := user.LookupGroupId(u.Gid)
+	if err != nil {
+		panic("Failed to lookup group: " + err.Error())
+	}
+	fmt.Printf("Running with group \"%s\" with GID %s.\n", g.Name, g.Gid)
 }


### PR DESCRIPTION
And output the user and group when alm starts for verification reasons.

Fixes #167

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/168)
<!-- Reviewable:end -->
