### PR TITLE
Moved inline strings of work item type fields to consts

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -222,42 +222,48 @@ func PopulateCommonTypes(ctx context.Context, db *gorm.DB, witr models.WorkItemT
 }
 
 func createOrUpdateSystemUserstory(ctx context.Context, witr models.WorkItemTypeRepository, db *gorm.DB) error {
-	return createOrUpdateCommon("system.userstory", ctx, witr, db)
+	return createOrUpdateCommon(models.SystemUserStory, ctx, witr, db)
 }
 
 func createOrUpdateSystemValueProposition(ctx context.Context, witr models.WorkItemTypeRepository, db *gorm.DB) error {
-	return createOrUpdateCommon("system.valueproposition", ctx, witr, db)
+	return createOrUpdateCommon(models.SystemValueProposition, ctx, witr, db)
 }
 
 func createOrUpdateSystemFundamental(ctx context.Context, witr models.WorkItemTypeRepository, db *gorm.DB) error {
-	return createOrUpdateCommon("system.fundamental", ctx, witr, db)
+	return createOrUpdateCommon(models.SystemFundamental, ctx, witr, db)
 }
 
 func createOrUpdateSystemExperience(ctx context.Context, witr models.WorkItemTypeRepository, db *gorm.DB) error {
-	return createOrUpdateCommon("system.experience", ctx, witr, db)
+	return createOrUpdateCommon(models.SystemExperience, ctx, witr, db)
 }
 
 func createOrUpdateSystemFeature(ctx context.Context, witr models.WorkItemTypeRepository, db *gorm.DB) error {
-	return createOrUpdateCommon("system.feature", ctx, witr, db)
+	return createOrUpdateCommon(models.SystemFeature, ctx, witr, db)
 }
 
 func createOrUpdateSystemBug(ctx context.Context, witr models.WorkItemTypeRepository, db *gorm.DB) error {
-	return createOrUpdateCommon("system.bug", ctx, witr, db)
+	return createOrUpdateCommon(models.SystemBug, ctx, witr, db)
 }
 
 func createOrUpdateCommon(typeName string, ctx context.Context, witr models.WorkItemTypeRepository, db *gorm.DB) error {
 	stString := "string"
 	workItemTypeFields := map[string]app.FieldDefinition{
-		"system.title":          app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: true},
-		"system.description":    app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: false},
-		"system.creator":        app.FieldDefinition{Type: &app.FieldType{Kind: "user"}, Required: true},
-		"system.assignee":       app.FieldDefinition{Type: &app.FieldType{Kind: "user"}, Required: false},
-		"system.remote_item_id": app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: false},
-		"system.state": app.FieldDefinition{
+		models.SystemTitle:        app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: true},
+		models.SystemDescription:  app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: false},
+		models.SystemCreator:      app.FieldDefinition{Type: &app.FieldType{Kind: "user"}, Required: true},
+		models.SystemAssignee:     app.FieldDefinition{Type: &app.FieldType{Kind: "user"}, Required: false},
+		models.SystemRemoteItemID: app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: false},
+		models.SystemState: app.FieldDefinition{
 			Type: &app.FieldType{
 				BaseType: &stString,
 				Kind:     "enum",
-				Values:   []interface{}{"new", "open", "in progress", "resolved", "closed"},
+				Values: []interface{}{
+					models.SystemStateNew,
+					models.SystemStateOpen,
+					models.SystemStateInProgress,
+					models.SystemStateResolved,
+					models.SystemStateClosed,
+				},
 			},
 			Required: true,
 		},

--- a/models/workitemtype.go
+++ b/models/workitemtype.go
@@ -1,5 +1,28 @@
 package models
 
+// String constants for the local work item types.
+const (
+	SystemRemoteItemID = "system.remote_item_id"
+	SystemTitle        = "system.title"
+	SystemDescription  = "system.description"
+	SystemState        = "system.state"
+	SystemAssignee     = "system.assignee"
+	SystemCreator      = "system.creator"
+
+	SystemUserStory        = "system.userstory"
+	SystemValueProposition = "system.valueproposition"
+	SystemFundamental      = "system.fundamental"
+	SystemExperience       = "system.experience"
+	SystemFeature          = "system.feature"
+	SystemBug              = "system.bug"
+
+	SystemStateOpen       = "open"
+	SystemStateNew        = "new"
+	SystemStateInProgress = "in progress"
+	SystemStateResolved   = "resolved"
+	SystemStateClosed     = "closed"
+)
+
 // WorkItemType represents a work item type as it is stored in the db
 type WorkItemType struct {
 	Lifecycle

--- a/models/workitemtype_repository_whitebox_test.go
+++ b/models/workitemtype_repository_whitebox_test.go
@@ -141,16 +141,22 @@ func TestTempConvertFieldsToModels(t *testing.T) {
 	stString := "string"
 
 	newFields := map[string]app.FieldDefinition{
-		"system.title":          app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: true},
-		"system.description":    app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: false},
-		"system.creator":        app.FieldDefinition{Type: &app.FieldType{Kind: "user"}, Required: true},
-		"system.assignee":       app.FieldDefinition{Type: &app.FieldType{Kind: "user"}, Required: false},
-		"system.remote_item_id": app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: false},
-		"system.state": app.FieldDefinition{
+		SystemTitle:        app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: true},
+		SystemDescription:  app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: false},
+		SystemCreator:      app.FieldDefinition{Type: &app.FieldType{Kind: "user"}, Required: true},
+		SystemAssignee:     app.FieldDefinition{Type: &app.FieldType{Kind: "user"}, Required: false},
+		SystemRemoteItemID: app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: false},
+		SystemState: app.FieldDefinition{
 			Type: &app.FieldType{
 				BaseType: &stString,
 				Kind:     "enum",
-				Values:   []interface{}{"new", "open", "in progress", "resolved", "closed"},
+				Values: []interface{}{
+					SystemStateNew,
+					SystemStateOpen,
+					SystemStateInProgress,
+					SystemStateResolved,
+					SystemStateClosed,
+				},
 			},
 			Required: true,
 		},

--- a/remoteworkitem/remoteworkitem.go
+++ b/remoteworkitem/remoteworkitem.go
@@ -4,17 +4,11 @@ import (
 	"encoding/json"
 
 	"github.com/almighty/almighty-core/app"
+	"github.com/almighty/almighty-core/models"
 )
 
 // List of supported attributes
 const (
-	SystemRemoteItemID = "system.remote_item_id"
-	SystemTitle        = "system.title"
-	SystemDescription  = "system.description"
-	SystemState        = "system.state"
-	SystemAssignee     = "system.assignee"
-	SystemCreator      = "system.creator"
-
 	// The keys in the flattened response JSON of a typical Github issue.
 
 	GithubTitle       = "title"
@@ -40,20 +34,20 @@ const (
 // WorkItemKeyMaps relate remote attribute keys to internal representation
 var WorkItemKeyMaps = map[string]WorkItemMap{
 	ProviderGithub: WorkItemMap{
-		AttributeExpression(GithubTitle):       SystemTitle,
-		AttributeExpression(GithubDescription): SystemDescription,
-		AttributeExpression(GithubState):       SystemState,
-		AttributeExpression(GithubID):          SystemRemoteItemID,
-		AttributeExpression(GithubCreator):     SystemCreator,
-		AttributeExpression(GithubAssignee):    SystemAssignee,
+		AttributeExpression(GithubTitle):       models.SystemTitle,
+		AttributeExpression(GithubDescription): models.SystemDescription,
+		AttributeExpression(GithubState):       models.SystemState,
+		AttributeExpression(GithubID):          models.SystemRemoteItemID,
+		AttributeExpression(GithubCreator):     models.SystemCreator,
+		AttributeExpression(GithubAssignee):    models.SystemAssignee,
 	},
 	ProviderJira: WorkItemMap{
-		AttributeExpression(JiraTitle):    SystemTitle,
-		AttributeExpression(JiraBody):     SystemDescription,
-		AttributeExpression(JiraState):    SystemState,
-		AttributeExpression(JiraID):       SystemRemoteItemID,
-		AttributeExpression(JiraCreator):  SystemCreator,
-		AttributeExpression(JiraAssignee): SystemAssignee,
+		AttributeExpression(JiraTitle):    models.SystemTitle,
+		AttributeExpression(JiraBody):     models.SystemDescription,
+		AttributeExpression(JiraState):    models.SystemState,
+		AttributeExpression(JiraID):       models.SystemRemoteItemID,
+		AttributeExpression(JiraCreator):  models.SystemCreator,
+		AttributeExpression(JiraAssignee): models.SystemAssignee,
 	},
 }
 

--- a/remoteworkitem/remoteworkitem_test.go
+++ b/remoteworkitem/remoteworkitem_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/almighty/almighty-core/test"
 	"github.com/stretchr/testify/assert"
@@ -53,7 +54,7 @@ func TestWorkItemMapping(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 
 	workItemMap := WorkItemMap{
-		AttributeExpression("title"): "system.title",
+		AttributeExpression("title"): models.SystemTitle,
 	}
 	jsonContent := `{"title":"abc"}`
 	remoteTrackerItem := TrackerItem{Item: jsonContent, RemoteItemID: "xyz", TrackerID: uint64(0)}
@@ -68,7 +69,7 @@ func TestWorkItemMapping(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.NotNil(t, workItem.Fields["system.title"], "system.title not mapped")
+	assert.NotNil(t, workItem.Fields[models.SystemTitle], fmt.Sprintf("%s not mapped", models.SystemTitle))
 }
 
 func TestGitHubIssueMapping(t *testing.T) {

--- a/remoteworkitem/trackeritem_repository.go
+++ b/remoteworkitem/trackeritem_repository.go
@@ -49,9 +49,9 @@ func convert(ts *models.GormTransactionSupport, tqID int, item map[string]string
 	}
 
 	// Get the remote item identifier ( which is currently the url ) to check if the work item exists in the database.
-	workItemRemoteID := workItem.Fields[SystemRemoteItemID]
+	workItemRemoteID := workItem.Fields[models.SystemRemoteItemID]
 
-	sqlExpression := Equals(Field(SystemRemoteItemID), Literal(workItemRemoteID))
+	sqlExpression := Equals(Field(models.SystemRemoteItemID), Literal(workItemRemoteID))
 
 	var newWorkItem *app.WorkItem
 
@@ -71,7 +71,7 @@ func convert(ts *models.GormTransactionSupport, tqID int, item map[string]string
 	} else {
 		fmt.Println("Work item not found , will now create new work item")
 
-		newWorkItem, err = wir.Create(context.Background(), "system.bug", workItem.Fields)
+		newWorkItem, err = wir.Create(context.Background(), models.SystemBug, workItem.Fields)
 		if err != nil {
 			fmt.Println("Error creating work item : ", err)
 		}

--- a/remoteworkitem/trackeritem_repository_test.go
+++ b/remoteworkitem/trackeritem_repository_test.go
@@ -40,10 +40,10 @@ func TestConvertNewWorkItem(t *testing.T) {
 		workItem, err := convert(ts, int(tq.ID), remoteItemData, ProviderGithub)
 
 		assert.Nil(t, err)
-		assert.Equal(t, "linking", workItem.Fields[SystemTitle])
-		assert.Equal(t, "sbose78", workItem.Fields[SystemCreator])
-		assert.Equal(t, "pranav", workItem.Fields[SystemAssignee])
-		assert.Equal(t, "closed", workItem.Fields[SystemState])
+		assert.Equal(t, "linking", workItem.Fields[models.SystemTitle])
+		assert.Equal(t, "sbose78", workItem.Fields[models.SystemCreator])
+		assert.Equal(t, "pranav", workItem.Fields[models.SystemAssignee])
+		assert.Equal(t, "closed", workItem.Fields[models.SystemState])
 
 		witr := models.NewWorkItemTypeRepository(ts)
 		wir := models.NewWorkItemRepository(ts, witr)
@@ -81,10 +81,10 @@ func TestConvertExistingWorkItem(t *testing.T) {
 		workItem, err := convert(ts, int(tq.ID), remoteItemData, ProviderGithub)
 
 		assert.Nil(t, err)
-		assert.Equal(t, "linking", workItem.Fields[SystemTitle])
-		assert.Equal(t, "sbose78", workItem.Fields[SystemCreator])
-		assert.Equal(t, "pranav", workItem.Fields[SystemAssignee])
-		assert.Equal(t, "closed", workItem.Fields[SystemState])
+		assert.Equal(t, "linking", workItem.Fields[models.SystemTitle])
+		assert.Equal(t, "sbose78", workItem.Fields[models.SystemCreator])
+		assert.Equal(t, "pranav", workItem.Fields[models.SystemAssignee])
+		assert.Equal(t, "closed", workItem.Fields[models.SystemState])
 		return err
 	})
 
@@ -99,10 +99,10 @@ func TestConvertExistingWorkItem(t *testing.T) {
 		workItemUpdated, err := convert(ts, int(tq.ID), remoteItemDataUpdated, ProviderGithub)
 
 		assert.Nil(t, err)
-		assert.Equal(t, "linking-updated", workItemUpdated.Fields[SystemTitle])
-		assert.Equal(t, "sbose78", workItemUpdated.Fields[SystemCreator])
-		assert.Equal(t, "pranav", workItemUpdated.Fields[SystemAssignee])
-		assert.Equal(t, "closed", workItemUpdated.Fields[SystemState])
+		assert.Equal(t, "linking-updated", workItemUpdated.Fields[models.SystemTitle])
+		assert.Equal(t, "sbose78", workItemUpdated.Fields[models.SystemCreator])
+		assert.Equal(t, "pranav", workItemUpdated.Fields[models.SystemAssignee])
+		assert.Equal(t, "closed", workItemUpdated.Fields[models.SystemState])
 
 		witr := models.NewWorkItemTypeRepository(ts)
 		wir := models.NewWorkItemRepository(ts, witr)
@@ -143,10 +143,10 @@ func TestConvertGithubIssue(t *testing.T) {
 		workItemGithub, err := convert(ts, int(tq.ID), remoteItemDataGithub, ProviderGithub)
 
 		assert.Nil(t, err)
-		assert.Equal(t, "map flatten : test case : with assignee", workItemGithub.Fields[SystemTitle])
-		assert.Equal(t, "sbose78", workItemGithub.Fields[SystemCreator])
-		assert.Equal(t, "sbose78", workItemGithub.Fields[SystemAssignee])
-		assert.Equal(t, "open", workItemGithub.Fields[SystemState])
+		assert.Equal(t, "map flatten : test case : with assignee", workItemGithub.Fields[models.SystemTitle])
+		assert.Equal(t, "sbose78", workItemGithub.Fields[models.SystemCreator])
+		assert.Equal(t, "sbose78", workItemGithub.Fields[models.SystemAssignee])
+		assert.Equal(t, "open", workItemGithub.Fields[models.SystemState])
 
 		return err
 	})

--- a/workitem_blackbox_test.go
+++ b/workitem_blackbox_test.go
@@ -23,11 +23,11 @@ func TestGetWorkItem(t *testing.T) {
 	controller := NewWorkitemController(svc, repo, ts)
 	assert.NotNil(t, controller)
 	payload := app.CreateWorkItemPayload{
-		Type: "system.bug",
+		Type: models.SystemBug,
 		Fields: map[string]interface{}{
-			"system.title":   "Test WI",
-			"system.creator": "aslak",
-			"system.state":   "closed"},
+			models.SystemTitle:   "Test WI",
+			models.SystemCreator: "aslak",
+			models.SystemState:   "closed"},
 	}
 
 	_, result := test.CreateWorkitemCreated(t, nil, nil, controller, &payload)
@@ -42,7 +42,7 @@ func TestGetWorkItem(t *testing.T) {
 		t.Errorf("Id should be %s, but is %s", result.ID, wi.ID)
 	}
 
-	wi.Fields["system.creator"] = "thomas"
+	wi.Fields[models.SystemCreator] = "thomas"
 	payload2 := app.UpdateWorkItemPayload{
 		Type:    wi.Type,
 		Version: wi.Version,
@@ -55,8 +55,8 @@ func TestGetWorkItem(t *testing.T) {
 	if updated.ID != result.ID {
 		t.Errorf("id has changed from %s to %s", result.ID, updated.ID)
 	}
-	if updated.Fields["system.creator"] != "thomas" {
-		t.Errorf("expected creator %s, but got %s", "thomas", updated.Fields["system.creator"])
+	if updated.Fields[models.SystemCreator] != "thomas" {
+		t.Errorf("expected creator %s, but got %s", "thomas", updated.Fields[models.SystemCreator])
 	}
 
 	test.DeleteWorkitemOK(t, nil, nil, controller, result.ID)
@@ -72,11 +72,11 @@ func TestCreateWI(t *testing.T) {
 	controller := NewWorkitemController(svc, repo, ts)
 	assert.NotNil(t, controller)
 	payload := app.CreateWorkItemPayload{
-		Type: "system.bug",
+		Type: models.SystemBug,
 		Fields: map[string]interface{}{
-			"system.title":   "Test WI",
-			"system.creator": "tmaeder",
-			"system.state":   "new",
+			models.SystemTitle:   "Test WI",
+			models.SystemCreator: "tmaeder",
+			models.SystemState:   models.SystemStateNew,
 		},
 	}
 
@@ -96,11 +96,12 @@ func TestListByFields(t *testing.T) {
 	controller := NewWorkitemController(svc, repo, ts)
 	assert.NotNil(t, controller)
 	payload := app.CreateWorkItemPayload{
-		Type: "system.bug",
+		Type: models.SystemBug,
 		Fields: map[string]interface{}{
-			"system.title":   "run integration test",
-			"system.creator": "aslak",
-			"system.state":   "closed"},
+			models.SystemTitle:   "run integration test",
+			models.SystemCreator: "aslak",
+			models.SystemState:   models.SystemStateClosed,
+		},
 	}
 
 	_, wi := test.CreateWorkitemCreated(t, nil, nil, controller, &payload)


### PR DESCRIPTION
Work item type names like "system.bug" were embedded as strings directly in the code. This has now been replaced with const names like models.SystemBug . The same has been done for work item type field names like system.title which is now being referred as models.SystemTitle everywhere in the code. A subset of these were present in remoteworkitem.go but has now been moved to models/workitemtype.go

Fixes #161