### PR TITLE
Persistence of mapped remote work item

### DIFF
--- a/models/workitem_repository.go
+++ b/models/workitem_repository.go
@@ -164,7 +164,7 @@ func (r *GormWorkItemRepository) List(ctx context.Context, criteria criteria.Exp
 	log.Printf("executing query: '%s' with params %v", where, parameters)
 
 	var rows []WorkItem
-	db := r.ts.tx.Where(where, parameters)
+	db := r.ts.TX().Where(where, parameters)
 	if start != nil {
 		db = db.Offset(*start)
 	}

--- a/models/workitemtype_repository.go
+++ b/models/workitemtype_repository.go
@@ -221,3 +221,20 @@ func convertFieldTypeToModels(t app.FieldType) (FieldType, error) {
 		return SimpleType{*kind}, nil
 	}
 }
+
+func TEMPConvertFieldTypesToModel(fields map[string]app.FieldDefinition) (map[string]FieldDefinition, error) {
+
+	allFields := map[string]FieldDefinition{}
+	for field, definition := range fields {
+		ct, err := convertFieldTypeToModels(*definition.Type)
+		if err != nil {
+			return nil, err
+		}
+		converted := FieldDefinition{
+			Required: definition.Required,
+			Type:     ct,
+		}
+		allFields[field] = converted
+	}
+	return allFields, nil
+}

--- a/models/workitemtype_repository_whitebox_test.go
+++ b/models/workitemtype_repository_whitebox_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/almighty/almighty-core/app"
@@ -129,4 +130,39 @@ func TestConvertFieldTypeToModels(t *testing.T) {
 	}
 	_, err := convertFieldTypeToModels(app.FieldType{Kind: "DefinitivelyNotAType"})
 	assert.NotNil(t, err)
+}
+
+// TestTempConvertFieldsToModels is a temporary function to workaround the access
+// issue from migrations.go  - hence keeping it in *_whitebox_test.go
+
+func TestTempConvertFieldsToModels(t *testing.T) {
+
+	resource.Require(t, resource.UnitTest)
+	stString := "string"
+
+	newFields := map[string]app.FieldDefinition{
+		"system.title":          app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: true},
+		"system.description":    app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: false},
+		"system.creator":        app.FieldDefinition{Type: &app.FieldType{Kind: "user"}, Required: true},
+		"system.assignee":       app.FieldDefinition{Type: &app.FieldType{Kind: "user"}, Required: false},
+		"system.remote_item_id": app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: false},
+		"system.state": app.FieldDefinition{
+			Type: &app.FieldType{
+				BaseType: &stString,
+				Kind:     "enum",
+				Values:   []interface{}{"new", "open", "in progress", "resolved", "closed"},
+			},
+			Required: true,
+		},
+	}
+
+	expectedJSON := `{"system.assignee":{"Required":false,"Type":{"Kind":"user"}},"system.creator":{"Required":true,"Type":{"Kind":"user"}},"system.description":{"Required":false,"Type":{"Kind":"string"}},"system.remote_item_id":{"Required":false,"Type":{"Kind":"string"}},"system.state":{"Required":true,"Type":{"Kind":"enum","BaseType":{"Kind":"string"},"Values":["new","open","in progress","resolved","closed"]}},"system.title":{"Required":true,"Type":{"Kind":"string"}}}`
+
+	convertedFields, err := TEMPConvertFieldTypesToModel(newFields)
+	jsonArray, err := json.Marshal(convertedFields)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actualJSON := string(jsonArray[:])
+	assert.Equal(t, expectedJSON, actualJSON)
 }

--- a/remoteworkitem/remoteworkitem.go
+++ b/remoteworkitem/remoteworkitem.go
@@ -11,7 +11,7 @@ const (
 	SystemRemoteItemID = "system.remote_item_id"
 	SystemTitle        = "system.title"
 	SystemDescription  = "system.description"
-	SystemStatus       = "system.status"
+	SystemState        = "system.state"
 	SystemAssignee     = "system.assignee"
 	SystemCreator      = "system.creator"
 
@@ -20,7 +20,7 @@ const (
 	GithubTitle       = "title"
 	GithubDescription = "body"
 	GithubState       = "state"
-	GithubID          = "id"
+	GithubID          = "url"
 	GithubCreator     = "user.login"
 	GithubAssignee    = "assignee.login"
 
@@ -42,7 +42,7 @@ var WorkItemKeyMaps = map[string]WorkItemMap{
 	ProviderGithub: WorkItemMap{
 		AttributeExpression(GithubTitle):       SystemTitle,
 		AttributeExpression(GithubDescription): SystemDescription,
-		AttributeExpression(GithubState):       SystemStatus,
+		AttributeExpression(GithubState):       SystemState,
 		AttributeExpression(GithubID):          SystemRemoteItemID,
 		AttributeExpression(GithubCreator):     SystemCreator,
 		AttributeExpression(GithubAssignee):    SystemAssignee,
@@ -50,7 +50,7 @@ var WorkItemKeyMaps = map[string]WorkItemMap{
 	ProviderJira: WorkItemMap{
 		AttributeExpression(JiraTitle):    SystemTitle,
 		AttributeExpression(JiraBody):     SystemDescription,
-		AttributeExpression(JiraState):    SystemStatus,
+		AttributeExpression(JiraState):    SystemState,
 		AttributeExpression(JiraID):       SystemRemoteItemID,
 		AttributeExpression(JiraCreator):  SystemCreator,
 		AttributeExpression(JiraAssignee): SystemAssignee,

--- a/remoteworkitem/trackeritem_repository.go
+++ b/remoteworkitem/trackeritem_repository.go
@@ -1,6 +1,15 @@
 package remoteworkitem
 
-import "github.com/jinzhu/gorm"
+import (
+	"fmt"
+
+	"golang.org/x/net/context"
+
+	"github.com/almighty/almighty-core/app"
+	. "github.com/almighty/almighty-core/criteria"
+	"github.com/almighty/almighty-core/models"
+	"github.com/jinzhu/gorm"
+)
 
 // upload imports the items into database
 func upload(db *gorm.DB, tID int, item map[string]string) error {
@@ -17,4 +26,55 @@ func upload(db *gorm.DB, tID int, item map[string]string) error {
 	}
 	ti.Item = content
 	return db.Save(&ti).Error
+}
+
+// Map a remote work item into an ALM work item and persist it into the database.
+func convert(ts *models.GormTransactionSupport, tqID int, item map[string]string, provider string) (*app.WorkItem, error) {
+	witr := models.NewWorkItemTypeRepository(ts)
+	wir := models.NewWorkItemRepository(ts, witr)
+	ti := TrackerItem{Item: item["content"], RemoteItemID: item["id"], TrackerID: uint64(tqID)}
+
+	// Converting the remote item to a local work item
+	remoteTrackerItemMethodRef, ok := RemoteWorkItemImplRegistry[provider]
+	if !ok {
+		return nil, BadParameterError{parameter: provider, value: provider}
+	}
+	remoteTrackerItem, err := remoteTrackerItemMethodRef(ti)
+	if err != nil {
+		return nil, InternalError{simpleError{message: " Error parsing the tracker data "}}
+	}
+	workItem, err := Map(remoteTrackerItem, WorkItemKeyMaps[provider])
+	if err != nil {
+		return nil, ConversionError{simpleError{message: " Error mapping to local work item "}}
+	}
+
+	// Get the remote item identifier ( which is currently the url ) to check if the work item exists in the database.
+	workItemRemoteID := workItem.Fields[SystemRemoteItemID]
+
+	sqlExpression := Equals(Field(SystemRemoteItemID), Literal(workItemRemoteID))
+
+	var newWorkItem *app.WorkItem
+
+	// Querying the database
+	existingWorkItems, err := wir.List(context.Background(), sqlExpression, nil, nil)
+
+	if len(existingWorkItems) != 0 {
+		fmt.Println("Workitem exists, will be updated")
+		existingWorkItem := existingWorkItems[0]
+		for key, value := range workItem.Fields {
+			existingWorkItem.Fields[key] = value
+		}
+		newWorkItem, err = wir.Save(context.Background(), *existingWorkItem)
+		if err != nil {
+			fmt.Println("Error updating work item : ", err)
+		}
+	} else {
+		fmt.Println("Work item not found , will now create new work item")
+
+		newWorkItem, err = wir.Create(context.Background(), "system.bug", workItem.Fields)
+		if err != nil {
+			fmt.Println("Error creating work item : ", err)
+		}
+	}
+	return newWorkItem, err
 }

--- a/remoteworkitem/trackeritem_repository_test.go
+++ b/remoteworkitem/trackeritem_repository_test.go
@@ -1,0 +1,154 @@
+package remoteworkitem
+
+import (
+	"golang.org/x/net/context"
+
+	"testing"
+
+	"github.com/almighty/almighty-core/models"
+	"github.com/almighty/almighty-core/resource"
+	"github.com/almighty/almighty-core/test"
+	"github.com/almighty/almighty-core/transaction"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertNewWorkItem(t *testing.T) {
+	resource.Require(t, resource.Database)
+
+	// Setting up the dependent tracker query and tracker data in the Database
+	tr := Tracker{URL: "https://api.github.com/", Type: ProviderGithub}
+	db.Create(&tr)
+	defer db.Delete(&tr)
+
+	tq := TrackerQuery{Query: "some random query", Schedule: "0 0 0 * * *", TrackerID: tr.ID}
+	db.Create(&tq)
+	defer db.Delete(&tq)
+
+	t.Log("Created Tracker Query and Tracker")
+
+	ts := models.NewGormTransactionSupport(db)
+
+	transaction.Do(ts, func() error {
+		t.Log("Scenario 1 : Scenario 1: Adding a work item which wasn't present.")
+
+		remoteItemData := map[string]string{
+			"content":  `{"title":"linking","url":"http://github.com/sbose/api/testonly/1","state":"closed","body":"body of issue","user.login":"sbose78","assignee.login":"pranav"}`,
+			"id":       "http://github.com/sbose/api/testonly/1",
+			"batch_id": "1",
+		}
+
+		workItem, err := convert(ts, int(tq.ID), remoteItemData, ProviderGithub)
+
+		assert.Nil(t, err)
+		assert.Equal(t, "linking", workItem.Fields[SystemTitle])
+		assert.Equal(t, "sbose78", workItem.Fields[SystemCreator])
+		assert.Equal(t, "pranav", workItem.Fields[SystemAssignee])
+		assert.Equal(t, "closed", workItem.Fields[SystemState])
+
+		witr := models.NewWorkItemTypeRepository(ts)
+		wir := models.NewWorkItemRepository(ts, witr)
+		wir.Delete(context.Background(), workItem.ID)
+
+		return err
+	})
+}
+
+func TestConvertExistingWorkItem(t *testing.T) {
+	resource.Require(t, resource.Database)
+
+	// Setting up the dependent tracker query and tracker data in the Database
+	tr := Tracker{URL: "https://api.github.com/", Type: ProviderGithub}
+	db.Create(&tr)
+	defer db.Delete(&tr)
+
+	tq := TrackerQuery{Query: "some random query", Schedule: "0 0 0 * * *", TrackerID: tr.ID}
+	db.Create(&tq)
+	defer db.Delete(&tq)
+
+	t.Log("Created Tracker Query and Tracker")
+
+	ts := models.NewGormTransactionSupport(db)
+
+	transaction.Do(ts, func() error {
+		t.Log("Adding a work item which wasn't present.")
+
+		remoteItemData := map[string]string{
+			"content":  `{"title":"linking","url":"http://github.com/sbose/api/testonly/1","state":"closed","body":"body of issue","user.login":"sbose78","assignee.login":"pranav"}`,
+			"id":       "http://github.com/sbose/api/testonly/1",
+			"batch_id": "1",
+		}
+
+		workItem, err := convert(ts, int(tq.ID), remoteItemData, ProviderGithub)
+
+		assert.Nil(t, err)
+		assert.Equal(t, "linking", workItem.Fields[SystemTitle])
+		assert.Equal(t, "sbose78", workItem.Fields[SystemCreator])
+		assert.Equal(t, "pranav", workItem.Fields[SystemAssignee])
+		assert.Equal(t, "closed", workItem.Fields[SystemState])
+		return err
+	})
+
+	t.Log("Updating the existing work item when it's reimported.")
+
+	transaction.Do(ts, func() error {
+		remoteItemDataUpdated := map[string]string{
+			"content":  `{"title":"linking-updated","url":"http://github.com/api/testonly/1","state":"closed","body":"body of issue","user.login":"sbose78","assignee.login":"pranav"}`,
+			"id":       "http://github.com/sbose/api/testonly/1",
+			"batch_id": "2",
+		}
+		workItemUpdated, err := convert(ts, int(tq.ID), remoteItemDataUpdated, ProviderGithub)
+
+		assert.Nil(t, err)
+		assert.Equal(t, "linking-updated", workItemUpdated.Fields[SystemTitle])
+		assert.Equal(t, "sbose78", workItemUpdated.Fields[SystemCreator])
+		assert.Equal(t, "pranav", workItemUpdated.Fields[SystemAssignee])
+		assert.Equal(t, "closed", workItemUpdated.Fields[SystemState])
+
+		witr := models.NewWorkItemTypeRepository(ts)
+		wir := models.NewWorkItemRepository(ts, witr)
+		wir.Delete(context.Background(), workItemUpdated.ID)
+
+		return err
+	})
+
+}
+
+func TestConvertGithubIssue(t *testing.T) {
+	resource.Require(t, resource.Database)
+
+	t.Log("Scenario 3 : Mapping and persisting a Github issue")
+
+	ts := models.NewGormTransactionSupport(db)
+
+	tr := Tracker{URL: "https://api.github.com/", Type: ProviderGithub}
+	db.Create(&tr)
+	defer db.Delete(&tr)
+
+	tq := TrackerQuery{Query: "some random query", Schedule: "0 0 0 * * *", TrackerID: tr.ID}
+	db.Create(&tq)
+	defer db.Delete(&tq)
+
+	transaction.Do(ts, func() error {
+		content, err := test.LoadTestData("github_issue_mapping.json", provideRemoteGithubDataWithAssignee)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		remoteItemDataGithub := map[string]string{
+			"content":  string(content[:]),
+			"id":       GithubIssueWithAssignee, // GH issue url
+			"batch_id": "2",
+		}
+
+		workItemGithub, err := convert(ts, int(tq.ID), remoteItemDataGithub, ProviderGithub)
+
+		assert.Nil(t, err)
+		assert.Equal(t, "map flatten : test case : with assignee", workItemGithub.Fields[SystemTitle])
+		assert.Equal(t, "sbose78", workItemGithub.Fields[SystemCreator])
+		assert.Equal(t, "sbose78", workItemGithub.Fields[SystemAssignee])
+		assert.Equal(t, "open", workItemGithub.Fields[SystemState])
+
+		return err
+	})
+
+}


### PR DESCRIPTION
1. After the remote work item is persisted in the temporary table called 'TrackerItem'
2. Convert the remote item into a local work item.
3. Check if the work item exists. Use the remote_item_id in the json to check for existence of work item.
4. If present, update it, else, create a new one.

Fixes https://github.com/almighty/almighty-core/issues/170
