### PR TITLE
fix umlaut issue

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -10,7 +10,7 @@ set -e
 # that might interest this worker.
 if [ -e "jenkins-env" ]; then
   cat jenkins-env \
-    | grep -E "(JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)" \
+    | grep -E "(JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
     | sed 's/^/export /g' \
     > ~/.jenkins-env
   source ~/.jenkins-env

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -10,7 +10,7 @@ set -e
 # that might interest this worker.
 if [ -e "jenkins-env" ]; then
   cat jenkins-env \
-    | grep -E "(JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)" \
+    | grep -E "(JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
     | sed 's/^/export /g' \
     > ~/.jenkins-env
   source ~/.jenkins-env


### PR DESCRIPTION
This should fix the problem with funky German Umlauts in the `ghprbActualCommitAuthor` variable.

Previously we extracte the `ghprbActualCommitAuthor` variable, but now we look for a `=` after the variable name and that should limit the selection of environment variables to just `ghprbActualCommit`.