### PR TITLE
Add realtime example for WorkItemType payload.

### DIFF
--- a/design/user_types.go
+++ b/design/user_types.go
@@ -34,21 +34,23 @@ var UpdateWorkItemPayload = Type("UpdateWorkItemPayload", func() {
 
 // CreateWorkItemTypePayload explains how input payload should look like
 var CreateWorkItemTypePayload = Type("CreateWorkItemTypePayload", func() {
-	Attribute("name", String, "Readable name of the type like Task, Issue, Bug, Epic etc.")
-	Attribute("fields", HashOf(String, fieldDefinition), "Type fields those must be followed by respective Work Items.")
-	Attribute("extendedTypeName", String, "If newly created type extends any existing type")
-	Required("name", "fields")
-	Example(map[string]interface{}{
-		"name": "Epic",
-		"fields": map[string]interface{}{
-			"system.owner": map[string]interface{}{
+	Attribute("name", String, "Readable name of the type like Task, Issue, Bug, Epic etc.", func() {
+		Example("Epic")
+	})
+	Attribute("fields", HashOf(String, fieldDefinition), "Type fields those must be followed by respective Work Items.", func() {
+		Example(map[string]interface{}{
+			"system.administrator": map[string]interface{}{
 				"Type": map[string]interface{}{
 					"Kind": "string",
 				},
 				"Required": true,
 			},
-		},
+		})
 	})
+	Attribute("extendedTypeName", String, "If newly created type extends any existing type", func() {
+		Example("(optional field)Parent type name")
+	})
+	Required("name", "fields")
 })
 
 // CreateTrackerAlternatePayload defines the structure of tracker payload for create

--- a/design/user_types.go
+++ b/design/user_types.go
@@ -32,11 +32,23 @@ var UpdateWorkItemPayload = Type("UpdateWorkItemPayload", func() {
 	Required("type", "fields", "version")
 })
 
+// CreateWorkItemTypePayload explains how input payload should look like
 var CreateWorkItemTypePayload = Type("CreateWorkItemTypePayload", func() {
 	Attribute("name", String, "Readable name of the type like Task, Issue, Bug, Epic etc.")
 	Attribute("fields", HashOf(String, fieldDefinition), "Type fields those must be followed by respective Work Items.")
 	Attribute("extendedTypeName", String, "If newly created type extends any existing type")
 	Required("name", "fields")
+	Example(map[string]interface{}{
+		"name": "Epic",
+		"fields": map[string]interface{}{
+			"system.owner": map[string]interface{}{
+				"Type": map[string]interface{}{
+					"Kind": "string",
+				},
+				"Required": true,
+			},
+		},
+	})
 })
 
 // CreateTrackerAlternatePayload defines the structure of tracker payload for create

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f40749f8fd3afc7446ab7779cb67618a9d03682fbf883534cb6a40bdc8f97372
-updated: 2016-09-07T11:31:53.570191805+02:00
+hash: f69d42148a4455c288f4f350f4e07ec00daf9ace5b51863b0726745333839690
+updated: 2016-09-29T10:03:44.437242317+05:30
 imports:
 - name: bitbucket.org/pkg/inflect
   version: 8961c3750a47b8c0b3e118d52513b97adf85a7e8
@@ -18,7 +18,7 @@ imports:
 - name: github.com/dimfeld/httppath
   version: c8e499c3ef3c3e272ed8bdcc1ccf39f73c88debc
 - name: github.com/dimfeld/httptreemux
-  version: 612c3d8e47f5a166d9346b694cf2aeb68eff5369
+  version: 96acf0909c0b45ebf4a25a816cedc6d317e63679
 - name: github.com/elazarl/go-bindata-assetfs
   version: 57eb5e1fc594ad4b0b1dbea7b286d299e0cb43c2
   subpackages:
@@ -26,13 +26,14 @@ imports:
 - name: github.com/fsnotify/fsnotify
   version: a8a77c9133d2d6fd8334f3260d06f60e8d80a5fb
 - name: github.com/goadesign/goa
-  version: 90e6c399f49c4125bbadf91eaa60156b9aa2a65e
+  version: b1b4f4d827a3b63b05d978ca82305c45451103b3
   vcs: git
   subpackages:
   - client
   - cors
   - design
   - design/apidsl
+  - dslengine
   - goagen
   - goagen/codegen
   - goagen/gen_app
@@ -41,7 +42,6 @@ imports:
   - middleware
   - middleware/security/jwt
   - uuid
-  - dslengine
 - name: github.com/goadesign/gorma
   version: f7116846126a4cb17a0cddd6b3b429ad1592f260
 - name: github.com/google/go-github
@@ -57,10 +57,10 @@ imports:
   subpackages:
   - hcl/ast
   - hcl/parser
-  - hcl/token
-  - json/parser
   - hcl/scanner
   - hcl/strconv
+  - hcl/token
+  - json/parser
   - json/scanner
   - json/token
 - name: github.com/howeyc/fsnotify
@@ -129,11 +129,11 @@ imports:
 - name: github.com/spf13/viper
   version: 16990631d4aa7e38f73dbbbf37fa13e67c648531
 - name: github.com/stretchr/testify
-  version: f390dcf405f7b83c997eac1b06768bb9f44dec18
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
-  - suite
   - require
+  - suite
 - name: github.com/wadey/gocovmerge
   version: b5bfa59ec0adc420475f97f89b58045c721d761c
 - name: github.com/zach-klippenstein/goregen
@@ -141,10 +141,10 @@ imports:
 - name: golang.org/x/crypto
   version: 9e590154d2353f3f5e1b24da7275686040dcf491
   subpackages:
-  - ssh
   - curve25519
   - ed25519
   - ed25519/internal/edwards25519
+  - ssh
 - name: golang.org/x/net
   version: f841c39de738b1d0df95b5a7187744f0e03d8112
   subpackages:
@@ -169,7 +169,7 @@ imports:
   version: a83829b6f1293c91addabc89d0571c246397bbf4
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 2df174808ee097f90d259e432cc04442cf60be21
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ import:
 - package: github.com/dgrijalva/jwt-go
   version: ^3.0.0
 - package: github.com/goadesign/goa
-  version: 90e6c399f49c4125bbadf91eaa60156b9aa2a65e
+  version: b1b4f4d827a3b63b05d978ca82305c45451103b3
   vcs: git
   subpackages:
   - client
@@ -79,3 +79,5 @@ import:
 - package: github.com/spf13/afero
 - package: github.com/spf13/cast
 - package: github.com/spf13/jwalterweatherman
+- package: github.com/dimfeld/httptreemux
+  version: ^3.1.0

--- a/tracker_test.go
+++ b/tracker_test.go
@@ -15,7 +15,7 @@ func TestCreateTracker(t *testing.T) {
 	ts := models.NewGormTransactionSupport(DB)
 	repo := remoteworkitem.NewTrackerRepository(ts)
 	controller := TrackerController{ts: ts, tRepository: repo, scheduler: rwiScheduler}
-	payload := app.CreateTrackerPayload{
+	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://issues.jboss.com",
 		Type: "jira",
 	}
@@ -31,7 +31,7 @@ func TestGetTracker(t *testing.T) {
 	ts := models.NewGormTransactionSupport(DB)
 	repo := remoteworkitem.NewTrackerRepository(ts)
 	controller := TrackerController{ts: ts, tRepository: repo, scheduler: rwiScheduler}
-	payload := app.CreateTrackerPayload{
+	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://issues.jboss.com",
 		Type: "jira",
 	}
@@ -46,7 +46,7 @@ func TestGetTracker(t *testing.T) {
 		t.Errorf("Id should be %s, but is %s", result.ID, tr.ID)
 	}
 
-	payload2 := app.UpdateTrackerPayload{
+	payload2 := app.UpdateTrackerAlternatePayload{
 		URL:  tr.URL,
 		Type: tr.Type,
 	}
@@ -71,7 +71,7 @@ func TestTrackerListItemsNotNil(t *testing.T) {
 	ts := models.NewGormTransactionSupport(DB)
 	repo := remoteworkitem.NewTrackerRepository(ts)
 	controller := TrackerController{ts: ts, tRepository: repo, scheduler: rwiScheduler}
-	payload := app.CreateTrackerPayload{
+	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://issues.jboss.com",
 		Type: "jira",
 	}
@@ -97,7 +97,7 @@ func TestCreateTrackerValidId(t *testing.T) {
 	ts := models.NewGormTransactionSupport(DB)
 	repo := remoteworkitem.NewTrackerRepository(ts)
 	controller := TrackerController{ts: ts, tRepository: repo, scheduler: rwiScheduler}
-	payload := app.CreateTrackerPayload{
+	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://issues.jboss.com",
 		Type: "jira",
 	}

--- a/trackerquery_test.go
+++ b/trackerquery_test.go
@@ -16,7 +16,7 @@ func TestCreateTrackerQuery(t *testing.T) {
 	ts := models.NewGormTransactionSupport(DB)
 	repo := remoteworkitem.NewTrackerRepository(ts)
 	controller := TrackerController{ts: ts, tRepository: repo, scheduler: rwiScheduler}
-	payload := app.CreateTrackerPayload{
+	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://api.github.com",
 		Type: "github",
 	}
@@ -25,7 +25,7 @@ func TestCreateTrackerQuery(t *testing.T) {
 	tqts := models.NewGormTransactionSupport(DB)
 	tqrepo := remoteworkitem.NewTrackerQueryRepository(tqts)
 	tqController := TrackerqueryController{ts: tqts, tqRepository: tqrepo, scheduler: rwiScheduler}
-	tqpayload := app.CreateTrackerqueryPayload{
+	tqpayload := app.CreateTrackerQueryAlternatePayload{
 
 		Query:     "is:open is:issue user:arquillian author:aslakknutsen",
 		Schedule:  "15 * * * * *",
@@ -44,7 +44,7 @@ func TestGetTrackerQuery(t *testing.T) {
 	ts := models.NewGormTransactionSupport(DB)
 	repo := remoteworkitem.NewTrackerRepository(ts)
 	controller := TrackerController{ts: ts, tRepository: repo, scheduler: rwiScheduler}
-	payload := app.CreateTrackerPayload{
+	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://api.github.com",
 		Type: "github",
 	}
@@ -52,7 +52,7 @@ func TestGetTrackerQuery(t *testing.T) {
 
 	tqrepo := remoteworkitem.NewTrackerQueryRepository(ts)
 	tqController := TrackerqueryController{ts: ts, tqRepository: tqrepo, scheduler: rwiScheduler}
-	tqpayload := app.CreateTrackerqueryPayload{
+	tqpayload := app.CreateTrackerQueryAlternatePayload{
 
 		Query:     "is:open is:issue user:arquillian author:aslakknutsen",
 		Schedule:  "15 * * * * *",
@@ -76,7 +76,7 @@ func TestUpdateTrackerQuery(t *testing.T) {
 	ts := models.NewGormTransactionSupport(DB)
 	repo := remoteworkitem.NewTrackerRepository(ts)
 	controller := TrackerController{ts: ts, tRepository: repo, scheduler: rwiScheduler}
-	payload := app.CreateTrackerPayload{
+	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://api.github.com",
 		Type: "github",
 	}
@@ -84,7 +84,7 @@ func TestUpdateTrackerQuery(t *testing.T) {
 
 	tqrepo := remoteworkitem.NewTrackerQueryRepository(ts)
 	tqController := TrackerqueryController{ts: ts, tqRepository: tqrepo, scheduler: rwiScheduler}
-	tqpayload := app.CreateTrackerqueryPayload{
+	tqpayload := app.CreateTrackerQueryAlternatePayload{
 
 		Query:     "is:open is:issue user:arquillian author:aslakknutsen",
 		Schedule:  "15 * * * * *",
@@ -102,7 +102,7 @@ func TestUpdateTrackerQuery(t *testing.T) {
 		t.Errorf("Id should be %s, but is %s", tqresult.ID, tqr.ID)
 	}
 
-	payload2 := app.UpdateTrackerqueryPayload{
+	payload2 := app.UpdateTrackerQueryAlternatePayload{
 		Query:     tqr.Query,
 		Schedule:  tqr.Schedule,
 		TrackerID: result.ID,

--- a/workitem_blackbox_test.go
+++ b/workitem_blackbox_test.go
@@ -22,7 +22,7 @@ func TestGetWorkItem(t *testing.T) {
 	assert.NotNil(t, svc)
 	controller := NewWorkitemController(svc, repo, ts)
 	assert.NotNil(t, controller)
-	payload := app.CreateWorkitemPayload{
+	payload := app.CreateWorkItemPayload{
 		Type: "system.bug",
 		Fields: map[string]interface{}{
 			"system.title":   "Test WI",
@@ -43,7 +43,7 @@ func TestGetWorkItem(t *testing.T) {
 	}
 
 	wi.Fields["system.creator"] = "thomas"
-	payload2 := app.UpdateWorkitemPayload{
+	payload2 := app.UpdateWorkItemPayload{
 		Type:    wi.Type,
 		Version: wi.Version,
 		Fields:  wi.Fields,
@@ -71,7 +71,7 @@ func TestCreateWI(t *testing.T) {
 	assert.NotNil(t, svc)
 	controller := NewWorkitemController(svc, repo, ts)
 	assert.NotNil(t, controller)
-	payload := app.CreateWorkitemPayload{
+	payload := app.CreateWorkItemPayload{
 		Type: "system.bug",
 		Fields: map[string]interface{}{
 			"system.title":   "Test WI",
@@ -95,7 +95,7 @@ func TestListByFields(t *testing.T) {
 	assert.NotNil(t, svc)
 	controller := NewWorkitemController(svc, repo, ts)
 	assert.NotNil(t, controller)
-	payload := app.CreateWorkitemPayload{
+	payload := app.CreateWorkItemPayload{
 		Type: "system.bug",
 		Fields: map[string]interface{}{
 			"system.title":   "run integration test",

--- a/workitemtype_blackbox_test.go
+++ b/workitemtype_blackbox_test.go
@@ -141,7 +141,7 @@ func (s *WorkItemTypeSuite) createWorkItemTypeAnimal() (http.ResponseWriter, *ap
 	}
 
 	// Use the goa generated code to create a work item type
-	payload := app.CreateWorkitemtypePayload{
+	payload := app.CreateWorkItemTypePayload{
 		Fields: map[string]*app.FieldDefinition{
 			"animal_type": &typeFieldDef,
 			"color":       &colorFieldDef,
@@ -165,7 +165,7 @@ func (s *WorkItemTypeSuite) createWorkItemTypePerson() (http.ResponseWriter, *ap
 	}
 
 	// Use the goa generated code to create a work item type
-	payload := app.CreateWorkitemtypePayload{
+	payload := app.CreateWorkItemTypePayload{
 		Fields: map[string]*app.FieldDefinition{
 			"name": &nameFieldDef,
 		},


### PR DESCRIPTION
fix #187 
How:
Generally we add examples for each attribute separate. But type of `fields` attribute is a hash made up of UserDefinedType `fieldDefinition` and hence adding separate example for `fields` was failing. After many attempts in many direction I found this simple solution that we can add `Whole Example` along with all Attributes. Plus point is that `ExtendedType` is optional and is not promoted for usage as of now hence that is skipped.

After updating goa to b1b4f4d827a3b63b05d978ca82305c45451103b3, all dependency tree was updated by glide

Hence changes made by goagen while generateing code inside 'app' directory. And we need to use `*AlternatePayload` in our tests.

Hence updated all failing tests.


