### PR TITLE
Securing WI and WIT APIs and related tests

### DIFF
--- a/design/resources.go
+++ b/design/resources.go
@@ -45,6 +45,7 @@ var _ = Resource("workitem", func() {
 	})
 
 	Action("create", func() {
+		Security("jwt")
 		Routing(
 			POST(""),
 		)
@@ -57,8 +58,10 @@ var _ = Resource("workitem", func() {
 			Media(ErrorMedia)
 		})
 		Response(InternalServerError)
+		Response(Unauthorized)
 	})
 	Action("delete", func() {
+		Security("jwt")
 		Routing(
 			DELETE("/:id"),
 		)
@@ -72,8 +75,10 @@ var _ = Resource("workitem", func() {
 		})
 		Response(InternalServerError)
 		Response(NotFound)
+		Response(Unauthorized)
 	})
 	Action("update", func() {
+		Security("jwt")
 		Routing(
 			PUT("/:id"),
 		)
@@ -90,6 +95,7 @@ var _ = Resource("workitem", func() {
 		})
 		Response(InternalServerError)
 		Response(NotFound)
+		Response(Unauthorized)
 	})
 
 })
@@ -114,6 +120,7 @@ var _ = Resource("workitemtype", func() {
 	})
 
 	Action("create", func() {
+		Security("jwt")
 		Routing(
 			POST(""),
 		)
@@ -126,6 +133,7 @@ var _ = Resource("workitemtype", func() {
 			Media(ErrorMedia)
 		})
 		Response(InternalServerError)
+		Response(Unauthorized)
 	})
 
 	Action("list", func() {

--- a/workitem_blackbox_test.go
+++ b/workitem_blackbox_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/almighty/almighty-core"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
+	"github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/resource"
 	jwt "github.com/dgrijalva/jwt-go"
@@ -189,7 +190,7 @@ type testSecureAPI struct {
 }
 
 func getWorkItemTestData(t *testing.T) []testSecureAPI {
-	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM(([]byte(RSAPrivateKeyTest)))
+	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((configuration.GetTokenPrivateKey()))
 	if err != nil {
 		t.Fatal("Could not parse Key ", err)
 	}
@@ -306,7 +307,7 @@ func TestUnauthorizeWorkItemCUD(t *testing.T) {
 	resource.Require(t, resource.Database)
 
 	// This will be modified after merge PR for "Viper Environment configurations"
-	publickey, err := jwt.ParseRSAPublicKeyFromPEM(([]byte(RSAPublicKeyTest)))
+	publickey, err := jwt.ParseRSAPublicKeyFromPEM((configuration.GetTokenPublicKey()))
 	if err != nil {
 		t.Fatal("Could not parse Key ", err)
 	}
@@ -372,44 +373,6 @@ func TestUnauthorizeWorkItemCUD(t *testing.T) {
 		assert.Equal(t, testObject.expectedStatusCode, content.Status)
 	}
 }
-
-var RSAPublicKeyTest = `-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnwrjH5iTSErw9xUptp6Q
-SFoUfpHUXZ+PaslYSUrpLjw1q27ODSFwmhV4+dAaTMO5chFv/kM36H3ZOyA146nw
-xBobS723okFaIkshRrf6qgtD6coTHlVUSBTAcwKEjNn4C9jtEpyOl+eSgxhMzRH3
-bwTIFlLlVMiZf7XVE7P3yuOCpqkk2rdYVSpQWQWKU+ZRywJkYcLwjEYjc70AoNpj
-O5QnY+Exx98E30iEdPHZpsfNhsjh9Z7IX5TrMYgz7zBTw8+niO/uq3RBaHyIhDbv
-enbR9Q59d88lbnEeHKgSMe2RQpFR3rxFRkc/64Rn/bMuL/ptNowPqh1P+9GjYzWm
-PwIDAQAB
------END PUBLIC KEY-----`
-
-var RSAPrivateKeyTest = `-----BEGIN RSA PRIVATE KEY-----
-MIIEpQIBAAKCAQEAnwrjH5iTSErw9xUptp6QSFoUfpHUXZ+PaslYSUrpLjw1q27O
-DSFwmhV4+dAaTMO5chFv/kM36H3ZOyA146nwxBobS723okFaIkshRrf6qgtD6coT
-HlVUSBTAcwKEjNn4C9jtEpyOl+eSgxhMzRH3bwTIFlLlVMiZf7XVE7P3yuOCpqkk
-2rdYVSpQWQWKU+ZRywJkYcLwjEYjc70AoNpjO5QnY+Exx98E30iEdPHZpsfNhsjh
-9Z7IX5TrMYgz7zBTw8+niO/uq3RBaHyIhDbvenbR9Q59d88lbnEeHKgSMe2RQpFR
-3rxFRkc/64Rn/bMuL/ptNowPqh1P+9GjYzWmPwIDAQABAoIBAQCBCl5ZpnvprhRx
-BVTA/Upnyd7TCxNZmzrME+10Gjmz79pD7DV25ejsu/taBYUxP6TZbliF3pggJOv6
-UxomTB4znlMDUz0JgyjUpkyril7xVQ6XRAPbGrS1f1Def+54MepWAn3oGeqASb3Q
-bAj0Yl12UFTf+AZmkhQpUKk/wUeN718EIY4GRHHQ6ykMSqCKvdnVbMyb9sIzbSTl
-v+l1nQFnB/neyJq6P0Q7cxlhVj03IhYj/AxveNlKqZd2Ih3m/CJo0Abtwhx+qHZp
-cCBrYj7VelEaGARTmfoIVoGxFGKZNCcNzn7R2ic7safxXqeEnxugsAYX/UmMoq1b
-vMYLcaLRAoGBAMqMbbgejbD8Cy6wa5yg7XquqOP5gPdIYYS88TkQTp+razDqKPIU
-hPKetnTDJ7PZleOLE6eJ+dQJ8gl6D/dtOsl4lVRy/BU74dk0fYMiEfiJMYEYuAU0
-MCramo3HAeySTP8pxSLFYqJVhcTpL9+NQgbpJBUlx5bLDlJPl7auY077AoGBAMkD
-UpJRIv/0gYSz5btVheEyDzcqzOMZUVsngabH7aoQ49VjKrfLzJ9WznzJS5gZF58P
-vB7RLuIA8m8Y4FUwxOr4w9WOevzlFh0gyzgNY4gCwrzEryOZqYYqCN+8QLWfq/hL
-+gYFYpEW5pJ/lAy2i8kPanC3DyoqiZCsUmlg6JKNAoGBAIdCkf6zgKGhHwKV07cs
-DIqx2p0rQEFid6UB3ADkb+zWt2VZ6fAHXeT7shJ1RK0o75ydgomObWR5I8XKWqE7
-s1dZjDdx9f9kFuVK1Upd1SxoycNRM4peGJB1nWJydEl8RajcRwZ6U+zeOc+OfWbH
-WUFuLadlrEx5212CQ2k+OZlDAoGAdsH2w6kZ83xCFOOv41ioqx5HLQGlYLpxfVg+
-2gkeWa523HglIcdPEghYIBNRDQAuG3RRYSeW+kEy+f4Jc2tHu8bS9FWkRcsWoIji
-ZzBJ0G5JHPtaub6sEC6/ZWe0F1nJYP2KLop57FxKRt0G2+fxeA0ahpMwa2oMMiQM
-4GM3pHUCgYEAj2ZjjsF2MXYA6kuPUG1vyY9pvj1n4fyEEoV/zxY1k56UKboVOtYr
-BA/cKaLPqUF+08Tz/9MPBw51UH4GYfppA/x0ktc8998984FeIpfIFX6I2U9yUnoQ
-OCCAgsB8g8yTB4qntAYyfofEoDiseKrngQT5DSdxd51A/jw7B8WyBK8=
------END RSA PRIVATE KEY-----`
 
 // this key will be used to sign the token but verification should
 // fail as this is not the key used by server security layer

--- a/workitemtype_blackbox_test.go
+++ b/workitemtype_blackbox_test.go
@@ -244,7 +244,7 @@ func TestSuiteWorkItemType(t *testing.T) {
 }
 
 func getWorkItemTypeTestData(t *testing.T) []testSecureAPI {
-	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM(([]byte(RSAPrivateKeyTest)))
+	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((configuration.GetTokenPrivateKey()))
 	if err != nil {
 		t.Fatal("Could not parse Key ", err)
 	}
@@ -301,7 +301,7 @@ func TestUnauthorizeWorkItemTypeCreate(t *testing.T) {
 	resource.Require(t, resource.Database)
 
 	// This will be modified after merge PR for "Viper Environment configurations"
-	publickey, err := jwt.ParseRSAPublicKeyFromPEM(([]byte(RSAPublicKeyTest)))
+	publickey, err := jwt.ParseRSAPublicKeyFromPEM((configuration.GetTokenPublicKey()))
 	if err != nil {
 		t.Fatal("Could not parse Key ", err)
 	}

--- a/workitemtype_blackbox_test.go
+++ b/workitemtype_blackbox_test.go
@@ -1,8 +1,11 @@
 package main_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	. "github.com/almighty/almighty-core"
@@ -13,7 +16,10 @@ import (
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/almighty/almighty-core/transaction"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
+	"github.com/goadesign/goa/middleware"
+	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -235,4 +241,128 @@ func (s *WorkItemTypeSuite) TestListWorkItemType() {
 func TestSuiteWorkItemType(t *testing.T) {
 	resource.Require(t, resource.Database)
 	suite.Run(t, new(WorkItemTypeSuite))
+}
+
+func getWorkItemTypeTestData(t *testing.T) []testSecureAPI {
+	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM(([]byte(RSAPrivateKeyTest)))
+	if err != nil {
+		t.Fatal("Could not parse Key ", err)
+	}
+	differentPrivatekey, err := jwt.ParseRSAPrivateKeyFromPEM(([]byte(RSADifferentPrivateKeyTest)))
+
+	createWITPayloadString := bytes.NewBuffer([]byte(`{"fields": {"system.administrator": {"Required": true,"Type": {"Kind": "string"}}},"name": "Epic"}`))
+
+	return []testSecureAPI{
+		// Create Work Item API with different parameters
+		{
+			method:             "POST",
+			url:                "/api/workitemtypes",
+			expectedStatusCode: 401,
+			expectedErrorCode:  "jwt_security_error",
+			payload:            createWITPayloadString,
+			jwtToken:           getExpiredAuthHeader(t, privatekey),
+		}, {
+			method:             "POST",
+			url:                "/api/workitemtypes",
+			expectedStatusCode: 401,
+			expectedErrorCode:  "jwt_security_error",
+			payload:            createWITPayloadString,
+			jwtToken:           getMalformedAuthHeader(t, privatekey),
+		}, {
+			method:             "POST",
+			url:                "/api/workitemtypes",
+			expectedStatusCode: 401,
+			expectedErrorCode:  "jwt_security_error",
+			payload:            createWITPayloadString,
+			jwtToken:           getValidAuthHeader(t, differentPrivatekey),
+		}, {
+			method:             "POST",
+			url:                "/api/workitemtypes",
+			expectedStatusCode: 401,
+			expectedErrorCode:  "jwt_security_error",
+			payload:            createWITPayloadString,
+			jwtToken:           "",
+		},
+		// Try fetching a random work Item Type
+		// We do not have security on GET hence this should return 404 not found
+		{
+			method:             "GET",
+			url:                "/api/workitems/someRandomTestWIT8712",
+			expectedStatusCode: 404,
+			expectedErrorCode:  "not_found",
+			payload:            nil,
+			jwtToken:           "",
+		},
+	}
+}
+
+// This test case will check authorized access to Create/Update/Delete APIs
+func TestUnauthorizeWorkItemTypeCreate(t *testing.T) {
+	resource.Require(t, resource.Database)
+
+	// This will be modified after merge PR for "Viper Environment configurations"
+	publickey, err := jwt.ParseRSAPublicKeyFromPEM(([]byte(RSAPublicKeyTest)))
+	if err != nil {
+		t.Fatal("Could not parse Key ", err)
+	}
+	tokenTests := getWorkItemTypeTestData(t)
+
+	for _, testObject := range tokenTests {
+		// Build a request
+		var req *http.Request
+		var err error
+		if testObject.payload == nil {
+			req, err = http.NewRequest(testObject.method, testObject.url, nil)
+		} else {
+			req, err = http.NewRequest(testObject.method, testObject.url, testObject.payload)
+		}
+		// req, err := http.NewRequest(testObject.method, testObject.url, testObject.payload)
+		if err != nil {
+			t.Fatal("could not create a HTTP request")
+		}
+		// Add Authorization Header
+		req.Header.Add("Authorization", testObject.jwtToken)
+
+		rr := httptest.NewRecorder()
+		ts := models.NewGormTransactionSupport(DB)
+		wir := models.NewWorkItemTypeRepository(ts)
+
+		// temperory service for testing the middleware
+		service := goa.New("TestUnauthorizedCreateWI-Service")
+		assert.NotNil(t, service)
+
+		// if error is thrown during request processing, it will be caught by ErrorHandler middleware
+		// this will put error code, status, details in recorder object.
+		// e.g> {"id":"AL6spYb2","code":"jwt_security_error","status":401,"detail":"JWT validation failed: crypto/rsa: verification error"}
+		service.Use(middleware.ErrorHandler(service, true))
+
+		// append a middleware to service. Use appropriate RSA keys
+		jwtMiddleware := goajwt.New(publickey, nil, app.NewJWTSecurity())
+		// Adding middleware via "app" is important
+		// Because it will check the design and accordingly apply the middleware if mentioned in design
+		// But if I use `service.Use(jwtMiddleware)` then middleware is applied for all the requests (without checking design)
+		app.UseJWTMiddleware(service, jwtMiddleware)
+
+		controller := NewWorkitemtypeController(service, wir, ts)
+		app.MountWorkitemtypeController(service, controller)
+
+		// Hit the service with own request
+		service.Mux.ServeHTTP(rr, req)
+
+		assert.Equal(t, testObject.expectedStatusCode, rr.Code)
+
+		// Below code tries to open Body response which is expected to be a JSON
+		// If could not parse it correctly into errorResponseStruct
+		// Then it gets logged and continue the test loop
+		content := new(errorResponseStruct)
+		err = json.Unmarshal(rr.Body.Bytes(), content)
+		if err != nil {
+			t.Log("Could not parse JSON response: ", rr.Body)
+			// safe to continue because we alread checked rr.Code=required_value
+			continue
+		}
+		// Additional checks for 'more' confirmation
+		assert.Equal(t, testObject.expectedErrorCode, content.Code)
+		assert.Equal(t, testObject.expectedStatusCode, content.Status)
+	}
 }


### PR DESCRIPTION
Securing WI and WIT APIs.

fixes #243 

**Why:**
We need to prevent creation/deletion/updation of work items by unknown/guest users.
User must login and then only should be able to take above actions.

**What:**
Security("jwt") added for WI create and WIT create/delete/update APIs. Added test cases for the same.

**How:**
Table Drive tests added for Create WIT and create/delete/update WIT api.
It Generates multiple invalid tokens and test negative scenarios.
Added JWT middleware by using app.UseJWTMiddleware so that middleware will be applicable as per design.
Tested with non-secured GET api also.