### PR TITLE
Run tests even if no DB conn was setup in TestMain

### DIFF
--- a/remoteworkitem/scheduler_test.go
+++ b/remoteworkitem/scheduler_test.go
@@ -13,29 +13,25 @@ import (
 var db *gorm.DB
 
 func TestMain(m *testing.M) {
-	if _, c := os.LookupEnv(resource.Database); c == false {
-		fmt.Printf(resource.StSkipReasonNotSet+"\n", resource.Database)
-		return
+	if _, c := os.LookupEnv(resource.Database); c != false {
+		dbhost := os.Getenv("ALMIGHTY_DB_HOST")
+		if "" == dbhost {
+			panic("The environment variable ALMIGHTY_DB_HOST is not specified or empty.")
+		}
+		var err error
+		db, err = gorm.Open("postgres", fmt.Sprintf("host=%s user=postgres password=mysecretpassword sslmode=disable", dbhost))
+		if err != nil {
+			panic("failed to connect database: " + err.Error())
+		}
+		defer db.Close()
+		// Migrate the schema
+		db.AutoMigrate(
+			&Tracker{},
+			&TrackerQuery{},
+			&TrackerItem{})
+		db.Model(&TrackerQuery{}).AddForeignKey("tracker_id", "trackers(id)", "RESTRICT", "RESTRICT")
 	}
-
-	dbhost := os.Getenv("ALMIGHTY_DB_HOST")
-	if "" == dbhost {
-		panic("The environment variable ALMIGHTY_DB_HOST is not specified or empty.")
-	}
-	var err error
-	db, err = gorm.Open("postgres", fmt.Sprintf("host=%s user=postgres password=mysecretpassword sslmode=disable", dbhost))
-	if err != nil {
-		panic("failed to connect database: " + err.Error())
-	}
-	defer db.Close()
-	// Migrate the schema
-	db.AutoMigrate(
-		&Tracker{},
-		&TrackerQuery{},
-		&TrackerItem{})
-	db.Model(&TrackerQuery{}).AddForeignKey("tracker_id", "trackers(id)", "RESTRICT", "RESTRICT")
-	ec := m.Run()
-	os.Exit(ec)
+	os.Exit(m.Run())
 }
 
 func TestNewScheduler(t *testing.T) {
@@ -49,6 +45,7 @@ func TestNewScheduler(t *testing.T) {
 }
 
 func TestLookupProvider(t *testing.T) {
+	resource.Require(t, resource.Database)
 	ts1 := trackerSchedule{TrackerType: ProviderGithub}
 	tp1 := LookupProvider(ts1)
 	if tp1 == nil {


### PR DESCRIPTION
My proposal is simple: Run tests `m.Run()` no matter what the state of the environment variable is: Each test is responsible to specify which resource is required.

This way we can have unit tests and integration tests in one package without modifying a lot of the code right now. There will be a time when we might have a better way to setup and tear down a database connection. @aslakknutsen and I talked about this already. But this is a short term solution for the problem I think.

Fixes #255