### PR TITLE
The `tracker_query_id` column is no more required

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -87,6 +87,9 @@ func getMigrations() migrations {
 	// Version 3
 	m = append(m, steps{executeSQLFile("003-login.sql")})
 
+	// Version 4
+	m = append(m, steps{executeSQLFile("004-drop-tracker-query-id.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/004-drop-tracker-query-id.sql
+++ b/migration/sql-files/004-drop-tracker-query-id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tracker_items DROP COLUMN tracker_query_id;


### PR DESCRIPTION
fixes #367