### PR TITLE
Make default of -config switch "" instead of "config.yaml"

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -10,13 +10,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-const (
-	// DefaultConfigFilePath is the path to the configuration file that is used if no other
-	// file is specified via the -config switch or via the ALMIGHTY_CONFIG_FILE_PATH environment
-	// variable.
-	DefaultConfigFilePath = "config.yaml"
-)
-
 // String returns the current configuration as a string
 func String() string {
 	allSettings := viper.AllSettings()

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func main() {
 	var configFilePath string
 	var printConfig bool
 	var scheduler *remoteworkitem.Scheduler
-	flag.StringVar(&configFilePath, "config", configuration.DefaultConfigFilePath, "Path to the config file to read")
+	flag.StringVar(&configFilePath, "config", "", "Path to the config file to read")
 	flag.BoolVar(&printConfig, "printConfig", false, "Prints the config (including merged environment variables) and exits")
 	flag.Parse()
 

--- a/remoteworkitem/scheduler_test.go
+++ b/remoteworkitem/scheduler_test.go
@@ -16,7 +16,7 @@ var db *gorm.DB
 func TestMain(m *testing.M) {
 	var err error
 
-	if err = configuration.Setup("../config.yaml"); err != nil {
+	if err = configuration.Setup(""); err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
 

--- a/workitem_whitebox_test.go
+++ b/workitem_whitebox_test.go
@@ -23,7 +23,7 @@ var rwiScheduler *remoteworkitem.Scheduler
 func TestMain(m *testing.M) {
 	var err error
 
-	if err = configuration.Setup(configuration.DefaultConfigFilePath); err != nil {
+	if err = configuration.Setup(""); err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
 

--- a/workitemtype_blackbox_test.go
+++ b/workitemtype_blackbox_test.go
@@ -41,7 +41,7 @@ func (s *WorkItemTypeSuite) SetupSuite() {
 
 	var err error
 
-	if err = configuration.Setup(configuration.DefaultConfigFilePath); err != nil {
+	if err = configuration.Setup(""); err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
 


### PR DESCRIPTION
This makes the -config switch fully optional even if there's no
config.yaml at hand.