### PR TITLE
Consolidated references to remote provider name

### DIFF
--- a/remoteworkitem/remoteworkitem.go
+++ b/remoteworkitem/remoteworkitem.go
@@ -12,6 +12,7 @@ const (
 	SystemDescription  = "system.description"
 	SystemStatus       = "system.status"
 	ProviderGithub     = "github"
+	ProviderJira       = "jira"
 )
 
 var WorkItemKeyMaps = map[string]WorkItemMap{
@@ -42,6 +43,7 @@ type RemoteWorkItem struct {
 
 var RemoteWorkItemImplRegistry = map[string]func(RemoteWorkItem) (AttributeAccesor, error){
 	ProviderGithub: NewGitHubRemoteWorkItem,
+	ProviderJira:   NewJiraRemoteWorkItem,
 }
 
 // GitHubRemoteWorkItem knows how to implement a FieldAccessor on a GitHub Issue JSON struct
@@ -61,6 +63,26 @@ func NewGitHubRemoteWorkItem(item RemoteWorkItem) (AttributeAccesor, error) {
 
 func (gh GitHubRemoteWorkItem) Get(field AttributeExpression) interface{} {
 	return gh.issue[string(field)]
+}
+
+// JiraRemoteWorkItem knows how to implement a FieldAccessor on a Jira Issue JSON struct
+type JiraRemoteWorkItem struct {
+	issue map[string]interface{}
+}
+
+// NewJiraRemoteWorkItem creates a new Decoded AttributeAccessor for a GitHub Issue
+func NewJiraRemoteWorkItem(item RemoteWorkItem) (AttributeAccesor, error) {
+	var j map[string]interface{}
+	err := json.Unmarshal(item.Content, &j)
+	if err != nil {
+		return nil, err
+	}
+	// TODO for sbose: Flatten !
+	return JiraRemoteWorkItem{issue: j}, nil
+}
+
+func (jira JiraRemoteWorkItem) Get(field AttributeExpression) interface{} {
+	return jira.issue[string(field)]
 }
 
 // Map maps the remote WorkItem to a local WorkItem

--- a/remoteworkitem/scheduler.go
+++ b/remoteworkitem/scheduler.go
@@ -62,9 +62,9 @@ func fetchTrackerQueries(db *gorm.DB) []trackerSchedule {
 // LookupProvider provides the respective tracker based on the type
 func LookupProvider(ts trackerSchedule) TrackerProvider {
 	switch ts.TrackerType {
-	case "github":
+	case ProviderGithub:
 		return &Github{URL: ts.URL, Query: ts.Query}
-	case "jira":
+	case ProviderJira:
 		return &Jira{URL: ts.URL, Query: ts.Query}
 	}
 	return nil

--- a/remoteworkitem/scheduler_test.go
+++ b/remoteworkitem/scheduler_test.go
@@ -49,12 +49,12 @@ func TestNewScheduler(t *testing.T) {
 }
 
 func TestLookupProvider(t *testing.T) {
-	ts1 := trackerSchedule{TrackerType: "github"}
+	ts1 := trackerSchedule{TrackerType: ProviderGithub}
 	tp1 := LookupProvider(ts1)
 	if tp1 == nil {
 		t.Error("nil provider")
 	}
-	ts2 := trackerSchedule{TrackerType: "jira"}
+	ts2 := trackerSchedule{TrackerType: ProviderJira}
 	tp2 := LookupProvider(ts2)
 	if tp2 == nil {
 		t.Error("nil provider")

--- a/remoteworkitem/tracker_repository.go
+++ b/remoteworkitem/tracker_repository.go
@@ -20,14 +20,11 @@ func NewTrackerRepository(ts *GormTransactionSupport) *GormTrackerRepository {
 	return &GormTrackerRepository{ts}
 }
 
-var trackerTypes = map[string]string{
-	"github": "Github",
-	"jira":   "Jira"}
-
 // Create creates a new tracker configuration in the repository
 // returns BadParameterError, ConversionError or InternalError
 func (r *GormTrackerRepository) Create(ctx context.Context, url string, typeID string) (*app.Tracker, error) {
-	_, present := trackerTypes[typeID]
+	_, present := RemoteWorkItemImplRegistry[typeID]
+	// Ensure we support this remote tracker.
 	if present != true {
 		return nil, BadParameterError{parameter: "type", value: typeID}
 	}


### PR DESCRIPTION
- Lookup to check supported providers replaced with the lookup in the registry used for fetching Accessor implementations.
- Replaced all strings "github" and "jira" with the appropriate constant declarations.

fixes #160

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/213)
<!-- Reviewable:end -->
