### PR TITLE
Update documentation after changes made in REST APIs.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -359,6 +359,7 @@ Start up dependent docker services using `docker-compose` and runs auto reload o
 
 ----
 $ cd $GOPATH/src/github.com/almighty/almighty-core
+$ export ALMIGHTY_DEVELOPER_MODE_ENABLED=true
 $ make dev
 ----
 
@@ -368,9 +369,16 @@ Test out the build by executing CLI commands in a different terminal.
 
 NOTE: The CLI needs the API Server which was started on executing `make dev`  to be up and running. Please do not kill the process. Alternatively if you haven't run `make dev` you could just start the server by running `./bin/alm`.
 
-Create a work item type.
+Generate a token for future use.
 ----
-./bin/alm-cli create workitemtype --payload '{"fields":{"system.owner":{"Type":{"Kind":"user"},"Required":true},"system.state":{"Type":{"Kind":"string"},"Required":false}},"name":"Epic"}' -H localhost:8080 --pp
+./bin/alm-cli generate login -H localhost:8080 --pp
+----
+
+You should get Token in response, save this token in your favourite editor as you need to use this token for POST API calls  
+
+Create a work item type (using above token).
+----
+./bin/alm-cli create workitemtype --key "<GENERATED TOKEN>" --payload '{"fields":{"system.owner":{"Type":{"Kind":"user"},"Required":true},"system.state":{"Type":{"Kind":"string"},"Required":false}},"name":"Epic"}' -H localhost:8080 --pp
 ----
 Note: Work Item Type `Name` is unique. If one tries to create another work item type with same name, error will be trown.
 
@@ -391,7 +399,7 @@ Based on WorkItemType created above, we can create WorkItem.
 We need to use name of work item type in the `type` field below.
 
 ----
-$ ./bin/alm-cli create workitem --payload '{"type": "Epic", "fields": { "system.owner": "tmaeder", "system.state": "open" }}' -H localhost:8080
+$ ./bin/alm-cli create workitem --key "<GENERATED TOKEN>" --payload '{"type": "Epic", "fields": { "system.owner": "tmaeder", "system.state": "open" }}' -H localhost:8080
 ----
 
 Retrieve the work item.

--- a/examples/workitemtype.adoc
+++ b/examples/workitemtype.adoc
@@ -4,6 +4,8 @@
 :sectnums:
 :experimental:
 
+*Requirements:* Need token to use following API. Please go through link:https://github.com/almighty/almighty-core/#3-developer-setup[README] to generate a token to use.
+
 == Create an "Epic" Work Item Type
 
 The following should fail as nothing is there (yet):
@@ -15,7 +17,7 @@ The following should fail as nothing is there (yet):
 Should create 1 WIT with `name=Epic`:
 
 ----
-./bin/alm-cli create workitemtype --payload '{"extendedTypeName":null,"fields":{"system.owner":{"Type":{"Kind":"user"},"Required":true},"system.state":{"Type":{"Kind":"string"},"Required":false}},"name":"Epic"}' -H localhost:8080 --pp
+./bin/alm-cli create workitemtype --key "GENERATED_TOKEN" --payload '{"extendedTypeName":null,"fields":{"system.owner":{"Type":{"Kind":"user"},"Required":true},"system.state":{"Type":{"Kind":"string"},"Required":false}},"name":"Epic"}' -H localhost:8080 --pp
 ----
 
 == Show newly created "Epic"
@@ -31,7 +33,7 @@ Should show you newly created item type:
 Create another item type:
 
 ----
-./bin/alm-cli create workitemtype --payload '{"extendedTypeName":null,"fields":{"system.owner":{"Type":{"Kind":"user"},"Required":true},"system.duration":{"Type":{"Kind":"integer"},"Required":false}},"name":"Issue"}' -H localhost:8080 --pp
+./bin/alm-cli create workitemtype --key "GENERATED_TOKEN" --payload '{"extendedTypeName":null,"fields":{"system.owner":{"Type":{"Kind":"user"},"Required":true},"system.duration":{"Type":{"Kind":"integer"},"Required":false}},"name":"Issue"}' -H localhost:8080 --pp
 ----
 
 Retrieve newly created `Issue` work item type:
@@ -45,7 +47,7 @@ Should fail - create item type based on pre-existing item type because `system.s
 (The `system.state` must not be of type `float` but of type `string`.)
 
 ----
-./bin/alm-cli create workitemtype --payload '{"extendedTypeName":"Epic","fields":{"system.owner":{"Type":{"Kind":"user"},"Required":true},"system.state":{"Type":{"Kind":"float"},"Required":false}},"name":"anotherEpic"}' -H localhost:8080 --pp
+./bin/alm-cli create workitemtype --key "GENERATED_TOKEN" --payload '{"extendedTypeName":"Epic","fields":{"system.owner":{"Type":{"Kind":"user"},"Required":true},"system.state":{"Type":{"Kind":"float"},"Required":false}},"name":"anotherEpic"}' -H localhost:8080 --pp
 ----
 
 Should create item type based on pre-existing item type:
@@ -53,7 +55,7 @@ Should create item type based on pre-existing item type:
 (Now `system.state` has the correct type of `string`.)
 
 ----
-./bin/alm-cli create workitemtype --payload '{"extendedTypeName":"Epic","fields":{"system.owner":{"Type":{"Kind":"user"},"Required":true},"system.state":{"Type":{"Kind":"string"},"Required":false}},"name":"anotherEpic"}' -H localhost:8080 --pp
+./bin/alm-cli create workitemtype --key "GENERATED_TOKEN" --payload '{"extendedTypeName":"Epic","fields":{"system.owner":{"Type":{"Kind":"user"},"Required":true},"system.state":{"Type":{"Kind":"string"},"Required":false}},"name":"anotherEpic"}' -H localhost:8080 --pp
 ----
 
 == List all work item types that we created


### PR DESCRIPTION
POST APIs now need to use Authorization Header, same is mentioned in the examples in the documentation.

Fixes #389 