### PR TITLE
Added a health check URL for monitoring

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,6 +109,13 @@ func main() {
 	http.Handle("/api/", service.Mux)
 	http.Handle("/", http.FileServer(assetFS()))
 	http.Handle("/favicon.ico", http.NotFoundHandler())
+	http.HandleFunc("/healthcheck", func(w http.ResponseWriter, r *http.Request){
+		_ , error := db.DB().Exec("select 1")
+		if error != nil {
+			http.Error(w, error.Error(), http.StatusInternalServerError)
+		}
+        return
+	}) 
 
 	// Start http
 	if err := http.ListenAndServe(":8080", nil); err != nil {


### PR DESCRIPTION
Why:
Systems that provision, monitor and maintain ALM would need to
know whether the service is UP.

What:
GET /healthcheck returns a 200 if db is reachable.
GET /healthcheck returns a 500 if the test query to DB fails.
GET /healthcheck returns a 4XX if there are resolution issues.

fixes #173

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/174)
<!-- Reviewable:end -->
