### PR TITLE
Source interesting parts of jenkins slave env

### DIFF
--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -6,6 +6,17 @@ set -x
 # Exit on error
 set -e
 
+# Source environment variables of the jenkins slave
+# that might interest this worker.
+if [ -e "jenkins-env" ]; then
+  cat jenkins-env \
+    | grep -E "(JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprb)" \
+    | grep -v "ghprbPullLongDescription" \
+    | sed 's/^/export /g' \
+    > ~/.jenkins-env
+  source ~/.jenkins-env
+fi
+
 # We need to disable selinux for now, XXX
 /usr/sbin/setenforce 0
 


### PR DESCRIPTION
This change sources interesting parts of the jenkins slave environment to the worker machine. 

This is a preparation for setting up an integration of an external coverage service, that might need some environment variables to be present in order to determine the CI type. Codecov.io is an example of such a service.

See almighty/almighty-jobs@e718d3aa96c1b933f269b138d39eab4dc6a881e7 to see how the jenkins-env file was created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/226)
<!-- Reviewable:end -->
