### PR TITLE
Use WIT cache in List instead of fetching same WITs many times

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 6578c071c341ad73b48c39a5c29d7f9848909000314659a75358d2c476171814
-updated: 2016-10-25T11:04:33.767635582+02:00
+hash: 4e5903b34fb4cdd4d167120c12a6bec94cc5a23a40d8455180af08924a5c851b
+updated: 2016-11-18T15:46:06.560794931-08:00
 imports:
 - name: bitbucket.org/pkg/inflect
   version: 8961c3750a47b8c0b3e118d52513b97adf85a7e8
@@ -22,8 +22,8 @@ imports:
 - name: github.com/dnaeon/go-vcr
   version: 9d71b8a6df86e00127f96bc8dabc09856ab8afdb
   subpackages:
-  - cassette
   - recorder
+  - cassette
 - name: github.com/elazarl/go-bindata-assetfs
   version: 57eb5e1fc594ad4b0b1dbea7b286d299e0cb43c2
   subpackages:
@@ -38,16 +38,23 @@ imports:
   - cors
   - design
   - design/apidsl
-  - dslengine
   - goagen
   - goagen/codegen
   - goagen/gen_app
   - goagen/utils
   - goatest
   - middleware
-  - middleware/gzip
   - middleware/security/jwt
+  - middleware/gzip
   - uuid
+  - dslengine
+- name: github.com/golang/groupcache
+  version: a6b377e3400b08991b80d6805d627f347f983866
+  subpackages:
+  - consistenthash
+  - groupcachepb
+  - lru
+  - singleflight
 - name: github.com/golang/protobuf
   version: 98fa357170587e470c5f27d3c3ea0947b71eb455
   subpackages:
@@ -65,10 +72,10 @@ imports:
   subpackages:
   - hcl/ast
   - hcl/parser
-  - hcl/scanner
-  - hcl/strconv
   - hcl/token
   - json/parser
+  - hcl/scanner
+  - hcl/strconv
   - json/scanner
   - json/token
 - name: github.com/howeyc/fsnotify
@@ -140,7 +147,6 @@ imports:
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
-  - require
   - suite
 - name: github.com/wadey/gocovmerge
   version: b5bfa59ec0adc420475f97f89b58045c721d761c
@@ -149,10 +155,10 @@ imports:
 - name: golang.org/x/crypto
   version: 9e590154d2353f3f5e1b24da7275686040dcf491
   subpackages:
+  - ssh
   - curve25519
   - ed25519
   - ed25519/internal/edwards25519
-  - ssh
 - name: golang.org/x/net
   version: f841c39de738b1d0df95b5a7187744f0e03d8112
   subpackages:
@@ -179,13 +185,13 @@ imports:
 - name: google.golang.org/appengine
   version: 5b8c3b819891014a2d12354528f7d046dd53c89e
   subpackages:
+  - urlfetch
   - internal
+  - internal/urlfetch
   - internal/base
   - internal/datastore
   - internal/log
   - internal/remote_api
-  - internal/urlfetch
-  - urlfetch
 - name: gopkg.in/asaskevich/govalidator.v4
   version: 7664702784775e51966f0885f5cd27435916517b
 - name: gopkg.in/yaml.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -86,3 +86,4 @@ import:
 - package: github.com/dnaeon/go-vcr
   subpackages:
   - recorder
+- package: github.com/golang/groupcache

--- a/models/cache.go
+++ b/models/cache.go
@@ -1,0 +1,51 @@
+package models
+
+import (
+	"encoding/json"
+
+	"github.com/golang/groupcache"
+)
+
+// GetterFunc is a function to load a value if it's not available in the cache
+type GetterFunc func(ctx groupcache.Context, key string) (interface{}, error)
+
+// NewCache constructs Cache
+func NewCache(name string, cacheBytes int64, fn GetterFunc) *Cache {
+	cch := groupcache.NewGroup(name, cacheBytes, groupcache.GetterFunc(
+		func(ctx groupcache.Context, key string, dest groupcache.Sink) error {
+			strct, err := fn(ctx, key)
+			if err != nil {
+				return err
+			}
+
+			bytes, err := json.Marshal(strct)
+			if err != nil {
+				return err
+			}
+
+			dest.SetBytes(bytes)
+
+			return nil
+		}))
+
+	return &Cache{cch}
+}
+
+// Cache represents a cache
+type Cache struct {
+	group *groupcache.Group
+}
+
+// Get loads a value from cache
+func (cache *Cache) Get(ctx groupcache.Context, key string, into interface{}) error {
+	var data []byte
+	if err := cache.group.Get(ctx, key, groupcache.AllocatingByteSliceSink(&data)); err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(data, &into); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/models/workitem_repository.go
+++ b/models/workitem_repository.go
@@ -248,7 +248,7 @@ func (r *GormWorkItemRepository) List(ctx context.Context, criteria criteria.Exp
 	res := make([]*app.WorkItem, len(result))
 
 	for index, value := range result {
-		wiType, err := r.wir.LoadTypeFromDB(ctx, value.Type)
+		wiType, err := r.wir.loadTypeFromCache(ctx, value.Type)
 		if err != nil {
 			return nil, 0, InternalError{simpleError{err.Error()}}
 		}

--- a/models/workitemtype_cache.go
+++ b/models/workitemtype_cache.go
@@ -1,0 +1,39 @@
+package models
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/golang/groupcache"
+	"golang.org/x/net/context"
+)
+
+const namePrefix = "wit"    // cache group name prefix
+const cacheBytes = 32 << 10 // 32 KB max per-node memory usage
+
+// WorkItemTypeCache implements a cache of WorkItemTypes
+type WorkItemTypeCache struct {
+	cache *Cache
+}
+
+// NewWorkItemTypeCache constructs WorkItemTypeCache
+func NewWorkItemTypeCache(r *GormWorkItemTypeRepository) *WorkItemTypeCache {
+	// One cache group per GormWorkItemTypeRepository instance
+	name := namePrefix + fmt.Sprintf("%p", r)
+	cch := NewCache(name, cacheBytes, GetterFunc(
+		func(ctx groupcache.Context, key string) (interface{}, error) {
+			log.Printf("Work item type %s not found in cache. Loading from DB", key)
+			var c context.Context
+			if ctx != nil {
+				c = ctx.(context.Context)
+			}
+			return r.LoadTypeFromDB(c, key)
+		}))
+
+	return &WorkItemTypeCache{cch}
+}
+
+// Get loads a WIT from the cache. If no WIT found in cache then loads it from DB
+func (cache *WorkItemTypeCache) Get(ctx context.Context, key string, into interface{}) error {
+	return cache.cache.Get(ctx, key, into)
+}

--- a/models/workitemtype_repository.go
+++ b/models/workitemtype_repository.go
@@ -13,17 +13,20 @@ import (
 
 // NewWorkItemRepository creates a wi repository based on gorm
 func NewWorkItemRepository(db *gorm.DB) *GormWorkItemRepository {
-	return &GormWorkItemRepository{db, &GormWorkItemTypeRepository{db}}
+	return &GormWorkItemRepository{db, NewWorkItemTypeRepository(db)}
 }
 
 // NewWorkItemTypeRepository creates a wi type repository based on gorm
 func NewWorkItemTypeRepository(db *gorm.DB) *GormWorkItemTypeRepository {
-	return &GormWorkItemTypeRepository{db}
+	r := &GormWorkItemTypeRepository{db, nil}
+	r.cache = NewWorkItemTypeCache(r)
+	return r
 }
 
 // GormWorkItemTypeRepository implements WorkItemTypeRepository using gorm
 type GormWorkItemTypeRepository struct {
-	db *gorm.DB
+	db    *gorm.DB
+	cache *WorkItemTypeCache
 }
 
 // Load returns the work item for the given id
@@ -40,7 +43,7 @@ func (r *GormWorkItemTypeRepository) Load(ctx context.Context, name string) (*ap
 
 // LoadTypeFromDB return work item type for the given id
 func (r *GormWorkItemTypeRepository) LoadTypeFromDB(ctx context.Context, name string) (*WorkItemType, error) {
-	log.Printf("loading work item type %s", name)
+	log.Printf("loading work item type %s from DB", name)
 	res := WorkItemType{}
 
 	db := r.db.Model(&res).Where("name=?", name).First(&res)
@@ -53,6 +56,15 @@ func (r *GormWorkItemTypeRepository) LoadTypeFromDB(ctx context.Context, name st
 	}
 
 	return &res, nil
+}
+
+func (r *GormWorkItemTypeRepository) loadTypeFromCache(ctx context.Context, name string) (*WorkItemType, error) {
+	log.Printf("loading work item type %s from cache", name)
+	res := WorkItemType{}
+
+	err := r.cache.Get(ctx, name, &res)
+
+	return &res, err
 }
 
 // Create creates a new work item in the repository


### PR DESCRIPTION
This solution uses https://github.com/golang/groupcache to cache WITs

Here are some metrics of List execution time on my laptop:
100 WIs; 3-5 WITs ~ 12ms the very first time and 4ms every next one when using this cache.
100 WIs; 3-5 WITs ~ 44ms every List execution when not using the cache.

If you think we can use groupcache then I will add some unit tests.

Fixes #242
