### PR TITLE
Consolidated the remote work item type into using TrackerItem

### DIFF
--- a/remoteworkitem/remoteworkitem_test.go
+++ b/remoteworkitem/remoteworkitem_test.go
@@ -56,10 +56,11 @@ func TestWorkItemMapping(t *testing.T) {
 	workItemMap := WorkItemMap{
 		AttributeExpression("title"): "system.title",
 	}
-	remoteWorkItem := RemoteWorkItem{ID: "xyz", Content: []byte(`{"title":"abc"}`)}
+	jsonContent := `{"title":"abc"}`
+	remoteTrackerItem := TrackerItem{Item: jsonContent, RemoteItemID: "xyz", BatchID: "bxyz", TrackerQueryID: uint64(0)}
 
 	remoteWorkItemImpl := RemoteWorkItemImplRegistry[ProviderGithub]
-	gh, err := remoteWorkItemImpl(remoteWorkItem)
+	gh, err := remoteWorkItemImpl(remoteTrackerItem)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,10 +81,10 @@ func TestGitHubIssueMapping(t *testing.T) {
 	}
 
 	workItemMap := WorkItemKeyMaps[ProviderGithub]
-	remoteWorkItem := RemoteWorkItem{ID: "xyz", Content: []byte(content)}
+	remoteTrackerkItem := TrackerItem{Item: string(content[:]), RemoteItemID: "xyz", BatchID: "bxyz", TrackerQueryID: uint64(0)}
 
 	remoteWorkItemImpl := RemoteWorkItemImplRegistry[ProviderGithub]
-	gh, err := remoteWorkItemImpl(remoteWorkItem)
+	gh, err := remoteWorkItemImpl(remoteTrackerkItem)
 
 	if err != nil {
 		t.Fatal(err)
@@ -108,10 +109,9 @@ func TestJiraIssueMapping(t *testing.T) {
 	}
 
 	workItemMap := WorkItemKeyMaps[ProviderJira]
-	remoteWorkItem := RemoteWorkItem{ID: "xyz", Content: []byte(content)}
-
+	remoteTrackerItem := TrackerItem{Item: string(content[:]), RemoteItemID: "xyz", BatchID: "bxyz", TrackerQueryID: uint64(0)}
 	remoteWorkItemImpl := RemoteWorkItemImplRegistry[ProviderJira]
-	ji, err := remoteWorkItemImpl(remoteWorkItem)
+	ji, err := remoteWorkItemImpl(remoteTrackerItem)
 
 	if err != nil {
 		t.Fatal(err)
@@ -230,11 +230,11 @@ func TestFlattenJiraResponseMapWithoutAssignee(t *testing.T) {
 
 func TestNewGitHubRemoteWorkItem(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
-	remoteWorkItem := RemoteWorkItem{
-		Content: []byte(`{"admins":[{"name":"aslak"}],"name":"shoubhik", "assignee":{"fixes": 2, "complete" : true,"foo":[ 1,2,3,4],"1":"sbose","2":"pranav","participants":{"4":"sbose56","5":"sbose78"}},"name":"shoubhik"}`),
-		ID:      "http://www.example.com",
-	}
-	githubRemoteWorkItem, ok := NewGitHubRemoteWorkItem(remoteWorkItem)
+
+	jsonContent := `{"admins":[{"name":"aslak"}],"name":"shoubhik", "assignee":{"fixes": 2, "complete" : true,"foo":[ 1,2,3,4],"1":"sbose","2":"pranav","participants":{"4":"sbose56","5":"sbose78"}},"name":"shoubhik"}`
+	remoteTrackerItem := TrackerItem{Item: jsonContent, RemoteItemID: "xyz", BatchID: "bxyz", TrackerQueryID: uint64(0)}
+
+	githubRemoteWorkItem, ok := NewGitHubRemoteWorkItem(remoteTrackerItem)
 	assert.Nil(t, ok)
 	assert.Equal(t, githubRemoteWorkItem.Get("admins.0.name"), "aslak")
 	assert.Equal(t, githubRemoteWorkItem.Get("name"), "shoubhik")
@@ -245,11 +245,11 @@ func TestNewGitHubRemoteWorkItem(t *testing.T) {
 
 func TestNewJiraRemoteWorkItem(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
-	remoteWorkItem := RemoteWorkItem{
-		Content: []byte(`{"admins":[{"name":"aslak"}],"name":"shoubhik", "assignee":{"fixes": 2, "complete" : true,"foo":[ 1,2,3,4],"1":"sbose","2":"pranav","participants":{"4":"sbose56","5":"sbose78"}},"name":"shoubhik"}`),
-		ID:      "http://www.example.com",
-	}
-	jiraRemoteWorkItem, ok := NewJiraRemoteWorkItem(remoteWorkItem)
+
+	jsonContent := `{"admins":[{"name":"aslak"}],"name":"shoubhik", "assignee":{"fixes": 2, "complete" : true,"foo":[ 1,2,3,4],"1":"sbose","2":"pranav","participants":{"4":"sbose56","5":"sbose78"}},"name":"shoubhik"}`
+	remoteTrackerItem := TrackerItem{Item: jsonContent, RemoteItemID: "xyz", BatchID: "bxyz", TrackerQueryID: uint64(0)}
+
+	jiraRemoteWorkItem, ok := NewJiraRemoteWorkItem(remoteTrackerItem)
 	assert.Nil(t, ok)
 	assert.Equal(t, jiraRemoteWorkItem.Get("admins.0.name"), "aslak")
 	assert.Equal(t, jiraRemoteWorkItem.Get("name"), "shoubhik")


### PR DESCRIPTION
PR #111 implemented the importing of a remote work item into our system and saving it in a 'staging' table
named 'TrackerItem'.

PR #152 introduced the design of mapping remote work items to ALM work items.

This PR consolidated the type 'RemoteWorkItem' and 'TrackerItem' into a single type 'TrackerItem' to be used across the codebase. They essentially wrapped the same data points prior to this PR. The tests have been updated to reflect this consolidation.

Fixes #162 #262 