### PR TITLE
Set creator value while creating WI.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -407,3 +407,24 @@ Retrieve the work item.
 $ ./bin/alm-cli show workitem --id 1 -H localhost:8080 --pp
 ----
 
+
+System defined Work Item Types are
+
+ * system.userstory
+ * system.valueproposition
+ * system.fundamental
+ * system.experience
+ * system.feature
+ * system.bug
+
+Use any one of above to create Work Item based on that type.
+Following example creates a Work Item of type `system.userstory`
+----
+$ ./bin/alm-cli create workitem --key "<GENERATED TOKEN>" --payload '{"type": "system.userstory", "fields": { "system.title": "A catchy Title", "system.owner": "tmaeder", "system.state": "open" }}' -H localhost:8080
+----
+
+In response you should get ID of created item, using that you can retrieve the work item.
+
+----
+$ ./bin/alm-cli show workitem --id <ID> -H localhost:8080 --pp
+----

--- a/account/user.go
+++ b/account/user.go
@@ -151,3 +151,15 @@ func UserWithIdentity() func(db *gorm.DB) *gorm.DB {
 
 	}
 }
+
+// TestIdentity only creates in memory obj for testing purposes
+var TestIdentity = Identity{
+	FullName: "Test Developer",
+}
+
+// TestUser only creates in memory obj for testing purposes
+var TestUser = User{
+	ID:       uuid.UUID{},
+	Email:    "testdeveloper@testalm.io",
+	Identity: TestIdentity,
+}

--- a/account/user.go
+++ b/account/user.go
@@ -154,12 +154,13 @@ func UserWithIdentity() func(db *gorm.DB) *gorm.DB {
 
 // TestIdentity only creates in memory obj for testing purposes
 var TestIdentity = Identity{
-	FullName: "Test Developer",
+	ID:       uuid.NewV4(),
+	FullName: "Test Developer Identity",
 }
 
 // TestUser only creates in memory obj for testing purposes
 var TestUser = User{
-	ID:       uuid.UUID{},
+	ID:       uuid.NewV4(),
 	Email:    "testdeveloper@testalm.io",
 	Identity: TestIdentity,
 }

--- a/application/repositories.go
+++ b/application/repositories.go
@@ -11,7 +11,7 @@ type WorkItemRepository interface {
 	Load(ctx context.Context, ID string) (*app.WorkItem, error)
 	Save(ctx context.Context, wi app.WorkItem) (*app.WorkItem, error)
 	Delete(ctx context.Context, ID string) error
-	Create(ctx context.Context, typeID string, fields map[string]interface{}) (*app.WorkItem, error)
+	Create(ctx context.Context, typeID string, fields map[string]interface{}, creator string) (*app.WorkItem, error)
 	List(ctx context.Context, criteria criteria.Expression, start *int, length *int) ([]*app.WorkItem, uint64, error)
 }
 

--- a/login/service.go
+++ b/login/service.go
@@ -3,13 +3,11 @@ package login
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"sync"
 
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/token"
-	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
@@ -204,42 +202,14 @@ type ghUser struct {
 	AvatarURL string `json:"avatar_url"`
 }
 
-type contextKey int
-
-const (
-	//currentUserInContextKey is a key that will be used to put and to get `currentUser` from goa.context
-	currentUserInContextKey contextKey = iota + 1
-)
-
-// WithIdentity fills the context with input id string
-func WithIdentity(ctx context.Context, id string) context.Context {
-	return context.WithValue(ctx, currentUserInContextKey, id)
-}
-
-// ContextIdentity reads the input context then extracts and returns logged in user from that
-func ContextIdentity(ctx context.Context) string {
-	val := ctx.Value(currentUserInContextKey)
-	if val != nil {
-		return val.(string)
+// ContextIdentity returns the identity's ID found in given context
+// Uses tokenManager.Locate to fetch the identity of currently logged in user
+func ContextIdentity(tokenManager token.Manager, ctx context.Context) (string, error) {
+	uuid, err := tokenManager.Locate(ctx)
+	if err != nil {
+		// TODO : need a way to define user as Guest
+		fmt.Println("Geust User")
+		return "", err
 	}
-	return ""
-}
-
-// ConfigureExtractUser is a configuration for middleware,
-// Accepts PublicKey and PrivateKey to create a token manager
-// Using token manager, it is responsible for extracting the token from context if present
-// Update the context with uuid found in token
-func ConfigureExtractUser(manager token.Manager) goa.Middleware {
-	return func(h goa.Handler) goa.Handler {
-		return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
-			// for now ignore the error becasue still test for logged in user is not done.
-			uuid, err := manager.Locate(ctx)
-			if err != nil {
-				// TODO : need a way to define user as Guest
-				fmt.Println("Geust User")
-			}
-			ctxWithUser := WithIdentity(ctx, uuid.String())
-			return h(ctxWithUser, rw, req)
-		}
-	}
+	return uuid.String(), nil
 }

--- a/main.go
+++ b/main.go
@@ -19,12 +19,11 @@ import (
 
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
-	"github.com/almighty/almighty-core/models"
-
 	"github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/login"
 	"github.com/almighty/almighty-core/migration"
+	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/remoteworkitem"
 	"github.com/almighty/almighty-core/token"
 	"github.com/goadesign/goa"
@@ -147,6 +146,7 @@ func main() {
 
 	tokenManager := token.NewManager(publicKey, privateKey)
 	app.UseJWTMiddleware(service, jwt.New(publicKey, nil, app.NewJWTSecurity()))
+	service.Use(login.ConfigureExtractUser(tokenManager))
 
 	// Mount "login" controller
 	oauth := &oauth2.Config{

--- a/main.go
+++ b/main.go
@@ -146,6 +146,7 @@ func main() {
 
 	tokenManager := token.NewManager(publicKey, privateKey)
 	app.UseJWTMiddleware(service, jwt.New(publicKey, nil, app.NewJWTSecurity()))
+	service.Use(login.InjectTokenManager(tokenManager))
 
 	// Mount "login" controller
 	oauth := &oauth2.Config{
@@ -166,7 +167,7 @@ func main() {
 	appDB := gormapplication.NewGormDB(db)
 
 	// Mount "workitem" controller
-	workitemCtrl := NewWorkitemController(service, appDB, tokenManager)
+	workitemCtrl := NewWorkitemController(service, appDB)
 	app.MountWorkitemController(service, workitemCtrl)
 
 	workitem2Ctrl := NewWorkitem2Controller(service, appDB)

--- a/main.go
+++ b/main.go
@@ -146,7 +146,6 @@ func main() {
 
 	tokenManager := token.NewManager(publicKey, privateKey)
 	app.UseJWTMiddleware(service, jwt.New(publicKey, nil, app.NewJWTSecurity()))
-	service.Use(login.ConfigureExtractUser(tokenManager))
 
 	// Mount "login" controller
 	oauth := &oauth2.Config{
@@ -167,7 +166,7 @@ func main() {
 	appDB := gormapplication.NewGormDB(db)
 
 	// Mount "workitem" controller
-	workitemCtrl := NewWorkitemController(service, appDB)
+	workitemCtrl := NewWorkitemController(service, appDB, tokenManager)
 	app.MountWorkitemController(service, workitemCtrl)
 
 	workitem2Ctrl := NewWorkitem2Controller(service, appDB)

--- a/models/workitem_repository.go
+++ b/models/workitem_repository.go
@@ -119,7 +119,7 @@ func (r *GormWorkItemRepository) Save(ctx context.Context, wi app.WorkItem) (*ap
 
 // Create creates a new work item in the repository
 // returns BadParameterError, ConversionError or InternalError
-func (r *GormWorkItemRepository) Create(ctx context.Context, typeID string, fields map[string]interface{}) (*app.WorkItem, error) {
+func (r *GormWorkItemRepository) Create(ctx context.Context, typeID string, fields map[string]interface{}, creator string) (*app.WorkItem, error) {
 	wiType, err := r.wir.loadTypeFromDB(ctx, typeID)
 	if err != nil {
 		return nil, BadParameterError{parameter: "type", value: typeID}
@@ -128,6 +128,7 @@ func (r *GormWorkItemRepository) Create(ctx context.Context, typeID string, fiel
 		Type:   typeID,
 		Fields: Fields{},
 	}
+	fields[SystemCreator] = creator
 	for fieldName, fieldDef := range wiType.Fields {
 		fieldValue := fields[fieldName]
 		var err error

--- a/remoteworkitem/trackeritem_repository.go
+++ b/remoteworkitem/trackeritem_repository.go
@@ -72,8 +72,12 @@ func convert(db *gorm.DB, tID int, item TrackerItemContent, provider string) (*a
 		}
 	} else {
 		fmt.Println("Work item not found , will now create new work item")
-
-		newWorkItem, err = wir.Create(context.Background(), models.SystemBug, workItem.Fields)
+		c := workItem.Fields[models.SystemCreator]
+		var creator string
+		if c != nil {
+			creator = c.(string)
+		}
+		newWorkItem, err = wir.Create(context.Background(), models.SystemBug, workItem.Fields, creator)
 		if err != nil {
 			fmt.Println("Error creating work item : ", err)
 		}

--- a/test/login.go
+++ b/test/login.go
@@ -4,6 +4,8 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/almighty/almighty-core/account"
+	"github.com/almighty/almighty-core/login"
+	"github.com/almighty/almighty-core/token"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
@@ -20,8 +22,9 @@ func WithIdentity(ctx context.Context, ident account.Identity) context.Context {
 }
 
 // ServiceAsUser creates a new service and fill the context with input Identity
-func ServiceAsUser(serviceName string, u account.Identity) *goa.Service {
+func ServiceAsUser(serviceName string, tm token.Manager, u account.Identity) *goa.Service {
 	svc := goa.New(serviceName)
 	svc.Context = WithIdentity(svc.Context, u)
+	svc.Context = login.ContextWithTokenManager(svc.Context, tm)
 	return svc
 }

--- a/test/login.go
+++ b/test/login.go
@@ -1,14 +1,27 @@
 package test
 
 import (
+	"golang.org/x/net/context"
+
 	"github.com/almighty/almighty-core/account"
-	"github.com/almighty/almighty-core/login"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
+	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 )
 
-// ServiceAsUser creates a new service and fill the context with input user
-func ServiceAsUser(serviceName string, u account.User) *goa.Service {
+// WithIdentity fills the context with token
+// Token is filled using input Identity object
+func WithIdentity(ctx context.Context, ident account.Identity) context.Context {
+	token := jwt.New(jwt.SigningMethodRS256)
+	token.Claims.(jwt.MapClaims)["uuid"] = ident.ID.String()
+	token.Claims.(jwt.MapClaims)["fullName"] = ident.FullName
+	token.Claims.(jwt.MapClaims)["imageURL"] = ident.ImageURL
+	return goajwt.WithJWT(ctx, token)
+}
+
+// ServiceAsUser creates a new service and fill the context with input Identity
+func ServiceAsUser(serviceName string, u account.Identity) *goa.Service {
 	svc := goa.New(serviceName)
-	svc.Context = login.WithIdentity(svc.Context, u.ID.String())
+	svc.Context = WithIdentity(svc.Context, u)
 	return svc
 }

--- a/test/login.go
+++ b/test/login.go
@@ -1,0 +1,14 @@
+package test
+
+import (
+	"github.com/almighty/almighty-core/account"
+	"github.com/almighty/almighty-core/login"
+	"github.com/goadesign/goa"
+)
+
+// ServiceAsUser creates a new service and fill the context with input user
+func ServiceAsUser(serviceName string, u account.User) *goa.Service {
+	svc := goa.New(serviceName)
+	svc.Context = login.WithIdentity(svc.Context, u.ID.String())
+	return svc
+}

--- a/test/workitemrepository.go
+++ b/test/workitemrepository.go
@@ -172,7 +172,7 @@ func (fake *WorkItemRepository) DeleteReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *WorkItemRepository) Create(ctx context.Context, typeID string, fields map[string]interface{}) (*app.WorkItem, error) {
+func (fake *WorkItemRepository) Create(ctx context.Context, typeID string, fields map[string]interface{}, creator string) (*app.WorkItem, error) {
 	fake.createMutex.Lock()
 	fake.createArgsForCall = append(fake.createArgsForCall, struct {
 		ctx    context.Context

--- a/workitem.go
+++ b/workitem.go
@@ -13,22 +13,20 @@ import (
 	"github.com/almighty/almighty-core/login"
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/query/simple"
-	"github.com/almighty/almighty-core/token"
 )
 
 // WorkitemController implements the workitem resource.
 type WorkitemController struct {
 	*goa.Controller
-	db           application.DB
-	tokenManager token.Manager
+	db application.DB
 }
 
 // NewWorkitemController creates a workitem controller.
-func NewWorkitemController(service *goa.Service, db application.DB, tokenManager token.Manager) *WorkitemController {
+func NewWorkitemController(service *goa.Service, db application.DB) *WorkitemController {
 	if db == nil {
 		panic("db must not be nil")
 	}
-	return &WorkitemController{Controller: service.NewController("WorkitemController"), db: db, tokenManager: tokenManager}
+	return &WorkitemController{Controller: service.NewController("WorkitemController"), db: db}
 }
 
 // Show runs the show action.
@@ -101,7 +99,7 @@ func (c *WorkitemController) List(ctx *app.ListWorkitemContext) error {
 // Create runs the create action.
 func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
 	return application.Transactional(c.db, func(appl application.Application) error {
-		currentUser, err := login.ContextIdentity(c.tokenManager, ctx)
+		currentUser, err := login.ContextIdentity(ctx)
 		if err != nil {
 			return ctx.Unauthorized()
 		}

--- a/workitem.go
+++ b/workitem.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/login"
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/query/simple"
 )
@@ -98,7 +99,7 @@ func (c *WorkitemController) List(ctx *app.ListWorkitemContext) error {
 // Create runs the create action.
 func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
 	return application.Transactional(c.db, func(appl application.Application) error {
-		wi, err := appl.WorkItems().Create(ctx.Context, ctx.Payload.Type, ctx.Payload.Fields)
+		wi, err := appl.WorkItems().Create(ctx.Context, ctx.Payload.Type, ctx.Payload.Fields, login.ContextIdentity(ctx))
 
 		if err != nil {
 			switch err := err.(type) {

--- a/workitem_blackbox_test.go
+++ b/workitem_blackbox_test.go
@@ -34,11 +34,11 @@ import (
 
 func TestGetWorkItem(t *testing.T) {
 	resource.Require(t, resource.Database)
-	svc := testsupport.ServiceAsUser("TestGetWorkItem-Service", account.TestIdentity)
-	assert.NotNil(t, svc)
 	pub, _ := almtoken.ParsePublicKey([]byte(almtoken.RSAPublicKey))
 	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
-	controller := NewWorkitemController(svc, gormapplication.NewGormDB(DB), almtoken.NewManager(pub, priv))
+	svc := testsupport.ServiceAsUser("TestGetWorkItem-Service", almtoken.NewManager(pub, priv), account.TestIdentity)
+	assert.NotNil(t, svc)
+	controller := NewWorkitemController(svc, gormapplication.NewGormDB(DB))
 	assert.NotNil(t, controller)
 	payload := app.CreateWorkItemPayload{
 		Type: models.SystemBug,
@@ -85,11 +85,11 @@ func TestGetWorkItem(t *testing.T) {
 
 func TestCreateWI(t *testing.T) {
 	resource.Require(t, resource.Database)
-	svc := testsupport.ServiceAsUser("TestCreateWI-Service", account.TestIdentity)
-	assert.NotNil(t, svc)
 	pub, _ := almtoken.ParsePublicKey([]byte(almtoken.RSAPublicKey))
 	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
-	controller := NewWorkitemController(svc, gormapplication.NewGormDB(DB), almtoken.NewManager(pub, priv))
+	svc := testsupport.ServiceAsUser("TestCreateWI-Service", almtoken.NewManager(pub, priv), account.TestIdentity)
+	assert.NotNil(t, svc)
+	controller := NewWorkitemController(svc, gormapplication.NewGormDB(DB))
 	assert.NotNil(t, controller)
 	payload := app.CreateWorkItemPayload{
 		Type: models.SystemBug,
@@ -112,9 +112,7 @@ func TestCreateWorkItemWithoutContext(t *testing.T) {
 	resource.Require(t, resource.Database)
 	svc := goa.New("TestCreateWorkItemWithoutContext-Service")
 	assert.NotNil(t, svc)
-	pub, _ := almtoken.ParsePublicKey([]byte(almtoken.RSAPublicKey))
-	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
-	controller := NewWorkitemController(svc, gormapplication.NewGormDB(DB), almtoken.NewManager(pub, priv))
+	controller := NewWorkitemController(svc, gormapplication.NewGormDB(DB))
 	assert.NotNil(t, controller)
 	payload := app.CreateWorkItemPayload{
 		Type: models.SystemBug,
@@ -129,11 +127,11 @@ func TestCreateWorkItemWithoutContext(t *testing.T) {
 
 func TestListByFields(t *testing.T) {
 	resource.Require(t, resource.Database)
-	svc := testsupport.ServiceAsUser("TestListByFields-Service", account.TestIdentity)
-	assert.NotNil(t, svc)
 	pub, _ := almtoken.ParsePublicKey([]byte(almtoken.RSAPublicKey))
 	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
-	controller := NewWorkitemController(svc, gormapplication.NewGormDB(DB), almtoken.NewManager(pub, priv))
+	svc := testsupport.ServiceAsUser("TestListByFields-Service", almtoken.NewManager(pub, priv), account.TestIdentity)
+	assert.NotNil(t, svc)
+	controller := NewWorkitemController(svc, gormapplication.NewGormDB(DB))
 	assert.NotNil(t, controller)
 	payload := app.CreateWorkItemPayload{
 		Type: models.SystemBug,
@@ -375,10 +373,7 @@ func TestUnauthorizeWorkItemCUD(t *testing.T) {
 		// Because it will check the design and accordingly apply the middleware if mentioned in design
 		// But if I use `service.Use(jwtMiddleware)` then middleware is applied for all the requests (without checking design)
 		app.UseJWTMiddleware(service, jwtMiddleware)
-
-		pub, _ := almtoken.ParsePublicKey([]byte(almtoken.RSAPublicKey))
-		priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
-		controller := NewWorkitemController(service, gormapplication.NewGormDB(DB), almtoken.NewManager(pub, priv))
+		controller := NewWorkitemController(service, gormapplication.NewGormDB(DB))
 		app.MountWorkitemController(service, controller)
 
 		// Hit the service with own request

--- a/workitem_whitebox_test.go
+++ b/workitem_whitebox_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/remoteworkitem"
 	"github.com/almighty/almighty-core/resource"
-	almtoken "github.com/almighty/almighty-core/token"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
@@ -57,9 +56,7 @@ func TestNewWorkitemController(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
 	assert.Panics(t, func() {
-		pub, _ := almtoken.ParsePublicKey([]byte(almtoken.RSAPublicKey))
-		priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
-		NewWorkitemController(goa.New("Test service"), nil, almtoken.NewManager(pub, priv))
+		NewWorkitemController(goa.New("Test service"), nil)
 	})
 }
 

--- a/workitem_whitebox_test.go
+++ b/workitem_whitebox_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/remoteworkitem"
 	"github.com/almighty/almighty-core/resource"
+	almtoken "github.com/almighty/almighty-core/token"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
@@ -56,7 +57,9 @@ func TestNewWorkitemController(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
 	assert.Panics(t, func() {
-		NewWorkitemController(goa.New("Test service"), nil)
+		pub, _ := almtoken.ParsePublicKey([]byte(almtoken.RSAPublicKey))
+		priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
+		NewWorkitemController(goa.New("Test service"), nil, almtoken.NewManager(pub, priv))
 	})
 }
 


### PR DESCRIPTION
 depends on #386 

Why:
    We need to set correct value for WI creator field.

What:
    Every WI has list of fields, out of which SystemCreator is to be filled by system only.
    Logged in user's UUID in string format should go in as value of SystemCreator in corresponding fields slice.

How:
    Added a middleware to fetch,locate and set uuid in the context. If not found (for non-secured APIs) it will set it as "guest user"- currently shown as empty UUID (all zeros).
    Added new parameter to repository creator method of WI to accept creator in string form.
    Did required changes in system and tests are modified.
