### PR TITLE
Fix transient errors during db access

### DIFF
--- a/main.go
+++ b/main.go
@@ -177,12 +177,12 @@ func main() {
 	ts2 := models.NewGormTransactionSupport(db)
 
 	// Mount "tracker" controller
-	repo2 := remoteworkitem.NewTrackerRepository(ts2)
+	repo2 := remoteworkitem.NewTrackerRepository()
 	c5 := NewTrackerController(service, repo2, ts2, scheduler)
 	app.MountTrackerController(service, c5)
 
 	// Mount "trackerquery" controller
-	repo3 := remoteworkitem.NewTrackerQueryRepository(ts2)
+	repo3 := remoteworkitem.NewTrackerQueryRepository()
 	c6 := NewTrackerqueryController(service, repo3, ts2, scheduler)
 	app.MountTrackerqueryController(service, c6)
 

--- a/main.go
+++ b/main.go
@@ -113,7 +113,7 @@ func main() {
 	// Make sure the database is populated with the correct types (e.g. system.bug etc.)
 	if configuration.GetPopulateCommonTypes() {
 		if err := transaction.Do(ts, context.Background(), func(ctx context.Context) error {
-			return migration.PopulateCommonTypes(context.Background(), models.CurrentTX(ctx), witRepo)
+			return migration.PopulateCommonTypes(ctx, models.CurrentTX(ctx), witRepo)
 		}); err != nil {
 			panic(err.Error())
 		}

--- a/main.go
+++ b/main.go
@@ -112,8 +112,8 @@ func main() {
 
 	// Make sure the database is populated with the correct types (e.g. system.bug etc.)
 	if configuration.GetPopulateCommonTypes() {
-		if err := transaction.Do(ts, func() error {
-			return migration.PopulateCommonTypes(context.Background(), ts.TX(), witRepo)
+		if err := transaction.Do(ts, context.Background(), func(ctx context.Context) error {
+			return migration.PopulateCommonTypes(context.Background(), models.CurrentTX(ctx), witRepo)
 		}); err != nil {
 			panic(err.Error())
 		}

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"strconv"
 
+	"golang.org/x/net/context"
+
+	"github.com/almighty/almighty-core/transaction"
 	"github.com/jinzhu/gorm"
 )
 
@@ -77,18 +80,22 @@ func (g *GormTransactionSupport) Begin() error {
 		return db.Error
 	}
 	return nil
+
 }
 
 // Commit implements TransactionSupport
-func (g *GormTransactionSupport) Commit() error {
-	err := g.tx.Commit().Error
-	g.tx = nil
+func (g *GormTransactionSupport) Commit(tx transaction.Transaction) error {
+	err := tx.(*gorm.DB).Commit().Error
 	return err
 }
 
 // Rollback implements TransactionSupport
-func (g *GormTransactionSupport) Rollback() error {
-	err := g.tx.Rollback().Error
-	g.tx = nil
+func (g *GormTransactionSupport) Rollback(tx transaction.Transaction) error {
+	err := tx.(*gorm.DB).Rollback().Error
 	return err
+}
+
+// CurrentTX returns the current gorm transaction or nil
+func CurrentTX(ctx context.Context) *gorm.DB {
+	return transaction.Current(ctx).(*gorm.DB)
 }

--- a/models/workitem_repository.go
+++ b/models/workitem_repository.go
@@ -32,7 +32,7 @@ func (r *GormWorkItemRepository) Load(ctx context.Context, ID string) (*app.Work
 
 	log.Printf("loading work item %d", id)
 	res := WorkItem{}
-	if r.ts.tx.First(&res, id).RecordNotFound() {
+	if CurrentTX(ctx).First(&res, id).RecordNotFound() {
 		log.Printf("not found, res=%v", res)
 		return nil, NotFoundError{"work item", ID}
 	}
@@ -57,7 +57,7 @@ func (r *GormWorkItemRepository) Delete(ctx context.Context, ID string) error {
 		return NotFoundError{entity: "work item", ID: ID}
 	}
 	workItem.ID = id
-	tx := r.ts.tx
+	tx := CurrentTX(ctx)
 
 	if err = tx.Delete(workItem).Error; err != nil {
 		if tx.RecordNotFound() {
@@ -79,7 +79,7 @@ func (r *GormWorkItemRepository) Save(ctx context.Context, wi app.WorkItem) (*ap
 	}
 
 	log.Printf("looking for id %d", id)
-	tx := r.ts.tx
+	tx := CurrentTX(ctx)
 	if tx.First(&res, id).RecordNotFound() {
 		log.Printf("not found, res=%v", res)
 		return nil, NotFoundError{entity: "work item", ID: wi.ID}
@@ -140,7 +140,7 @@ func (r *GormWorkItemRepository) Create(ctx context.Context, typeID string, fiel
 			return nil, BadParameterError{fieldName, fieldValue}
 		}
 	}
-	tx := r.ts.tx
+	tx := CurrentTX(ctx)
 
 	if err = tx.Create(&wi).Error; err != nil {
 		return nil, InternalError{simpleError{err.Error()}}
@@ -164,7 +164,7 @@ func (r *GormWorkItemRepository) List(ctx context.Context, criteria criteria.Exp
 	log.Printf("executing query: '%s' with params %v", where, parameters)
 
 	var rows []WorkItem
-	db := r.ts.TX().Where(where, parameters)
+	db := CurrentTX(ctx).Where(where, parameters)
 	if start != nil {
 		db = db.Offset(*start)
 	}

--- a/models/workitemtype_repository.go
+++ b/models/workitemtype_repository.go
@@ -36,11 +36,11 @@ func (r *GormWorkItemTypeRepository) loadTypeFromDB(ctx context.Context, name st
 	log.Printf("loading work item type %s", name)
 	res := WorkItemType{}
 
-	if r.ts.tx.Where("name=?", name).First(&res).RecordNotFound() {
+	if CurrentTX(ctx).Where("name=?", name).First(&res).RecordNotFound() {
 		log.Printf("not found, res=%v", res)
 		return nil, NotFoundError{"work item type", name}
 	}
-	if err := r.ts.tx.Error; err != nil {
+	if err := CurrentTX(ctx).Error; err != nil {
 		return nil, InternalError{simpleError{err.Error()}}
 	}
 
@@ -54,11 +54,11 @@ func (r *GormWorkItemTypeRepository) Create(ctx context.Context, extendedTypeNam
 	path := "/"
 	if extendedTypeName != nil {
 		extendedType := WorkItemType{}
-		if r.ts.tx.First(&extendedType, extendedTypeName).RecordNotFound() {
+		if CurrentTX(ctx).First(&extendedType, extendedTypeName).RecordNotFound() {
 			log.Printf("not found, res=%v", extendedType)
 			return nil, BadParameterError{parameter: "extendedTypeName", value: *extendedTypeName}
 		}
-		if err := r.ts.tx.Error; err != nil {
+		if err := CurrentTX(ctx).Error; err != nil {
 			return nil, InternalError{simpleError{err.Error()}}
 		}
 		// copy fields from extended type
@@ -92,7 +92,7 @@ func (r *GormWorkItemTypeRepository) Create(ctx context.Context, extendedTypeNam
 		Fields:     allFields,
 	}
 
-	if err := r.ts.tx.Create(&created).Error; err != nil {
+	if err := CurrentTX(ctx).Create(&created).Error; err != nil {
 		return nil, InternalError{simpleError{err.Error()}}
 	}
 
@@ -108,7 +108,7 @@ func (r *GormWorkItemTypeRepository) List(ctx context.Context, start *int, limit
 	var parameters []interface{}
 
 	var rows []WorkItemType
-	db := r.ts.tx.Where(where, parameters)
+	db := CurrentTX(ctx).Where(where, parameters)
 	if start != nil {
 		db = db.Offset(*start)
 	}

--- a/remoteworkitem/tracker_repository_test.go
+++ b/remoteworkitem/tracker_repository_test.go
@@ -1,6 +1,7 @@
 package remoteworkitem
 
 import (
+	"errors"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -9,52 +10,53 @@ import (
 	"github.com/almighty/almighty-core/criteria"
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/resource"
+	"github.com/almighty/almighty-core/transaction"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestTrackerCreate(t *testing.T) {
-	doWithTrackerRepository(t, func(trackerRepo TrackerRepository) {
-		tracker, err := trackerRepo.Create(context.Background(), "gugus", "dada")
+	doWithTrackerRepository(t, func(ctx context.Context, trackerRepo TrackerRepository) {
+		tracker, err := trackerRepo.Create(ctx, "gugus", "dada")
 		assert.IsType(t, BadParameterError{}, err)
 		assert.Nil(t, tracker)
 
-		tracker, err = trackerRepo.Create(context.Background(), "gugus", ProviderGithub)
+		tracker, err = trackerRepo.Create(ctx, "gugus", ProviderGithub)
 		assert.Nil(t, err)
 		assert.NotNil(t, tracker)
 		assert.Equal(t, "gugus", tracker.URL)
 		assert.Equal(t, ProviderGithub, tracker.Type)
 
-		tracker2, err := trackerRepo.Load(context.Background(), tracker.ID)
+		tracker2, err := trackerRepo.Load(ctx, tracker.ID)
 		assert.Nil(t, err)
 		assert.NotNil(t, tracker2)
 	})
 }
 
 func TestTrackerSave(t *testing.T) {
-	doWithTrackerRepository(t, func(trackerRepo TrackerRepository) {
-		tracker, err := trackerRepo.Save(context.Background(), app.Tracker{})
+	doWithTrackerRepository(t, func(ctx context.Context, trackerRepo TrackerRepository) {
+		tracker, err := trackerRepo.Save(ctx, app.Tracker{})
 		assert.IsType(t, NotFoundError{}, err)
 		assert.Nil(t, tracker)
 
-		tracker, _ = trackerRepo.Create(context.Background(), "gugus", ProviderGithub)
+		tracker, _ = trackerRepo.Create(ctx, "gugus", ProviderGithub)
 		tracker.Type = "blabla"
-		tracker2, err := trackerRepo.Save(context.Background(), *tracker)
+		tracker2, err := trackerRepo.Save(ctx, *tracker)
 		assert.IsType(t, BadParameterError{}, err)
 		assert.Nil(t, tracker2)
 
 		tracker.Type = ProviderJira
 		tracker.URL = "blabla"
-		tracker, err = trackerRepo.Save(context.Background(), *tracker)
+		tracker, err = trackerRepo.Save(ctx, *tracker)
 		assert.Equal(t, ProviderJira, tracker.Type)
 		assert.Equal(t, "blabla", tracker.URL)
 
 		tracker.ID = "10000"
-		tracker2, err = trackerRepo.Save(context.Background(), *tracker)
+		tracker2, err = trackerRepo.Save(ctx, *tracker)
 		assert.IsType(t, NotFoundError{}, err)
 		assert.Nil(t, tracker2)
 
 		tracker.ID = "asdf"
-		tracker2, err = trackerRepo.Save(context.Background(), *tracker)
+		tracker2, err = trackerRepo.Save(ctx, *tracker)
 		assert.IsType(t, NotFoundError{}, err)
 		assert.Nil(t, tracker2)
 
@@ -62,64 +64,64 @@ func TestTrackerSave(t *testing.T) {
 }
 
 func TestTrackerDelete(t *testing.T) {
-	doWithTrackerRepository(t, func(trackerRepo TrackerRepository) {
-		err := trackerRepo.Delete(context.Background(), "asdf")
+	doWithTrackerRepository(t, func(ctx context.Context, trackerRepo TrackerRepository) {
+		err := trackerRepo.Delete(ctx, "asdf")
 		assert.IsType(t, NotFoundError{}, err)
 
 		// guard against other test leaving stuff behind
-		err = trackerRepo.Delete(context.Background(), "10000")
+		err = trackerRepo.Delete(ctx, "10000")
 
-		err = trackerRepo.Delete(context.Background(), "10000")
+		err = trackerRepo.Delete(ctx, "10000")
 		assert.IsType(t, NotFoundError{}, err)
 
-		tracker, _ := trackerRepo.Create(context.Background(), "gugus", ProviderGithub)
-		err = trackerRepo.Delete(context.Background(), tracker.ID)
+		tracker, _ := trackerRepo.Create(ctx, "gugus", ProviderGithub)
+		err = trackerRepo.Delete(ctx, tracker.ID)
 		assert.Nil(t, err)
 
-		tracker, err = trackerRepo.Load(context.Background(), tracker.ID)
+		tracker, err = trackerRepo.Load(ctx, tracker.ID)
 		assert.IsType(t, NotFoundError{}, err)
 		assert.Nil(t, tracker)
 
-		tracker, err = trackerRepo.Load(context.Background(), "xyz")
+		tracker, err = trackerRepo.Load(ctx, "xyz")
 		assert.IsType(t, NotFoundError{}, err)
 		assert.Nil(t, tracker)
 	})
 }
 
 func TestTrackerList(t *testing.T) {
-	doWithTrackerRepository(t, func(trackerRepo TrackerRepository) {
-		trackers, _ := trackerRepo.List(context.Background(), criteria.Literal(true), nil, nil)
+	doWithTrackerRepository(t, func(ctx context.Context, trackerRepo TrackerRepository) {
+		trackers, _ := trackerRepo.List(ctx, criteria.Literal(true), nil, nil)
 
-		trackerRepo.Create(context.Background(), "gugus", ProviderGithub)
-		trackerRepo.Create(context.Background(), "dada", ProviderJira)
-		trackerRepo.Create(context.Background(), "blabla", ProviderJira)
-		trackerRepo.Create(context.Background(), "xoxo", ProviderGithub)
+		trackerRepo.Create(ctx, "gugus", ProviderGithub)
+		trackerRepo.Create(ctx, "dada", ProviderJira)
+		trackerRepo.Create(ctx, "blabla", ProviderJira)
+		trackerRepo.Create(ctx, "xoxo", ProviderGithub)
 
-		trackers2, _ := trackerRepo.List(context.Background(), criteria.Literal(true), nil, nil)
+		trackers2, _ := trackerRepo.List(ctx, criteria.Literal(true), nil, nil)
 
 		assert.Equal(t, len(trackers)+4, len(trackers2))
 		start, len := 1, 1
 
-		trackers3, _ := trackerRepo.List(context.Background(), criteria.Literal(true), &start, &len)
+		trackers3, _ := trackerRepo.List(ctx, criteria.Literal(true), &start, &len)
 		assert.Equal(t, trackers2[1], trackers3[0])
 
 	})
 }
 
-func doWithTrackerRepository(t *testing.T, todo func(repo TrackerRepository)) {
-	doWithTransaction(t, func(ts *models.GormTransactionSupport) {
-		trackerRepo := NewTrackerRepository(ts)
-		todo(trackerRepo)
+func doWithTrackerRepository(t *testing.T, todo func(context.Context, TrackerRepository)) {
+	doWithTransaction(t, func(ctx context.Context) {
+		trackerRepo := NewTrackerRepository()
+		todo(ctx, trackerRepo)
 	})
 
 }
 
-func doWithTransaction(t *testing.T, todo func(ts *models.GormTransactionSupport)) {
+func doWithTransaction(t *testing.T, todo func(context.Context)) {
+
 	resource.Require(t, resource.Database)
 	ts := models.NewGormTransactionSupport(db)
-	if err := ts.Begin(); err != nil {
-		panic(err.Error())
-	}
-	defer ts.Rollback()
-	todo(ts)
+	transaction.Do(ts, context.Background(), func(ctx context.Context) error {
+		todo(ctx)
+		return errors.New("force rollback")
+	})
 }

--- a/remoteworkitem/trackeritem_repository.go
+++ b/remoteworkitem/trackeritem_repository.go
@@ -29,7 +29,7 @@ func upload(db *gorm.DB, tID int, item map[string]string) error {
 }
 
 // Map a remote work item into an ALM work item and persist it into the database.
-func convert(ts *models.GormTransactionSupport, tqID int, item map[string]string, provider string) (*app.WorkItem, error) {
+func convert(ts *models.GormTransactionSupport, ctx context.Context, tqID int, item map[string]string, provider string) (*app.WorkItem, error) {
 	witr := models.NewWorkItemTypeRepository(ts)
 	wir := models.NewWorkItemRepository(ts, witr)
 	ti := TrackerItem{Item: item["content"], RemoteItemID: item["id"], TrackerID: uint64(tqID)}
@@ -56,7 +56,7 @@ func convert(ts *models.GormTransactionSupport, tqID int, item map[string]string
 	var newWorkItem *app.WorkItem
 
 	// Querying the database
-	existingWorkItems, err := wir.List(context.Background(), sqlExpression, nil, nil)
+	existingWorkItems, err := wir.List(ctx, sqlExpression, nil, nil)
 
 	if len(existingWorkItems) != 0 {
 		fmt.Println("Workitem exists, will be updated")
@@ -64,14 +64,14 @@ func convert(ts *models.GormTransactionSupport, tqID int, item map[string]string
 		for key, value := range workItem.Fields {
 			existingWorkItem.Fields[key] = value
 		}
-		newWorkItem, err = wir.Save(context.Background(), *existingWorkItem)
+		newWorkItem, err = wir.Save(ctx, *existingWorkItem)
 		if err != nil {
 			fmt.Println("Error updating work item : ", err)
 		}
 	} else {
 		fmt.Println("Work item not found , will now create new work item")
 
-		newWorkItem, err = wir.Create(context.Background(), models.SystemBug, workItem.Fields)
+		newWorkItem, err = wir.Create(ctx, models.SystemBug, workItem.Fields)
 		if err != nil {
 			fmt.Println("Error creating work item : ", err)
 		}

--- a/remoteworkitem/trackeritem_repository_test.go
+++ b/remoteworkitem/trackeritem_repository_test.go
@@ -28,7 +28,7 @@ func TestConvertNewWorkItem(t *testing.T) {
 
 	ts := models.NewGormTransactionSupport(db)
 
-	transaction.Do(ts, func() error {
+	transaction.Do(ts, context.Background(), func(ctx context.Context) error {
 		t.Log("Scenario 1 : Scenario 1: Adding a work item which wasn't present.")
 
 		remoteItemData := map[string]string{
@@ -37,7 +37,7 @@ func TestConvertNewWorkItem(t *testing.T) {
 			"batch_id": "1",
 		}
 
-		workItem, err := convert(ts, int(tq.ID), remoteItemData, ProviderGithub)
+		workItem, err := convert(ts, ctx, int(tq.ID), remoteItemData, ProviderGithub)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "linking", workItem.Fields[models.SystemTitle])
@@ -47,7 +47,7 @@ func TestConvertNewWorkItem(t *testing.T) {
 
 		witr := models.NewWorkItemTypeRepository(ts)
 		wir := models.NewWorkItemRepository(ts, witr)
-		wir.Delete(context.Background(), workItem.ID)
+		wir.Delete(ctx, workItem.ID)
 
 		return err
 	})
@@ -69,7 +69,7 @@ func TestConvertExistingWorkItem(t *testing.T) {
 
 	ts := models.NewGormTransactionSupport(db)
 
-	transaction.Do(ts, func() error {
+	transaction.Do(ts, context.Background(), func(ctx context.Context) error {
 		t.Log("Adding a work item which wasn't present.")
 
 		remoteItemData := map[string]string{
@@ -78,7 +78,7 @@ func TestConvertExistingWorkItem(t *testing.T) {
 			"batch_id": "1",
 		}
 
-		workItem, err := convert(ts, int(tq.ID), remoteItemData, ProviderGithub)
+		workItem, err := convert(ts, ctx, int(tq.ID), remoteItemData, ProviderGithub)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "linking", workItem.Fields[models.SystemTitle])
@@ -90,13 +90,13 @@ func TestConvertExistingWorkItem(t *testing.T) {
 
 	t.Log("Updating the existing work item when it's reimported.")
 
-	transaction.Do(ts, func() error {
+	transaction.Do(ts, context.Background(), func(ctx context.Context) error {
 		remoteItemDataUpdated := map[string]string{
 			"content":  `{"title":"linking-updated","url":"http://github.com/api/testonly/1","state":"closed","body":"body of issue","user.login":"sbose78","assignee.login":"pranav"}`,
 			"id":       "http://github.com/sbose/api/testonly/1",
 			"batch_id": "2",
 		}
-		workItemUpdated, err := convert(ts, int(tq.ID), remoteItemDataUpdated, ProviderGithub)
+		workItemUpdated, err := convert(ts, ctx, int(tq.ID), remoteItemDataUpdated, ProviderGithub)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "linking-updated", workItemUpdated.Fields[models.SystemTitle])
@@ -106,7 +106,7 @@ func TestConvertExistingWorkItem(t *testing.T) {
 
 		witr := models.NewWorkItemTypeRepository(ts)
 		wir := models.NewWorkItemRepository(ts, witr)
-		wir.Delete(context.Background(), workItemUpdated.ID)
+		wir.Delete(ctx, workItemUpdated.ID)
 
 		return err
 	})
@@ -128,7 +128,7 @@ func TestConvertGithubIssue(t *testing.T) {
 	db.Create(&tq)
 	defer db.Delete(&tq)
 
-	transaction.Do(ts, func() error {
+	transaction.Do(ts, context.Background(), func(ctx context.Context) error {
 		content, err := test.LoadTestData("github_issue_mapping.json", provideRemoteGithubDataWithAssignee)
 		if err != nil {
 			t.Fatal(err)
@@ -140,7 +140,7 @@ func TestConvertGithubIssue(t *testing.T) {
 			"batch_id": "2",
 		}
 
-		workItemGithub, err := convert(ts, int(tq.ID), remoteItemDataGithub, ProviderGithub)
+		workItemGithub, err := convert(ts, ctx, int(tq.ID), remoteItemDataGithub, ProviderGithub)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "map flatten : test case : with assignee", workItemGithub.Fields[models.SystemTitle])

--- a/remoteworkitem/trackerquery_repository_test.go
+++ b/remoteworkitem/trackerquery_repository_test.go
@@ -5,39 +5,38 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/almighty/almighty-core/models"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestTrackerQueryCreate(t *testing.T) {
-	doWithTrackerRepositories(t, func(trackerRepo TrackerRepository, queryRepo TrackerQueryRepository) {
-		query, err := queryRepo.Create(context.Background(), "abc", "xyz", "lmn")
+	doWithTrackerRepositories(t, func(ctx context.Context, trackerRepo TrackerRepository, queryRepo TrackerQueryRepository) {
+		query, err := queryRepo.Create(ctx, "abc", "xyz", "lmn")
 		assert.IsType(t, NotFoundError{}, err)
 		assert.Nil(t, query)
 
-		tracker, err := trackerRepo.Create(context.Background(), "gugus", ProviderJira)
-		query, err = queryRepo.Create(context.Background(), "abc", "xyz", tracker.ID)
+		tracker, err := trackerRepo.Create(ctx, "gugus", ProviderJira)
+		query, err = queryRepo.Create(ctx, "abc", "xyz", tracker.ID)
 		assert.Nil(t, err)
 		assert.Equal(t, "abc", query.Query)
 		assert.Equal(t, "xyz", query.Schedule)
 
-		query2, err := queryRepo.Load(context.Background(), query.ID)
+		query2, err := queryRepo.Load(ctx, query.ID)
 		assert.Nil(t, err)
 		assert.Equal(t, query, query2)
 	})
 }
 
 func TestTrackerQuerySave(t *testing.T) {
-	doWithTrackerRepositories(t, func(trackerRepo TrackerRepository, queryRepo TrackerQueryRepository) {
+	doWithTrackerRepositories(t, func(ctx context.Context, trackerRepo TrackerRepository, queryRepo TrackerQueryRepository) {
 
-		query, err := queryRepo.Load(context.Background(), "abcd")
+		query, err := queryRepo.Load(ctx, "abcd")
 		assert.IsType(t, NotFoundError{}, err)
 		assert.Nil(t, query)
 
-		tracker, err := trackerRepo.Create(context.Background(), "gugus", ProviderJira)
-		tracker2, err := trackerRepo.Create(context.Background(), "theother", ProviderGithub)
-		query, err = queryRepo.Create(context.Background(), "abc", "xyz", tracker.ID)
-		query2, err := queryRepo.Load(context.Background(), query.ID)
+		tracker, err := trackerRepo.Create(ctx, "gugus", ProviderJira)
+		tracker2, err := trackerRepo.Create(ctx, "theother", ProviderGithub)
+		query, err = queryRepo.Create(ctx, "abc", "xyz", tracker.ID)
+		query2, err := queryRepo.Load(ctx, query.ID)
 		assert.Nil(t, err)
 		assert.Equal(t, query, query2)
 
@@ -48,34 +47,34 @@ func TestTrackerQuerySave(t *testing.T) {
 			t.Errorf("could not convert id: %s", tracker2.ID)
 		}
 
-		query2, err = queryRepo.Save(context.Background(), *query)
+		query2, err = queryRepo.Save(ctx, *query)
 		assert.Nil(t, err)
 		assert.Equal(t, query, query2)
 
-		trackerRepo.Delete(context.Background(), "10000")
+		trackerRepo.Delete(ctx, "10000")
 
 		query.TrackerID = "10000"
-		query2, err = queryRepo.Save(context.Background(), *query)
+		query2, err = queryRepo.Save(ctx, *query)
 		assert.IsType(t, NotFoundError{}, err)
 		assert.Nil(t, query2)
 	})
 }
 
 func TestTrackerQueryDelete(t *testing.T) {
-	doWithTrackerRepositories(t, func(trackerRepo TrackerRepository, queryRepo TrackerQueryRepository) {
-		_, err := queryRepo.Load(context.Background(), "asdf")
+	doWithTrackerRepositories(t, func(ctx context.Context, trackerRepo TrackerRepository, queryRepo TrackerQueryRepository) {
+		_, err := queryRepo.Load(ctx, "asdf")
 		assert.IsType(t, NotFoundError{}, err)
 
-		_, err = queryRepo.Load(context.Background(), "100000")
+		_, err = queryRepo.Load(ctx, "100000")
 		assert.IsType(t, NotFoundError{}, err)
 	})
 }
 
-func doWithTrackerRepositories(t *testing.T, todo func(trackerRepo TrackerRepository, queryRepo TrackerQueryRepository)) {
-	doWithTransaction(t, func(ts *models.GormTransactionSupport) {
-		trackerRepo := NewTrackerRepository(ts)
-		queryRepo := NewTrackerQueryRepository(ts)
-		todo(trackerRepo, queryRepo)
+func doWithTrackerRepositories(t *testing.T, todo func(context.Context, TrackerRepository, TrackerQueryRepository)) {
+	doWithTransaction(t, func(ctx context.Context) {
+		trackerRepo := NewTrackerRepository()
+		queryRepo := NewTrackerQueryRepository()
+		todo(ctx, trackerRepo, queryRepo)
 	})
 
 }

--- a/tracker.go
+++ b/tracker.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 
+	"golang.org/x/net/context"
+
 	"github.com/almighty/almighty-core/app"
 	query "github.com/almighty/almighty-core/query/simple"
 	"github.com/almighty/almighty-core/remoteworkitem"
@@ -26,8 +28,8 @@ func NewTrackerController(service *goa.Service, tRepository remoteworkitem.Track
 
 // Create runs the create action.
 func (c *TrackerController) Create(ctx *app.CreateTrackerContext) error {
-	result := transaction.Do(c.ts, func() error {
-		t, err := c.tRepository.Create(ctx.Context, ctx.Payload.URL, ctx.Payload.Type)
+	result := transaction.Do(c.ts, ctx.Context, func(context context.Context) error {
+		t, err := c.tRepository.Create(context, ctx.Payload.URL, ctx.Payload.Type)
 		if err != nil {
 			switch err := err.(type) {
 			case remoteworkitem.BadParameterError, remoteworkitem.ConversionError:
@@ -45,8 +47,8 @@ func (c *TrackerController) Create(ctx *app.CreateTrackerContext) error {
 
 // Delete runs the delete action.
 func (c *TrackerController) Delete(ctx *app.DeleteTrackerContext) error {
-	result := transaction.Do(c.ts, func() error {
-		err := c.tRepository.Delete(ctx.Context, ctx.ID)
+	result := transaction.Do(c.ts, ctx.Context, func(context context.Context) error {
+		err := c.tRepository.Delete(context, ctx.ID)
 		if err != nil {
 			switch err.(type) {
 			case remoteworkitem.NotFoundError:
@@ -63,8 +65,8 @@ func (c *TrackerController) Delete(ctx *app.DeleteTrackerContext) error {
 
 // Show runs the show action.
 func (c *TrackerController) Show(ctx *app.ShowTrackerContext) error {
-	return transaction.Do(c.ts, func() error {
-		t, err := c.tRepository.Load(ctx.Context, ctx.ID)
+	return transaction.Do(c.ts, ctx.Context, func(context context.Context) error {
+		t, err := c.tRepository.Load(context, ctx.ID)
 		if err != nil {
 			switch err.(type) {
 			case remoteworkitem.NotFoundError:
@@ -88,8 +90,8 @@ func (c *TrackerController) List(ctx *app.ListTrackerContext) error {
 	if err != nil {
 		return goa.ErrBadRequest(fmt.Sprintf("could not parse paging: %s", err.Error()))
 	}
-	return transaction.Do(c.ts, func() error {
-		result, err := c.tRepository.List(ctx.Context, exp, start, &limit)
+	return transaction.Do(c.ts, ctx.Context, func(context context.Context) error {
+		result, err := c.tRepository.List(context, exp, start, &limit)
 		if err != nil {
 			return goa.ErrInternal(fmt.Sprintf("Error listing trackers: %s", err.Error()))
 		}
@@ -100,14 +102,14 @@ func (c *TrackerController) List(ctx *app.ListTrackerContext) error {
 
 // Update runs the update action.
 func (c *TrackerController) Update(ctx *app.UpdateTrackerContext) error {
-	result := transaction.Do(c.ts, func() error {
+	result := transaction.Do(c.ts, ctx.Context, func(context context.Context) error {
 
 		toSave := app.Tracker{
 			ID:   ctx.ID,
 			URL:  ctx.Payload.URL,
 			Type: ctx.Payload.Type,
 		}
-		t, err := c.tRepository.Save(ctx.Context, toSave)
+		t, err := c.tRepository.Save(context, toSave)
 
 		if err != nil {
 			switch err := err.(type) {

--- a/tracker_test.go
+++ b/tracker_test.go
@@ -13,7 +13,7 @@ import (
 func TestCreateTracker(t *testing.T) {
 	resource.Require(t, resource.Database)
 	ts := models.NewGormTransactionSupport(DB)
-	repo := remoteworkitem.NewTrackerRepository(ts)
+	repo := remoteworkitem.NewTrackerRepository()
 	controller := TrackerController{ts: ts, tRepository: repo, scheduler: rwiScheduler}
 	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://issues.jboss.com",
@@ -29,7 +29,7 @@ func TestCreateTracker(t *testing.T) {
 func TestGetTracker(t *testing.T) {
 	resource.Require(t, resource.Database)
 	ts := models.NewGormTransactionSupport(DB)
-	repo := remoteworkitem.NewTrackerRepository(ts)
+	repo := remoteworkitem.NewTrackerRepository()
 	controller := TrackerController{ts: ts, tRepository: repo, scheduler: rwiScheduler}
 	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://issues.jboss.com",
@@ -69,7 +69,7 @@ func TestGetTracker(t *testing.T) {
 func TestTrackerListItemsNotNil(t *testing.T) {
 	resource.Require(t, resource.Database)
 	ts := models.NewGormTransactionSupport(DB)
-	repo := remoteworkitem.NewTrackerRepository(ts)
+	repo := remoteworkitem.NewTrackerRepository()
 	controller := TrackerController{ts: ts, tRepository: repo, scheduler: rwiScheduler}
 	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://issues.jboss.com",
@@ -95,7 +95,7 @@ func TestTrackerListItemsNotNil(t *testing.T) {
 func TestCreateTrackerValidId(t *testing.T) {
 	resource.Require(t, resource.Database)
 	ts := models.NewGormTransactionSupport(DB)
-	repo := remoteworkitem.NewTrackerRepository(ts)
+	repo := remoteworkitem.NewTrackerRepository()
 	controller := TrackerController{ts: ts, tRepository: repo, scheduler: rwiScheduler}
 	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://issues.jboss.com",

--- a/trackerquery.go
+++ b/trackerquery.go
@@ -3,6 +3,8 @@ package main
 import (
 	"log"
 
+	"golang.org/x/net/context"
+
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/remoteworkitem"
 	"github.com/almighty/almighty-core/transaction"
@@ -24,8 +26,8 @@ func NewTrackerqueryController(service *goa.Service, tqRepository remoteworkitem
 
 // Create runs the create action.
 func (c *TrackerqueryController) Create(ctx *app.CreateTrackerqueryContext) error {
-	result := transaction.Do(c.ts, func() error {
-		tq, err := c.tqRepository.Create(ctx.Context, ctx.Payload.Query, ctx.Payload.Schedule, ctx.Payload.TrackerID)
+	result := transaction.Do(c.ts, ctx.Context, func(context context.Context) error {
+		tq, err := c.tqRepository.Create(context, ctx.Payload.Query, ctx.Payload.Schedule, ctx.Payload.TrackerID)
 		if err != nil {
 			switch err := err.(type) {
 			case remoteworkitem.BadParameterError, remoteworkitem.ConversionError:
@@ -43,8 +45,8 @@ func (c *TrackerqueryController) Create(ctx *app.CreateTrackerqueryContext) erro
 
 // Show runs the show action.
 func (c *TrackerqueryController) Show(ctx *app.ShowTrackerqueryContext) error {
-	return transaction.Do(c.ts, func() error {
-		tq, err := c.tqRepository.Load(ctx.Context, ctx.ID)
+	return transaction.Do(c.ts, ctx.Context, func(context context.Context) error {
+		tq, err := c.tqRepository.Load(context, ctx.ID)
 		if err != nil {
 			switch err.(type) {
 			case remoteworkitem.NotFoundError:
@@ -60,7 +62,7 @@ func (c *TrackerqueryController) Show(ctx *app.ShowTrackerqueryContext) error {
 
 // Update runs the update action.
 func (c *TrackerqueryController) Update(ctx *app.UpdateTrackerqueryContext) error {
-	result := transaction.Do(c.ts, func() error {
+	result := transaction.Do(c.ts, ctx.Context, func(context context.Context) error {
 
 		toSave := app.TrackerQuery{
 			ID:        ctx.ID,
@@ -68,7 +70,7 @@ func (c *TrackerqueryController) Update(ctx *app.UpdateTrackerqueryContext) erro
 			Schedule:  ctx.Payload.Schedule,
 			TrackerID: ctx.Payload.TrackerID,
 		}
-		tq, err := c.tqRepository.Save(ctx.Context, toSave)
+		tq, err := c.tqRepository.Save(context, toSave)
 
 		if err != nil {
 			switch err := err.(type) {

--- a/trackerquery_test.go
+++ b/trackerquery_test.go
@@ -14,7 +14,7 @@ import (
 func TestCreateTrackerQuery(t *testing.T) {
 	resource.Require(t, resource.Database)
 	ts := models.NewGormTransactionSupport(DB)
-	repo := remoteworkitem.NewTrackerRepository(ts)
+	repo := remoteworkitem.NewTrackerRepository()
 	controller := TrackerController{ts: ts, tRepository: repo, scheduler: rwiScheduler}
 	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://api.github.com",
@@ -23,7 +23,7 @@ func TestCreateTrackerQuery(t *testing.T) {
 	_, result := test.CreateTrackerCreated(t, nil, nil, &controller, &payload)
 	t.Log(result.ID)
 	tqts := models.NewGormTransactionSupport(DB)
-	tqrepo := remoteworkitem.NewTrackerQueryRepository(tqts)
+	tqrepo := remoteworkitem.NewTrackerQueryRepository()
 	tqController := TrackerqueryController{ts: tqts, tqRepository: tqrepo, scheduler: rwiScheduler}
 	tqpayload := app.CreateTrackerQueryAlternatePayload{
 
@@ -42,7 +42,7 @@ func TestCreateTrackerQuery(t *testing.T) {
 func TestGetTrackerQuery(t *testing.T) {
 	resource.Require(t, resource.Database)
 	ts := models.NewGormTransactionSupport(DB)
-	repo := remoteworkitem.NewTrackerRepository(ts)
+	repo := remoteworkitem.NewTrackerRepository()
 	controller := TrackerController{ts: ts, tRepository: repo, scheduler: rwiScheduler}
 	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://api.github.com",
@@ -50,7 +50,7 @@ func TestGetTrackerQuery(t *testing.T) {
 	}
 	_, result := test.CreateTrackerCreated(t, nil, nil, &controller, &payload)
 
-	tqrepo := remoteworkitem.NewTrackerQueryRepository(ts)
+	tqrepo := remoteworkitem.NewTrackerQueryRepository()
 	tqController := TrackerqueryController{ts: ts, tqRepository: tqrepo, scheduler: rwiScheduler}
 	tqpayload := app.CreateTrackerQueryAlternatePayload{
 
@@ -74,7 +74,7 @@ func TestGetTrackerQuery(t *testing.T) {
 func TestUpdateTrackerQuery(t *testing.T) {
 	resource.Require(t, resource.Database)
 	ts := models.NewGormTransactionSupport(DB)
-	repo := remoteworkitem.NewTrackerRepository(ts)
+	repo := remoteworkitem.NewTrackerRepository()
 	controller := TrackerController{ts: ts, tRepository: repo, scheduler: rwiScheduler}
 	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://api.github.com",
@@ -82,7 +82,7 @@ func TestUpdateTrackerQuery(t *testing.T) {
 	}
 	_, result := test.CreateTrackerCreated(t, nil, nil, &controller, &payload)
 
-	tqrepo := remoteworkitem.NewTrackerQueryRepository(ts)
+	tqrepo := remoteworkitem.NewTrackerQueryRepository()
 	tqController := TrackerqueryController{ts: ts, tqRepository: tqrepo, scheduler: rwiScheduler}
 	tqpayload := app.CreateTrackerQueryAlternatePayload{
 

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -1,23 +1,38 @@
 package transaction
 
+import "golang.org/x/net/context"
+
+// Transaction is an opaque handle to the transaction. Cast as necessary
+type Transaction interface{}
+
+var transactionKey struct{}
+
 // Support abstracts from concrete transaction implementation
 type Support interface {
 	// Begin starts a transaction
-	Begin() error
+	Begin() (Transaction, error)
 	// Commit commits a transaction
-	Commit() error
+	Commit(Transaction) error
 	// Rollback rolls back the transaction
-	Rollback() error
+	Rollback(Transaction) error
 }
 
 // Do executes the given function in a transaction. If todo returns an error, the transaction is rolled back
-func Do(support Support, todo func() error) error {
-	if err := support.Begin(); err != nil {
+func Do(support Support, ctx context.Context, todo func(context.Context) error) error {
+	var tx Transaction
+	var err error
+	if tx, err = support.Begin(); err != nil {
 		return err
 	}
-	if err := todo(); err != nil {
-		support.Rollback()
+
+	if err := todo(context.WithValue(ctx, transactionKey, tx)); err != nil {
+		support.Rollback(tx)
 		return err
 	}
-	return support.Commit()
+	return support.Commit(tx)
+}
+
+// Current returns the current Transaction or nil if none is active
+func Current(ctx context.Context) Transaction {
+	return ctx.Value(transactionKey)
 }

--- a/workitem.go
+++ b/workitem.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	"github.com/goadesign/goa"
 
 	"github.com/almighty/almighty-core/app"
@@ -32,8 +34,8 @@ func NewWorkitemController(service *goa.Service, wiRepository models.WorkItemRep
 
 // Show runs the show action.
 func (c *WorkitemController) Show(ctx *app.ShowWorkitemContext) error {
-	return transaction.Do(c.ts, func() error {
-		wi, err := c.wiRepository.Load(ctx.Context, ctx.ID)
+	return transaction.Do(c.ts, ctx.Context, func(context context.Context) error {
+		wi, err := c.wiRepository.Load(context, ctx.ID)
 		if err != nil {
 			switch err.(type) {
 			case models.NotFoundError:
@@ -88,8 +90,8 @@ func (c *WorkitemController) List(ctx *app.ListWorkitemContext) error {
 	if err != nil {
 		return goa.ErrBadRequest(fmt.Sprintf("could not parse paging: %s", err.Error()))
 	}
-	return transaction.Do(c.ts, func() error {
-		result, err := c.wiRepository.List(ctx.Context, exp, start, &limit)
+	return transaction.Do(c.ts, ctx.Context, func(context context.Context) error {
+		result, err := c.wiRepository.List(context, exp, start, &limit)
 		if err != nil {
 			return goa.ErrInternal(fmt.Sprintf("Error listing work items: %s", err.Error()))
 		}
@@ -99,8 +101,8 @@ func (c *WorkitemController) List(ctx *app.ListWorkitemContext) error {
 
 // Create runs the create action.
 func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
-	return transaction.Do(c.ts, func() error {
-		wi, err := c.wiRepository.Create(ctx.Context, ctx.Payload.Type, ctx.Payload.Fields)
+	return transaction.Do(c.ts, ctx.Context, func(context context.Context) error {
+		wi, err := c.wiRepository.Create(context, ctx.Payload.Type, ctx.Payload.Fields)
 
 		if err != nil {
 			switch err := err.(type) {
@@ -117,8 +119,8 @@ func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
 
 // Delete runs the delete action.
 func (c *WorkitemController) Delete(ctx *app.DeleteWorkitemContext) error {
-	return transaction.Do(c.ts, func() error {
-		err := c.wiRepository.Delete(ctx.Context, ctx.ID)
+	return transaction.Do(c.ts, ctx.Context, func(context context.Context) error {
+		err := c.wiRepository.Delete(context, ctx.ID)
 		if err != nil {
 			switch err.(type) {
 			case models.NotFoundError:
@@ -133,7 +135,7 @@ func (c *WorkitemController) Delete(ctx *app.DeleteWorkitemContext) error {
 
 // Update runs the update action.
 func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
-	return transaction.Do(c.ts, func() error {
+	return transaction.Do(c.ts, ctx.Context, func(context context.Context) error {
 
 		toSave := app.WorkItem{
 			ID:      ctx.ID,
@@ -141,7 +143,7 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 			Version: ctx.Payload.Version,
 			Fields:  ctx.Payload.Fields,
 		}
-		wi, err := c.wiRepository.Save(ctx.Context, toSave)
+		wi, err := c.wiRepository.Save(context, toSave)
 
 		if err != nil {
 			switch err := err.(type) {

--- a/workitem_whitebox_test.go
+++ b/workitem_whitebox_test.go
@@ -41,8 +41,8 @@ func TestMain(m *testing.M) {
 			ts := models.NewGormTransactionSupport(DB)
 			witRepo := models.NewWorkItemTypeRepository(ts)
 
-			if err := transaction.Do(ts, func() error {
-				return migration.PopulateCommonTypes(context.Background(), ts.TX(), witRepo)
+			if err := transaction.Do(ts, context.Background(), func(ctx context.Context) error {
+				return migration.PopulateCommonTypes(ctx, models.CurrentTX(ctx), witRepo)
 			}); err != nil {
 				panic(err.Error())
 			}

--- a/workitemtype.go
+++ b/workitemtype.go
@@ -3,6 +3,8 @@ package main
 import (
 	"log"
 
+	"golang.org/x/net/context"
+
 	"fmt"
 
 	"github.com/almighty/almighty-core/app"
@@ -29,8 +31,8 @@ func NewWorkitemtypeController(service *goa.Service, witRepository models.WorkIt
 
 // Show runs the show action.
 func (c *WorkitemtypeController) Show(ctx *app.ShowWorkitemtypeContext) error {
-	return transaction.Do(c.ts, func() error {
-		res, err := c.witRepository.Load(ctx.Context, ctx.Name)
+	return transaction.Do(c.ts, ctx.Context, func(context context.Context) error {
+		res, err := c.witRepository.Load(context, ctx.Name)
 		if err != nil {
 			switch err.(type) {
 			case models.NotFoundError:
@@ -46,13 +48,13 @@ func (c *WorkitemtypeController) Show(ctx *app.ShowWorkitemtypeContext) error {
 
 // Create runs the create action.
 func (c *WorkitemtypeController) Create(ctx *app.CreateWorkitemtypeContext) error {
-	return transaction.Do(c.ts, func() error {
+	return transaction.Do(c.ts, ctx.Context, func(context context.Context) error {
 		var fields = map[string]app.FieldDefinition{}
 
 		for key, fd := range ctx.Payload.Fields {
 			fields[key] = *fd
 		}
-		wit, err := c.witRepository.Create(ctx.Context, ctx.Payload.ExtendedTypeName, ctx.Payload.Name, fields)
+		wit, err := c.witRepository.Create(context, ctx.Payload.ExtendedTypeName, ctx.Payload.Name, fields)
 
 		if err != nil {
 			switch err := err.(type) {
@@ -73,8 +75,8 @@ func (c *WorkitemtypeController) List(ctx *app.ListWorkitemtypeContext) error {
 	if err != nil {
 		return goa.ErrBadRequest(fmt.Sprintf("could not parse paging: %s", err.Error()))
 	}
-	return transaction.Do(c.ts, func() error {
-		result, err := c.witRepository.List(ctx.Context, start, &limit)
+	return transaction.Do(c.ts, ctx.Context, func(context context.Context) error {
+		result, err := c.witRepository.List(context, start, &limit)
 		if err != nil {
 			return goa.ErrInternal(fmt.Sprintf("Error listing work item types: %s", err.Error()))
 		}

--- a/workitemtype_blackbox_test.go
+++ b/workitemtype_blackbox_test.go
@@ -65,6 +65,7 @@ func (s *WorkItemTypeSuite) SetupSuite() {
 		}); err != nil {
 			panic(err.Error())
 		}
+
 	}
 }
 

--- a/workitemtype_blackbox_test.go
+++ b/workitemtype_blackbox_test.go
@@ -60,8 +60,8 @@ func (s *WorkItemTypeSuite) SetupSuite() {
 
 	// Make sure the database is populated with the correct types (e.g. system.bug etc.)
 	if configuration.GetPopulateCommonTypes() {
-		if err := transaction.Do(s.ts, func() error {
-			return migration.PopulateCommonTypes(context.Background(), s.ts.TX(), s.witRepo)
+		if err := transaction.Do(s.ts, context.Background(), func(ctx context.Context) error {
+			return migration.PopulateCommonTypes(ctx, models.CurrentTX(ctx), s.witRepo)
 		}); err != nil {
 			panic(err.Error())
 		}


### PR DESCRIPTION
My implementation of TransactionSupport was squireling away the current transaction in a struct field. This is, of course not thread safe and lead to non-reproducible errors in production.
This PR stores the current transaction in the context.Context object passed to repositories and fixes all usages.
