### PR TITLE
Don't panic if the current user cannot be found

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,14 +120,16 @@ func main() {
 func printUserInfo() {
 	u, err := user.Current()
 	if err != nil {
-		panic("Failed to get current user: " + err.Error())
-	}
-	fmt.Printf("Running as user name \"%s\" with UID %s.\n", u.Username, u.Uid)
-	/*
+		fmt.Printf("Failed to get current user: %s", err.Error())
+	} else {
+		fmt.Printf("Running as user name \"%s\" with UID %s.\n", u.Username, u.Uid)
+		/*
 		g, err := user.LookupGroupId(u.Gid)
 		if err != nil {
-			panic("Failed to lookup group: " + err.Error())
+			fmt.Printf("Failed to lookup group: %", err.Error())
+		} else {
+			fmt.Printf("Running with group \"%s\" with GID %s.\n", g.Name, g.Gid)
 		}
-		fmt.Printf("Running with group \"%s\" with GID %s.\n", g.Name, g.Gid)
-	*/
+		*/
+	}
 }


### PR DESCRIPTION
We don't panic if the current user cannot be found but instead just print the error.

(This only happened in openshift.)

Fixes #172

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/177)
<!-- Reviewable:end -->
