### PR TITLE
Added new packages for Lifecycle and Equaler (solve cyclic import) 

### DIFF
--- a/account/identity.go
+++ b/account/identity.go
@@ -3,7 +3,7 @@ package account
 import (
 	"time"
 
-	"github.com/almighty/almighty-core/models"
+	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	uuid "github.com/satori/go.uuid"
@@ -12,7 +12,7 @@ import (
 
 // Identity ddenDescribes a unique Person with the ALM
 type Identity struct {
-	models.Lifecycle
+	gormsupport.Lifecycle
 	ID       uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"` // This is the ID PK field
 	Emails   []User    // has many Users
 	FullName string    // The fullname of the Identity

--- a/account/user.go
+++ b/account/user.go
@@ -3,7 +3,7 @@ package account
 import (
 	"time"
 
-	"github.com/almighty/almighty-core/models"
+	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	uuid "github.com/satori/go.uuid"
@@ -12,7 +12,7 @@ import (
 
 // User describes a User(single email) in any system
 type User struct {
-	models.Lifecycle
+	gormsupport.Lifecycle
 	ID         uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"` // This is the ID PK field
 	Email      string    `sql:"unique_index"`                                            // This is the unique email field
 	IdentityID uuid.UUID `sql:"type:uuid"`                                               // Belongs To Identity

--- a/convert/equaler.go
+++ b/convert/equaler.go
@@ -1,4 +1,4 @@
-package models
+package convert
 
 // The Equaler interface allows object that implement it, to be compared
 type Equaler interface {

--- a/convert/equaler_blackbox_test.go
+++ b/convert/equaler_blackbox_test.go
@@ -1,9 +1,9 @@
-package models_test
+package convert_test
 
 import (
 	"testing"
 
-	. "github.com/almighty/almighty-core/models"
+	"github.com/almighty/almighty-core/convert"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/stretchr/testify/assert"
 )
@@ -12,10 +12,10 @@ import (
 type foo struct{}
 
 // Ensure foo implements the Equaler interface
-var _ Equaler = foo{}
-var _ Equaler = (*foo)(nil)
+var _ convert.Equaler = foo{}
+var _ convert.Equaler = (*foo)(nil)
 
-func (f foo) Equal(u Equaler) bool {
+func (f foo) Equal(u convert.Equaler) bool {
 	_, ok := u.(foo)
 	if !ok {
 		return false
@@ -27,8 +27,8 @@ func TestDummyEqualerEqual(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
 
-	a := DummyEqualer{}
-	b := DummyEqualer{}
+	a := convert.DummyEqualer{}
+	b := convert.DummyEqualer{}
 
 	// Test for type difference
 	assert.False(t, a.Equal(foo{}))

--- a/gormsupport/lifecycle.go
+++ b/gormsupport/lifecycle.go
@@ -1,7 +1,9 @@
-package models
+package gormsupport
 
 import (
 	"time"
+
+	"github.com/almighty/almighty-core/convert"
 )
 
 // The Lifecycle struct contains all the items from gorm.Model except the ID field,
@@ -13,27 +15,27 @@ type Lifecycle struct {
 }
 
 // Ensure Lifecyle implements the Equaler interface
-var _ Equaler = Lifecycle{}
-var _ Equaler = (*Lifecycle)(nil)
+var _ convert.Equaler = Lifecycle{}
+var _ convert.Equaler = (*Lifecycle)(nil)
 
 // Equal returns true if two Lifecycle objects are equal; otherwise false is returned.
-func (self Lifecycle) Equal(u Equaler) bool {
+func (lc Lifecycle) Equal(u convert.Equaler) bool {
 	other, ok := u.(Lifecycle)
 	if !ok {
 		return false
 	}
-	if !self.CreatedAt.Equal(other.CreatedAt) {
+	if !lc.CreatedAt.Equal(other.CreatedAt) {
 		return false
 	}
-	if !self.UpdatedAt.Equal(other.UpdatedAt) {
+	if !lc.UpdatedAt.Equal(other.UpdatedAt) {
 		return false
 	}
 	// DeletedAt can be nil so we need to do a special check here.
-	if self.DeletedAt == nil && other.DeletedAt == nil {
+	if lc.DeletedAt == nil && other.DeletedAt == nil {
 		return true
 	}
-	if self.DeletedAt != nil && other.DeletedAt != nil {
-		return self.DeletedAt.Equal(*other.DeletedAt)
+	if lc.DeletedAt != nil && other.DeletedAt != nil {
+		return lc.DeletedAt.Equal(*other.DeletedAt)
 	}
 	return false
 }

--- a/gormsupport/lifecycle_blackbox_test.go
+++ b/gormsupport/lifecycle_blackbox_test.go
@@ -1,10 +1,11 @@
-package models_test
+package gormsupport_test
 
 import (
 	"testing"
 	"time"
 
-	"github.com/almighty/almighty-core/models"
+	"github.com/almighty/almighty-core/convert"
+	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/stretchr/testify/assert"
 )
@@ -16,18 +17,18 @@ func TestLifecycle_Equal(t *testing.T) {
 	now := time.Now()
 	nowPlus := time.Now().Add(time.Duration(1000))
 
-	a := models.Lifecycle{
+	a := gormsupport.Lifecycle{
 		CreatedAt: now,
 		UpdatedAt: now,
 		DeletedAt: nil,
 	}
 
 	// Test for type difference
-	b := models.DummyEqualer{}
+	b := convert.DummyEqualer{}
 	assert.False(t, a.Equal(b))
 
 	// Test CreateAt difference
-	c := models.Lifecycle{
+	c := gormsupport.Lifecycle{
 		CreatedAt: nowPlus,
 		UpdatedAt: now,
 		DeletedAt: nil,
@@ -35,7 +36,7 @@ func TestLifecycle_Equal(t *testing.T) {
 	assert.False(t, a.Equal(c))
 
 	// Test UpdatedAt difference
-	d := models.Lifecycle{
+	d := gormsupport.Lifecycle{
 		CreatedAt: now,
 		UpdatedAt: nowPlus,
 		DeletedAt: nil,
@@ -43,7 +44,7 @@ func TestLifecycle_Equal(t *testing.T) {
 	assert.False(t, a.Equal(d))
 
 	// Test DeletedAt (one is not nil, the other is) difference
-	e := models.Lifecycle{
+	e := gormsupport.Lifecycle{
 		CreatedAt: now,
 		UpdatedAt: now,
 		DeletedAt: &now,
@@ -51,12 +52,12 @@ func TestLifecycle_Equal(t *testing.T) {
 	assert.False(t, a.Equal(e))
 
 	// Test DeletedAt (both are not nil) difference
-	g := models.Lifecycle{
+	g := gormsupport.Lifecycle{
 		CreatedAt: now,
 		UpdatedAt: nowPlus,
 		DeletedAt: &now,
 	}
-	h := models.Lifecycle{
+	h := gormsupport.Lifecycle{
 		CreatedAt: now,
 		UpdatedAt: nowPlus,
 		DeletedAt: &nowPlus,

--- a/models/enum_type.go
+++ b/models/enum_type.go
@@ -3,6 +3,8 @@ package models
 import (
 	"fmt"
 	"reflect"
+
+	"github.com/almighty/almighty-core/convert"
 )
 
 type EnumType struct {
@@ -12,11 +14,11 @@ type EnumType struct {
 }
 
 // Ensure EnumType implements the Equaler interface
-var _ Equaler = EnumType{}
-var _ Equaler = (*EnumType)(nil)
+var _ convert.Equaler = EnumType{}
+var _ convert.Equaler = (*EnumType)(nil)
 
 // Equal returns true if two EnumType objects are equal; otherwise false is returned.
-func (self EnumType) Equal(u Equaler) bool {
+func (self EnumType) Equal(u convert.Equaler) bool {
 	other, ok := u.(EnumType)
 	if !ok {
 		return false

--- a/models/enum_type_blackbox_test.go
+++ b/models/enum_type_blackbox_test.go
@@ -3,6 +3,7 @@ package models_test
 import (
 	"testing"
 
+	"github.com/almighty/almighty-core/convert"
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/stretchr/testify/assert"
@@ -19,7 +20,7 @@ func TestEnumType_Equal(t *testing.T) {
 	}
 
 	// Test type inequality
-	assert.False(t, a.Equal(models.DummyEqualer{}))
+	assert.False(t, a.Equal(convert.DummyEqualer{}))
 
 	// Test simple type difference
 	stInteger := models.SimpleType{Kind: models.KindInteger}

--- a/models/field_definition.go
+++ b/models/field_definition.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+
+	"github.com/almighty/almighty-core/convert"
 )
 
 // constants for describing possible field types
@@ -36,7 +38,7 @@ type FieldType interface {
 	// ConvertToModel converts a field value for storage in the db
 	ConvertFromModel(value interface{}) (interface{}, error)
 	// Implement the Equaler interface
-	Equal(u Equaler) bool
+	Equal(u convert.Equaler) bool
 }
 
 // FieldDefintion describes type & other restrictions of a field
@@ -46,11 +48,11 @@ type FieldDefinition struct {
 }
 
 // Ensure FieldDefinition implements the Equaler interface
-var _ Equaler = FieldDefinition{}
-var _ Equaler = (*FieldDefinition)(nil)
+var _ convert.Equaler = FieldDefinition{}
+var _ convert.Equaler = (*FieldDefinition)(nil)
 
 // Equal returns true if two FieldDefinition objects are equal; otherwise false is returned.
-func (self FieldDefinition) Equal(u Equaler) bool {
+func (self FieldDefinition) Equal(u convert.Equaler) bool {
 	other, ok := u.(FieldDefinition)
 	if !ok {
 		return false
@@ -83,11 +85,11 @@ type rawFieldDef struct {
 }
 
 // Ensure rawFieldDef implements the Equaler interface
-var _ Equaler = rawFieldDef{}
-var _ Equaler = (*rawFieldDef)(nil)
+var _ convert.Equaler = rawFieldDef{}
+var _ convert.Equaler = (*rawFieldDef)(nil)
 
 // Equal returns true if two rawFieldDef objects are equal; otherwise false is returned.
-func (self rawFieldDef) Equal(u Equaler) bool {
+func (self rawFieldDef) Equal(u convert.Equaler) bool {
 	other, ok := u.(rawFieldDef)
 	if !ok {
 		return false

--- a/models/json_storage.go
+++ b/models/json_storage.go
@@ -5,17 +5,19 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+
+	"github.com/almighty/almighty-core/convert"
 )
 
 type Fields map[string]interface{}
 
 // Ensure Fields implements the Equaler interface
-var _ Equaler = Fields{}
-var _ Equaler = (*Fields)(nil)
+var _ convert.Equaler = Fields{}
+var _ convert.Equaler = (*Fields)(nil)
 
 // Equal returns true if two Fields objects are equal; otherwise false is returned.
 // TODO: (kwk) think about a better comparison for Fields map.
-func (self Fields) Equal(u Equaler) bool {
+func (self Fields) Equal(u convert.Equaler) bool {
 	other, ok := u.(Fields)
 	if !ok {
 		return false

--- a/models/list_type.go
+++ b/models/list_type.go
@@ -3,6 +3,8 @@ package models
 import (
 	"fmt"
 	"reflect"
+
+	"github.com/almighty/almighty-core/convert"
 )
 
 //ListType describes a list of SimpleType values
@@ -12,11 +14,11 @@ type ListType struct {
 }
 
 // Ensure ListType implements the Equaler interface
-var _ Equaler = ListType{}
-var _ Equaler = (*ListType)(nil)
+var _ convert.Equaler = ListType{}
+var _ convert.Equaler = (*ListType)(nil)
 
 // Equal returns true if two ListType objects are equal; otherwise false is returned.
-func (self ListType) Equal(u Equaler) bool {
+func (self ListType) Equal(u convert.Equaler) bool {
 	other, ok := u.(ListType)
 	if !ok {
 		return false

--- a/models/list_type_blackbox_test.go
+++ b/models/list_type_blackbox_test.go
@@ -3,6 +3,7 @@ package models_test
 import (
 	"testing"
 
+	"github.com/almighty/almighty-core/convert"
 	. "github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,7 @@ func TestListType_Equal(t *testing.T) {
 	}
 
 	// Test type incompatibility
-	assert.False(t, a.Equal(DummyEqualer{}))
+	assert.False(t, a.Equal(convert.DummyEqualer{}))
 
 	// Test simple type difference
 	b := ListType{

--- a/models/simple_type.go
+++ b/models/simple_type.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/almighty/almighty-core/convert"
 	"github.com/asaskevich/govalidator"
 )
 
@@ -15,11 +16,11 @@ type SimpleType struct {
 }
 
 // Ensure SimpleType implements the Equaler interface
-var _ Equaler = SimpleType{}
-var _ Equaler = (*SimpleType)(nil)
+var _ convert.Equaler = SimpleType{}
+var _ convert.Equaler = (*SimpleType)(nil)
 
 // Equal returns true if two SimpleType objects are equal; otherwise false is returned.
-func (self SimpleType) Equal(u Equaler) bool {
+func (self SimpleType) Equal(u convert.Equaler) bool {
 	other, ok := u.(SimpleType)
 	if !ok {
 		return false

--- a/models/simple_type_blackbox_test.go
+++ b/models/simple_type_blackbox_test.go
@@ -3,6 +3,7 @@ package models_test
 import (
 	"testing"
 
+	"github.com/almighty/almighty-core/convert"
 	. "github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/stretchr/testify/assert"
@@ -14,7 +15,7 @@ func TestSimpleTypeEqual(t *testing.T) {
 
 	// Test type difference
 	a := SimpleType{Kind: KindString}
-	assert.False(t, a.Equal(DummyEqualer{}))
+	assert.False(t, a.Equal(convert.DummyEqualer{}))
 
 	// Test kind difference
 	b := SimpleType{Kind: KindInteger}

--- a/models/workitem.go
+++ b/models/workitem.go
@@ -1,8 +1,13 @@
 package models
 
+import (
+	"github.com/almighty/almighty-core/convert"
+	"github.com/almighty/almighty-core/gormsupport"
+)
+
 // WorkItem represents a work item as it is stored in the database
 type WorkItem struct {
-	Lifecycle
+	gormsupport.Lifecycle
 	ID uint64 `gorm:"primary_key"`
 	// Id of the type of this work item
 	Type string
@@ -13,11 +18,11 @@ type WorkItem struct {
 }
 
 // Ensure WorkItem implements the Equaler interface
-var _ Equaler = WorkItem{}
-var _ Equaler = (*WorkItem)(nil)
+var _ convert.Equaler = WorkItem{}
+var _ convert.Equaler = (*WorkItem)(nil)
 
 // Equal returns true if two WorkItem objects are equal; otherwise false is returned.
-func (self WorkItem) Equal(u Equaler) bool {
+func (self WorkItem) Equal(u convert.Equaler) bool {
 	other, ok := u.(WorkItem)
 	if !ok {
 		return false

--- a/models/workitem_blackbox_test.go
+++ b/models/workitem_blackbox_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/almighty/almighty-core/convert"
+	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/stretchr/testify/assert"
@@ -23,12 +25,12 @@ func TestWorkItem_Equal(t *testing.T) {
 	}
 
 	// Test type difference
-	b := models.DummyEqualer{}
+	b := convert.DummyEqualer{}
 	assert.False(t, a.Equal(b))
 
 	// Test lifecycle difference
 	c := a
-	c.Lifecycle = models.Lifecycle{CreatedAt: time.Now().Add(time.Duration(1000))}
+	c.Lifecycle = gormsupport.Lifecycle{CreatedAt: time.Now().Add(time.Duration(1000))}
 	assert.False(t, a.Equal(c))
 
 	// Test type difference

--- a/models/workitemtype.go
+++ b/models/workitemtype.go
@@ -1,5 +1,10 @@
 package models
 
+import (
+	"github.com/almighty/almighty-core/convert"
+	"github.com/almighty/almighty-core/gormsupport"
+)
+
 // String constants for the local work item types.
 const (
 	SystemRemoteItemID = "system.remote_item_id"
@@ -25,7 +30,7 @@ const (
 
 // WorkItemType represents a work item type as it is stored in the db
 type WorkItemType struct {
-	Lifecycle
+	gormsupport.Lifecycle
 	// the unique name of this work item type.
 	Name string `gorm:"primary_key"`
 	// Version for optimistic concurrency control
@@ -37,11 +42,11 @@ type WorkItemType struct {
 }
 
 // Ensure Fields implements the Equaler interface
-var _ Equaler = WorkItemType{}
-var _ Equaler = (*WorkItemType)(nil)
+var _ convert.Equaler = WorkItemType{}
+var _ convert.Equaler = (*WorkItemType)(nil)
 
 // Equal returns true if two WorkItemType objects are equal; otherwise false is returned.
-func (self WorkItemType) Equal(u Equaler) bool {
+func (self WorkItemType) Equal(u convert.Equaler) bool {
 	other, ok := u.(WorkItemType)
 	if !ok {
 		return false

--- a/models/workitemtype_blackbox_test.go
+++ b/models/workitemtype_blackbox_test.go
@@ -8,6 +8,8 @@ import (
 
 	"time"
 
+	"github.com/almighty/almighty-core/convert"
+	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/stretchr/testify/assert"
@@ -99,12 +101,12 @@ func TestWorkItemType_Equal(t *testing.T) {
 	}
 
 	// Test types
-	b := models.DummyEqualer{}
+	b := convert.DummyEqualer{}
 	assert.False(t, a.Equal(b))
 
 	// Test lifecycle
 	c := a
-	c.Lifecycle = models.Lifecycle{CreatedAt: time.Now().Add(time.Duration(1000))}
+	c.Lifecycle = gormsupport.Lifecycle{CreatedAt: time.Now().Add(time.Duration(1000))}
 	assert.False(t, a.Equal(c))
 
 	// Test version

--- a/remoteworkitem/tracker.go
+++ b/remoteworkitem/tracker.go
@@ -1,10 +1,10 @@
 package remoteworkitem
 
-import "github.com/almighty/almighty-core/models"
+import "github.com/almighty/almighty-core/gormsupport"
 
 // Tracker represents tracker configuration
 type Tracker struct {
-	models.Lifecycle
+	gormsupport.Lifecycle
 	ID uint64 `gorm:"primary_key"`
 	// URL of the tracker
 	URL string

--- a/remoteworkitem/trackeritem.go
+++ b/remoteworkitem/trackeritem.go
@@ -1,11 +1,11 @@
 package remoteworkitem
 
-import "github.com/almighty/almighty-core/models"
+import "github.com/almighty/almighty-core/gormsupport"
 
 // TrackerItem represents a remote tracker item
 // Staging area before pushing to work item
 type TrackerItem struct {
-	models.Lifecycle
+	gormsupport.Lifecycle
 	ID uint64 `gorm:"primary_key"`
 	// Remote item ID - unique across multiple trackers
 	RemoteItemID string `gorm:"not null;unique"`

--- a/remoteworkitem/trackerquery.go
+++ b/remoteworkitem/trackerquery.go
@@ -1,10 +1,10 @@
 package remoteworkitem
 
-import "github.com/almighty/almighty-core/models"
+import "github.com/almighty/almighty-core/gormsupport"
 
 // TrackerQuery represents tracker query
 type TrackerQuery struct {
-	models.Lifecycle
+	gormsupport.Lifecycle
 	ID uint64 `gorm:"primary_key"`
 	// Search query of the tracker
 	Query string


### PR DESCRIPTION
This is ground work for upcoming PR which is about setting system.creator in creation of WI.

@tsmaeder @aslakknutsen Please review and merge if this is acceptable, as I needed this for upcoming PR.

Why:
Need to avoid cyclic imports and it is good to make packages if there is piece of work that can/should live in isolation.

What:
Moved Lifecycle to "gormsupport" new package.
Moved Equaler to "convert" new package.