### PR TITLE
close broken DB object

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -76,7 +76,7 @@ imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jinzhu/gorm
-  version: 5174cc5c242a728b435ea2be8a2f7f998e15429b
+  version: c1b9cf186e4bcd8e5d566ef43f2ae2dfe22dc34e
 - name: github.com/jinzhu/inflection
   version: 8f4d3a0d04ce0b7c0cf3126fb98524246d00d102
 - name: github.com/jteeuwen/go-bindata

--- a/glide.yaml
+++ b/glide.yaml
@@ -45,7 +45,7 @@ import:
 - package: github.com/mattn/go-colorable
 - package: github.com/pilu/config
 - package: github.com/jinzhu/gorm
-  version: ^1.0.0
+  version: c1b9cf186e4bcd8e5d566ef43f2ae2dfe22dc34e
 - package: github.com/mattn/go-isatty
   version: ^0.0.1
 - package: github.com/axw/gocov

--- a/main.go
+++ b/main.go
@@ -85,6 +85,7 @@ func main() {
 		log.Printf("Opening DB connection attempt %d of %d\n", i, configuration.GetPostgresConnectionMaxRetries())
 		db, err = gorm.Open("postgres", configuration.GetPostgresConfigString())
 		if err != nil {
+			db.Close()
 			time.Sleep(configuration.GetPostgresConnectionRetrySleep())
 		} else {
 			defer db.Close()


### PR DESCRIPTION
As per this document: http://go-database-sql.org/accessing.html
"the sql.DB object is designed to be long-lived"
The gorm.DB wraps sql.DB, so the above statement is still valid.
Since the ALM code is attempting to create new DB object, it's better
to close every time it fails to establish connection.