### PR TITLE
Avoid too early expansion of $PATH variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ generate: prebuild-check $(DESIGNS) $(GOAGEN_BIN) $(GO_BINDATA_ASSETFS_BIN) $(GO
 	$(GOAGEN_BIN) bootstrap -d ${PACKAGE_NAME}/${DESIGN_DIR}
 	$(GOAGEN_BIN) js -d ${PACKAGE_NAME}/${DESIGN_DIR} -o assets/ --noexample
 	$(GOAGEN_BIN) gen -d ${PACKAGE_NAME}/${DESIGN_DIR} --pkg-path=github.com/goadesign/gorma
-	PATH="$(PATH):$(EXTRA_PATH)" $(GO_BINDATA_ASSETFS_BIN) -debug assets/...
+	PATH="$$PATH:$(EXTRA_PATH)" $(GO_BINDATA_ASSETFS_BIN) -debug assets/...
 
 .PHONY: dev
 dev: prebuild-check $(FRESH_BIN)


### PR DESCRIPTION
The first version we had caused problems on Windows systems: `$(PATH)`. This was problematic due to paths with whitespaces in them.

In my second approach I did this: `$$(PATH)`. The double `$$` was used to avoid a too early expansion of the `PATH` variable. Sadly this was also wrong and cause troubles (see [this mail thread](https://www.redhat.com/archives/almighty-public/2016-September/msg00219.html))

This time, the early expansion is correct: `$$PATH`.

Lot of text for such a small change ;)