### PR TITLE
Remove dot-imports of goa design and design/apidsl packages

### DIFF
--- a/design/api.go
+++ b/design/api.go
@@ -1,43 +1,43 @@
 package design
 
 import (
-	. "github.com/goadesign/goa/design"
-	. "github.com/goadesign/goa/design/apidsl"
+	d "github.com/goadesign/goa/design"
+	a "github.com/goadesign/goa/design/apidsl"
 )
 
-var _ = API("alm", func() {
-	Title("ALMighty: One to rule them all")
-	Description("The next big thing")
-	Version("1.0")
-	Host("almighty.io")
-	Scheme("http")
-	BasePath("/api")
-	Consumes("application/json")
-	Produces("application/json")
+var _ = a.API("alm", func() {
+	a.Title("ALMighty: One to rule them all")
+	a.Description("The next big thing")
+	a.Version("1.0")
+	a.Host("almighty.io")
+	a.Scheme("http")
+	a.BasePath("/api")
+	a.Consumes("application/json")
+	a.Produces("application/json")
 
-	License(func() {
-		Name("Apache License Version 2.0")
-		URL("http://www.apache.org/licenses/LICENSE-2.0")
+	a.License(func() {
+		a.Name("Apache License Version 2.0")
+		a.URL("http://www.apache.org/licenses/LICENSE-2.0")
 	})
-	Origin("/[.*almighty.io|localhost]/", func() {
-		Methods("GET", "POST", "PUT", "PATCH", "DELETE")
-		Headers("X-Request-Id", "Content-Type", "Authorization")
-		MaxAge(600)
-		Credentials()
-	})
-
-	JWTSecurity("jwt", func() {
-		Description("JWT Token Auth")
-		TokenURL("/api/login/authorize")
-		Header("Authorization")
+	a.Origin("/[.*almighty.io|localhost]/", func() {
+		a.Methods("GET", "POST", "PUT", "PATCH", "DELETE")
+		a.Headers("X-Request-Id", "Content-Type", "Authorization")
+		a.MaxAge(600)
+		a.Credentials()
 	})
 
-	ResponseTemplate(Created, func(pattern string) {
-		Description("Resource created")
-		Status(201)
-		Headers(func() {
-			Header("Location", String, "href to created resource", func() {
-				Pattern(pattern)
+	a.JWTSecurity("jwt", func() {
+		a.Description("JWT Token Auth")
+		a.TokenURL("/api/login/authorize")
+		a.Header("Authorization")
+	})
+
+	a.ResponseTemplate(d.Created, func(pattern string) {
+		a.Description("Resource created")
+		a.Status(201)
+		a.Headers(func() {
+			a.Header("Location", d.String, "href to created resource", func() {
+				a.Pattern(pattern)
 			})
 		})
 	})

--- a/design/media_types.go
+++ b/design/media_types.go
@@ -1,199 +1,200 @@
 package design
 
 import (
-	. "github.com/goadesign/goa/design"
-	. "github.com/goadesign/goa/design/apidsl"
+	d "github.com/goadesign/goa/design"
+	a "github.com/goadesign/goa/design/apidsl"
 )
 
 // ALMStatus defines the status of the current running ALM instance
-var ALMStatus = MediaType("application/vnd.status+json", func() {
-	Description("The status of the current running instance")
-	Attributes(func() {
-		Attribute("commit", String, "Commit SHA this build is based on")
-		Attribute("buildTime", String, "The time when built")
-		Attribute("startTime", String, "The time when started")
-		Attribute("error", String, "The error if any")
-		Required("commit", "buildTime", "startTime")
+var ALMStatus = a.MediaType("application/vnd.status+json", func() {
+	a.Description("The status of the current running instance")
+	a.Attributes(func() {
+		a.Attribute("commit", d.String, "Commit SHA this build is based on")
+		a.Attribute("buildTime", d.String, "The time when built")
+		a.Attribute("startTime", d.String, "The time when started")
+		a.Attribute("error", d.String, "The error if any")
+		a.Required("commit", "buildTime", "startTime")
 	})
-	View("default", func() {
-		Attribute("commit")
-		Attribute("buildTime")
-		Attribute("startTime")
-		Attribute("error")
+	a.View("default", func() {
+		a.Attribute("commit")
+		a.Attribute("buildTime")
+		a.Attribute("startTime")
+		a.Attribute("error")
 	})
 })
 
 // AuthToken represents an authentication JWT Token
-var AuthToken = MediaType("application/vnd.authtoken+json", func() {
-	TypeName("AuthToken")
-	Description("JWT Token")
-	Attributes(func() {
-		Attribute("token", String, "JWT Token")
-		Required("token")
+var AuthToken = a.MediaType("application/vnd.authtoken+json", func() {
+	a.TypeName("AuthToken")
+	a.Description("JWT Token")
+	a.Attributes(func() {
+		a.Attribute("token", d.String, "JWT Token")
+		a.Required("token")
 	})
-	View("default", func() {
-		Attribute("token")
+	a.View("default", func() {
+		a.Attribute("token")
 	})
 })
 
 // workItem is the media type for work items
-var workItem = MediaType("application/vnd.workitem+json", func() {
-	TypeName("WorkItem")
-	Description("A work item hold field values according to a given field type")
-	Attribute("id", String, "unique id per installation")
-	Attribute("version", Integer, "Version for optimistic concurrency control")
-	Attribute("type", String, "Name of the type of this work item")
-	Attribute("fields", HashOf(String, Any), "The field values, according to the field type")
+var workItem = a.MediaType("application/vnd.workitem+json", func() {
+	a.TypeName("WorkItem")
+	a.Description("A work item hold field values according to a given field type")
+	a.Attribute("id", d.String, "unique id per installation")
+	a.Attribute("version", d.Integer, "Version for optimistic concurrency control")
+	a.Attribute("type", d.String, "Name of the type of this work item")
+	a.Attribute("fields", a.HashOf(d.String, d.Any), "The field values, according to the field type")
 
-	Required("id")
-	Required("version")
-	Required("type")
-	Required("fields")
+	a.Required("id")
+	a.Required("version")
+	a.Required("type")
+	a.Required("fields")
 
-	View("default", func() {
-		Attribute("id")
-		Attribute("version")
-		Attribute("type")
-		Attribute("fields")
+	a.View("default", func() {
+		a.Attribute("id")
+		a.Attribute("version")
+		a.Attribute("type")
+		a.Attribute("fields")
 	})
 })
 
-var pagingLinks = Type("pagingLinks", func() {
-	Attribute("prev", String)
-	Attribute("next", String)
-	Attribute("first", String)
-	Attribute("last", String)
+var pagingLinks = a.Type("pagingLinks", func() {
+	a.Attribute("prev", d.String)
+	a.Attribute("next", d.String)
+	a.Attribute("first", d.String)
+	a.Attribute("last", d.String)
 })
 
-var meta = Type("workItemListResponseMeta", func() {
-	Attribute("totalCount", Number)
+var meta = a.Type("workItemListResponseMeta", func() {
+	a.Attribute("totalCount", d.Number)
 
-	Required("totalCount")
+	a.Required("totalCount")
 })
 
 // workItemListResponse contains paged results for listing work items and paging links
-var workItemListResponse = MediaType("application/vnd.workitemlist+json", func() {
-	TypeName("WorkItemListResponse")
-	Description("Holds the paginated response to a work item list request")
-	Attribute("links", pagingLinks)
-	Attribute("meta", meta)
-	Attribute("data", CollectionOf(workItem))
+var workItemListResponse = a.MediaType("application/vnd.workitemlist+json", func() {
+	a.TypeName("WorkItemListResponse")
+	a.Description("Holds the paginated response to a work item list request")
+	a.Attribute("links", pagingLinks)
+	a.Attribute("meta", meta)
+	a.Attribute("data", a.CollectionOf(workItem))
 
-	Required("links")
-	Required("meta")
-	Required("data")
+	a.Required("links")
+	a.Required("meta")
+	a.Required("data")
 
-	View("default", func() {
-		Attribute("links", func() {
-			Attribute("prev", String)
-			Attribute("next", String)
-			Attribute("first", String)
-			Attribute("last", String)
+	a.View("default", func() {
+		a.Attribute("links", func() {
+			a.Attribute("prev", d.String)
+			a.Attribute("next", d.String)
+			a.Attribute("first", d.String)
+			a.Attribute("last", d.String)
 		})
-		Attribute("meta", func() {
-			Attribute("totalCount", Number)
+		a.Attribute("meta", func() {
+			a.Attribute("totalCount", d.Number)
 		})
-		Attribute("data")
+		a.Attribute("data")
 	})
 })
 
 // fieldDefinition defines the possible values for a field in a work item type
-var fieldDefinition = Type("fieldDefinition", func() {
-	Description("A fieldDescription aggregates a fieldType and additional field metadata")
-	Attribute("required", Boolean)
-	Attribute("type", fieldType)
+var fieldDefinition = a.Type("fieldDefinition", func() {
+	a.Description("A fieldDescription aggregates a fieldType and additional field metadata")
+	a.Attribute("required", d.Boolean)
+	a.Attribute("type", fieldType)
 
-	Required("required")
-	Required("type")
+	a.Required("required")
+	a.Required("type")
 
-	View("default", func() {
-		Attribute("kind")
+	a.View("default", func() {
+		a.Attribute("kind")
 	})
 })
 
 // fieldType is the datatype of a single field in a work item tepy
-var fieldType = Type("fieldType", func() {
-	Description("A fieldType describes the values a particular field can hold")
-	Attribute("kind", String, "The constant indicating the kind of type, for example 'string' or 'enum' or 'instant'")
-	Attribute("componentType", String, "The kind of type of the individual elements for a list type. Required for list types. Must be a simple type, not  enum or list")
-	Attribute("baseType", String, "The kind of type of the enumeration values for an enum type. Required for enum types. Must be a simple type, not  enum or list")
-	Attribute("values", ArrayOf(Any), "The possible values for an enum type. The values must be of a type convertible to the base type")
+var fieldType = a.Type("fieldType", func() {
+	a.Description("A fieldType describes the values a particular field can hold")
+	a.Attribute("kind", d.String, "The constant indicating the kind of type, for example 'string' or 'enum' or 'instant'")
+	a.Attribute("componentType", d.String, "The kind of type of the individual elements for a list type. Required for list types. Must be a simple type, not  enum or list")
+	a.Attribute("baseType", d.String, "The kind of type of the enumeration values for an enum type. Required for enum types. Must be a simple type, not  enum or list")
+	a.Attribute("values", a.ArrayOf(d.Any), "The possible values for an enum type. The values must be of a type convertible to the base type")
 
-	Required("kind")
+	a.Required("kind")
 })
 
 // workItemType is the media type representing a work item type.
-var workItemType = MediaType("application/vnd.workitemtype+json", func() {
-	TypeName("WorkItemType")
-	Description("A work item type describes the values a work item type instance can hold.")
-	Attribute("version", Integer, "Version for optimistic concurrency control")
-	Attribute("name", String, "User Readable Name of this item type")
-	Attribute("fields", HashOf(String, fieldDefinition), "Definitions of fields in this work item type")
+var workItemType = a.MediaType("application/vnd.workitemtype+json", func() {
+	a.TypeName("WorkItemType")
+	a.Description("A work item type describes the values a work item type instance can hold.")
+	a.Attribute("version", d.Integer, "Version for optimistic concurrency control")
+	a.Attribute("name", d.String, "User Readable Name of this item type")
+	a.Attribute("fields", a.HashOf(d.String, fieldDefinition), "Definitions of fields in this work item type")
 
-	Required("version")
-	Required("name")
-	Required("fields")
+	a.Required("version")
+	a.Required("name")
+	a.Required("fields")
 
-	View("default", func() {
-		Attribute("version")
-		Attribute("name")
-		Attribute("fields")
+	a.View("default", func() {
+		a.Attribute("version")
+		a.Attribute("name")
+		a.Attribute("fields")
 	})
-	View("link", func() {
-		Attribute("name")
+	a.View("link", func() {
+		a.Attribute("name")
 	})
 
 })
 
 // Tracker configuration
-var Tracker = MediaType("application/vnd.tracker+json", func() {
-	TypeName("Tracker")
-	Description("Tracker configuration")
-	Attribute("id", String, "unique id per tracker")
-	Attribute("url", String, "URL of the tracker")
-	Attribute("type", String, "Type of the tracker")
+var Tracker = a.MediaType("application/vnd.tracker+json", func() {
+	a.TypeName("Tracker")
+	a.Description("Tracker configuration")
+	a.Attribute("id", d.String, "unique id per tracker")
+	a.Attribute("url", d.String, "URL of the tracker")
+	a.Attribute("type", d.String, "Type of the tracker")
 
-	Required("id")
-	Required("url")
-	Required("type")
+	a.Required("id")
+	a.Required("url")
+	a.Required("type")
 
-	View("default", func() {
-		Attribute("id")
-		Attribute("url")
-		Attribute("type")
+	a.View("default", func() {
+		a.Attribute("id")
+		a.Attribute("url")
+		a.Attribute("type")
 	})
 })
 
 // TrackerQuery represents the search query with schedule
-var TrackerQuery = MediaType("application/vnd.trackerquery+json", func() {
-	TypeName("TrackerQuery")
-	Description("Tracker query with schedule")
-	Attribute("id", String, "unique id per installation")
-	Attribute("query", String, "Search query")
-	Attribute("schedule", String, "Schedule for fetch and import")
-	Attribute("trackerID", String, "Tracker ID")
+var TrackerQuery = a.MediaType("application/vnd.trackerquery+json", func() {
+	a.TypeName("TrackerQuery")
+	a.Description("Tracker query with schedule")
+	a.Attribute("id", d.String, "unique id per installation")
+	a.Attribute("query", d.String, "Search query")
+	a.Attribute("schedule", d.String, "Schedule for fetch and import")
+	a.Attribute("trackerID", d.String, "Tracker ID")
 
-	Required("id")
-	Required("query")
-	Required("schedule")
-	Required("trackerID")
+	a.Required("id")
+	a.Required("query")
+	a.Required("schedule")
+	a.Required("trackerID")
 
-	View("default", func() {
-		Attribute("id")
-		Attribute("query")
-		Attribute("schedule")
-		Attribute("trackerID")
+	a.View("default", func() {
+		a.Attribute("id")
+		a.Attribute("query")
+		a.Attribute("schedule")
+		a.Attribute("trackerID")
 	})
 })
 
-var User = MediaType("application/vnd.user+json", func() {
-	TypeName("User")
-	Description("ALM User")
-	Attribute("fullName", String, "The users full name")
-	Attribute("imageURL", String, "The avatar image for the user")
+// User represents a user object (TODO: add better description)
+var User = a.MediaType("application/vnd.user+json", func() {
+	a.TypeName("User")
+	a.Description("ALM User")
+	a.Attribute("fullName", d.String, "The users full name")
+	a.Attribute("imageURL", d.String, "The avatar image for the user")
 
-	View("default", func() {
-		Attribute("fullName")
-		Attribute("imageURL")
+	a.View("default", func() {
+		a.Attribute("fullName")
+		a.Attribute("imageURL")
 	})
 })

--- a/design/resources.go
+++ b/design/resources.go
@@ -1,381 +1,381 @@
 package design
 
 import (
-	. "github.com/goadesign/goa/design"
-	. "github.com/goadesign/goa/design/apidsl"
+	d "github.com/goadesign/goa/design"
+	a "github.com/goadesign/goa/design/apidsl"
 )
 
-var _ = Resource("workitem", func() {
-	BasePath("/workitems")
+var _ = a.Resource("workitem", func() {
+	a.BasePath("/workitems")
 
-	Action("show", func() {
-		Routing(
-			GET("/:id"),
+	a.Action("show", func() {
+		a.Routing(
+			a.GET("/:id"),
 		)
-		Description("Retrieve work item with given id.")
-		Params(func() {
-			Param("id", String, "id")
+		a.Description("Retrieve work item with given id.")
+		a.Params(func() {
+			a.Param("id", d.String, "id")
 		})
-		Response(OK, func() {
-			Media(workItem)
+		a.Response(d.OK, func() {
+			a.Media(workItem)
 		})
-		Response(BadRequest, func() {
-			Media(ErrorMedia)
+		a.Response(d.BadRequest, func() {
+			a.Media(d.ErrorMedia)
 		})
-		Response(InternalServerError)
-		Response(NotFound)
-	})
-
-	Action("list", func() {
-		Routing(
-			GET(""),
-		)
-		Description("List work items.")
-		Params(func() {
-			Param("filter", String, "a query language expression restricting the set of found work items")
-			Param("page", String, "Paging in the format <start>,<limit>")
-		})
-		Response(OK, func() {
-			Media(CollectionOf(workItem))
-		})
-		Response(BadRequest, func() {
-			Media(ErrorMedia)
-		})
-		Response(InternalServerError)
+		a.Response(d.InternalServerError)
+		a.Response(d.NotFound)
 	})
 
-	Action("create", func() {
-		Security("jwt")
-		Routing(
-			POST(""),
+	a.Action("list", func() {
+		a.Routing(
+			a.GET(""),
 		)
-		Description("create work item with type and id.")
-		Payload(CreateWorkItemPayload)
-		Response(Created, "/workitems/.*", func() {
-			Media(workItem)
+		a.Description("List work items.")
+		a.Params(func() {
+			a.Param("filter", d.String, "a query language expression restricting the set of found work items")
+			a.Param("page", d.String, "Paging in the format <start>,<limit>")
 		})
-		Response(BadRequest, func() {
-			Media(ErrorMedia)
+		a.Response(d.OK, func() {
+			a.Media(a.CollectionOf(workItem))
 		})
-		Response(InternalServerError)
-		Response(Unauthorized)
+		a.Response(d.BadRequest, func() {
+			a.Media(d.ErrorMedia)
+		})
+		a.Response(d.InternalServerError)
 	})
-	Action("delete", func() {
-		Security("jwt")
-		Routing(
-			DELETE("/:id"),
+
+	a.Action("create", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.POST(""),
 		)
-		Description("Delete work item with given id.")
-		Params(func() {
-			Param("id", String, "id")
+		a.Description("create work item with type and id.")
+		a.Payload(CreateWorkItemPayload)
+		a.Response(d.Created, "/workitems/.*", func() {
+			a.Media(workItem)
 		})
-		Response(OK)
-		Response(BadRequest, func() {
-			Media(ErrorMedia)
+		a.Response(d.BadRequest, func() {
+			a.Media(d.ErrorMedia)
 		})
-		Response(InternalServerError)
-		Response(NotFound)
-		Response(Unauthorized)
+		a.Response(d.InternalServerError)
+		a.Response(d.Unauthorized)
 	})
-	Action("update", func() {
-		Security("jwt")
-		Routing(
-			PUT("/:id"),
+	a.Action("delete", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.DELETE("/:id"),
 		)
-		Description("update the given work item with given id.")
-		Params(func() {
-			Param("id", String, "id")
+		a.Description("Delete work item with given id.")
+		a.Params(func() {
+			a.Param("id", d.String, "id")
 		})
-		Payload(UpdateWorkItemPayload)
-		Response(OK, func() {
-			Media(workItem)
+		a.Response(d.OK)
+		a.Response(d.BadRequest, func() {
+			a.Media(d.ErrorMedia)
 		})
-		Response(BadRequest, func() {
-			Media(ErrorMedia)
+		a.Response(d.InternalServerError)
+		a.Response(d.NotFound)
+		a.Response(d.Unauthorized)
+	})
+	a.Action("update", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.PUT("/:id"),
+		)
+		a.Description("update the given work item with given id.")
+		a.Params(func() {
+			a.Param("id", d.String, "id")
 		})
-		Response(InternalServerError)
-		Response(NotFound)
-		Response(Unauthorized)
+		a.Payload(UpdateWorkItemPayload)
+		a.Response(d.OK, func() {
+			a.Media(workItem)
+		})
+		a.Response(d.BadRequest, func() {
+			a.Media(d.ErrorMedia)
+		})
+		a.Response(d.InternalServerError)
+		a.Response(d.NotFound)
+		a.Response(d.Unauthorized)
 	})
 
 })
 
 // new version of "list" for migration
-var _ = Resource("workitem.2", func() {
-	BasePath("/workitems.2")
-	Action("list", func() {
-		Routing(
-			GET(""),
+var _ = a.Resource("workitem.2", func() {
+	a.BasePath("/workitems.2")
+	a.Action("list", func() {
+		a.Routing(
+			a.GET(""),
 		)
-		Description("List work items.")
-		Params(func() {
-			Param("filter", String, "a query language expression restricting the set of found work items")
-			Param("page[offset]", Number, "Paging in the format <start>,<limit>")
-			Param("page[limit]", Number, "Paging in the format <start>,<limit>")
+		a.Description("List work items.")
+		a.Params(func() {
+			a.Param("filter", d.String, "a query language expression restricting the set of found work items")
+			a.Param("page[offset]", d.Number, "Paging in the format <start>,<limit>")
+			a.Param("page[limit]", d.Number, "Paging in the format <start>,<limit>")
 		})
-		Response(OK, func() {
-			Media(workItemListResponse)
+		a.Response(d.OK, func() {
+			a.Media(workItemListResponse)
 		})
-		Response(BadRequest, func() {
-			Media(ErrorMedia)
+		a.Response(d.BadRequest, func() {
+			a.Media(d.ErrorMedia)
 		})
-		Response(InternalServerError)
+		a.Response(d.InternalServerError)
 	})
 
 })
 
-var _ = Resource("workitemtype", func() {
+var _ = a.Resource("workitemtype", func() {
 
-	BasePath("/workitemtypes")
+	a.BasePath("/workitemtypes")
 
-	Action("show", func() {
+	a.Action("show", func() {
 
-		Routing(
-			GET("/:name"),
+		a.Routing(
+			a.GET("/:name"),
 		)
-		Description("Retrieve work item type with given name.")
-		Params(func() {
-			Param("name", String, "name")
+		a.Description("Retrieve work item type with given name.")
+		a.Params(func() {
+			a.Param("name", d.String, "name")
 		})
-		Response(OK, func() {
-			Media(workItemType)
+		a.Response(d.OK, func() {
+			a.Media(workItemType)
 		})
-		Response(NotFound)
+		a.Response(d.NotFound)
 	})
 
-	Action("create", func() {
-		Security("jwt")
-		Routing(
-			POST(""),
+	a.Action("create", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.POST(""),
 		)
-		Description("Create work item type.")
-		Payload(CreateWorkItemTypePayload)
-		Response(Created, "/workitemtypes/.*", func() {
-			Media(workItemType)
+		a.Description("Create work item type.")
+		a.Payload(CreateWorkItemTypePayload)
+		a.Response(d.Created, "/workitemtypes/.*", func() {
+			a.Media(workItemType)
 		})
-		Response(BadRequest, func() {
-			Media(ErrorMedia)
+		a.Response(d.BadRequest, func() {
+			a.Media(d.ErrorMedia)
 		})
-		Response(InternalServerError)
-		Response(Unauthorized)
+		a.Response(d.InternalServerError)
+		a.Response(d.Unauthorized)
 	})
 
-	Action("list", func() {
-		Routing(
-			GET(""),
+	a.Action("list", func() {
+		a.Routing(
+			a.GET(""),
 		)
-		Description("List work item types.")
-		Params(func() {
-			Param("page", String, "Paging in the format <start>,<limit>")
+		a.Description("List work item types.")
+		a.Params(func() {
+			a.Param("page", d.String, "Paging in the format <start>,<limit>")
 		})
-		Response(OK, func() {
-			Media(CollectionOf(workItemType))
+		a.Response(d.OK, func() {
+			a.Media(a.CollectionOf(workItemType))
 		})
-		Response(BadRequest, func() {
-			Media(ErrorMedia)
+		a.Response(d.BadRequest, func() {
+			a.Media(d.ErrorMedia)
 		})
-		Response(InternalServerError)
-	})
-})
-
-var _ = Resource("user", func() {
-	BasePath("/user")
-
-	Action("show", func() {
-		Security("jwt")
-		Routing(
-			GET(""),
-		)
-		Description("Get the authenticated user")
-		Response(OK, func() {
-			Media(User)
-		})
-		Response(BadRequest, func() {
-			Media(ErrorMedia)
-		})
-		Response(InternalServerError)
-		Response(Unauthorized)
-	})
-
-})
-
-var _ = Resource("status", func() {
-
-	DefaultMedia(ALMStatus)
-	BasePath("/status")
-
-	Action("show", func() {
-		Routing(
-			GET(""),
-		)
-		Description("Show the status of the current running instance")
-		Response(OK)
-		Response(ServiceUnavailable, ALMStatus)
+		a.Response(d.InternalServerError)
 	})
 })
 
-var _ = Resource("login", func() {
+var _ = a.Resource("user", func() {
+	a.BasePath("/user")
 
-	BasePath("/login")
-
-	Action("authorize", func() {
-		Routing(
-			GET("authorize"),
+	a.Action("show", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.GET(""),
 		)
-		Description("Authorize with the ALM")
-		Response(Unauthorized)
-		Response(TemporaryRedirect)
-	})
-
-	Action("generate", func() {
-		Routing(
-			GET("generate"),
-		)
-		Description("Generates a set of Tokens for different Auth levels. NOT FOR PRODUCTION. Only available if server is running in dev mode")
-		Response(OK, func() {
-			Media(CollectionOf(AuthToken))
+		a.Description("Get the authenticated user")
+		a.Response(d.OK, func() {
+			a.Media(User)
 		})
-		Response(Unauthorized)
-	})
-})
-
-var _ = Resource("tracker", func() {
-	BasePath("/trackers")
-
-	Action("list", func() {
-		Routing(
-			GET(""),
-		)
-		Description("List all tracker configurations.")
-		Params(func() {
-			Param("filter", String, "a query language expression restricting the set of found items")
-			Param("page", String, "Paging in the format <start>,<limit>")
+		a.Response(d.BadRequest, func() {
+			a.Media(d.ErrorMedia)
 		})
-		Response(OK, func() {
-			Media(CollectionOf(Tracker))
-		})
-		Response(BadRequest, func() {
-			Media(ErrorMedia)
-		})
-		Response(InternalServerError)
-		Response(NotFound)
-	})
-
-	Action("show", func() {
-		Routing(
-			GET("/:id"),
-		)
-		Description("Retrieve tracker configuration for the given id.")
-		Params(func() {
-			Param("id", String, "id")
-		})
-		Response(OK, func() {
-			Media(Tracker)
-		})
-		Response(BadRequest, func() {
-			Media(ErrorMedia)
-		})
-		Response(InternalServerError)
-		Response(NotFound)
-	})
-
-	Action("create", func() {
-		Routing(
-			POST(""),
-		)
-		Description("Add new tracker configuration.")
-		Payload(CreateTrackerAlternatePayload)
-		Response(Created, "/trackers/.*", func() {
-			Media(Tracker)
-		})
-		Response(BadRequest, func() {
-			Media(ErrorMedia)
-		})
-		Response(InternalServerError)
-		Response(NotFound)
-	})
-	Action("delete", func() {
-		Routing(
-			DELETE("/:id"),
-		)
-		Description("Delete tracker configuration.")
-		Params(func() {
-			Param("id", String, "id")
-		})
-		Response(OK)
-		Response(BadRequest, func() {
-			Media(ErrorMedia)
-		})
-		Response(InternalServerError)
-		Response(NotFound)
-	})
-	Action("update", func() {
-		Routing(
-			PUT("/:id"),
-		)
-		Description("Update tracker configuration.")
-		Payload(UpdateTrackerAlternatePayload)
-		Response(OK, func() {
-			Media(Tracker)
-		})
-		Response(BadRequest, func() {
-			Media(ErrorMedia)
-		})
-		Response(InternalServerError)
-		Response(NotFound)
+		a.Response(d.InternalServerError)
+		a.Response(d.Unauthorized)
 	})
 
 })
 
-var _ = Resource("trackerquery", func() {
-	BasePath("/trackerqueries")
-	Action("show", func() {
-		Routing(
-			GET("/:id"),
+var _ = a.Resource("status", func() {
+
+	a.DefaultMedia(ALMStatus)
+	a.BasePath("/status")
+
+	a.Action("show", func() {
+		a.Routing(
+			a.GET(""),
 		)
-		Description("Retrieve tracker configuration for the given id.")
-		Params(func() {
-			Param("id", String, "id")
-		})
-		Response(OK, func() {
-			Media(TrackerQuery)
-		})
-		Response(BadRequest, func() {
-			Media(ErrorMedia)
-		})
-		Response(InternalServerError)
-		Response(NotFound)
+		a.Description("Show the status of the current running instance")
+		a.Response(d.OK)
+		a.Response(d.ServiceUnavailable, ALMStatus)
+	})
+})
+
+var _ = a.Resource("login", func() {
+
+	a.BasePath("/login")
+
+	a.Action("authorize", func() {
+		a.Routing(
+			a.GET("authorize"),
+		)
+		a.Description("Authorize with the ALM")
+		a.Response(d.Unauthorized)
+		a.Response(d.TemporaryRedirect)
 	})
 
-	Action("create", func() {
-		Routing(
-			POST(""),
+	a.Action("generate", func() {
+		a.Routing(
+			a.GET("generate"),
 		)
-		Description("Add new tracker query.")
-		Payload(CreateTrackerQueryAlternatePayload)
-		Response(Created, "/trackerqueries/.*", func() {
-			Media(TrackerQuery)
+		a.Description("Generates a set of Tokens for different Auth levels. NOT FOR PRODUCTION. Only available if server is running in dev mode")
+		a.Response(d.OK, func() {
+			a.Media(a.CollectionOf(AuthToken))
 		})
-		Response(BadRequest, func() {
-			Media(ErrorMedia)
-		})
-		Response(InternalServerError)
-		Response(NotFound)
+		a.Response(d.Unauthorized)
 	})
-	Action("update", func() {
-		Routing(
-			PUT("/:id"),
+})
+
+var _ = a.Resource("tracker", func() {
+	a.BasePath("/trackers")
+
+	a.Action("list", func() {
+		a.Routing(
+			a.GET(""),
 		)
-		Description("Update tracker query.")
-		Payload(UpdateTrackerQueryAlternatePayload)
-		Response(OK, func() {
-			Media(TrackerQuery)
+		a.Description("List all tracker configurations.")
+		a.Params(func() {
+			a.Param("filter", d.String, "a query language expression restricting the set of found items")
+			a.Param("page", d.String, "Paging in the format <start>,<limit>")
 		})
-		Response(BadRequest, func() {
-			Media(ErrorMedia)
+		a.Response(d.OK, func() {
+			a.Media(a.CollectionOf(Tracker))
 		})
-		Response(InternalServerError)
-		Response(NotFound)
+		a.Response(d.BadRequest, func() {
+			a.Media(d.ErrorMedia)
+		})
+		a.Response(d.InternalServerError)
+		a.Response(d.NotFound)
+	})
+
+	a.Action("show", func() {
+		a.Routing(
+			a.GET("/:id"),
+		)
+		a.Description("Retrieve tracker configuration for the given id.")
+		a.Params(func() {
+			a.Param("id", d.String, "id")
+		})
+		a.Response(d.OK, func() {
+			a.Media(Tracker)
+		})
+		a.Response(d.BadRequest, func() {
+			a.Media(d.ErrorMedia)
+		})
+		a.Response(d.InternalServerError)
+		a.Response(d.NotFound)
+	})
+
+	a.Action("create", func() {
+		a.Routing(
+			a.POST(""),
+		)
+		a.Description("Add new tracker configuration.")
+		a.Payload(CreateTrackerAlternatePayload)
+		a.Response(d.Created, "/trackers/.*", func() {
+			a.Media(Tracker)
+		})
+		a.Response(d.BadRequest, func() {
+			a.Media(d.ErrorMedia)
+		})
+		a.Response(d.InternalServerError)
+		a.Response(d.NotFound)
+	})
+	a.Action("delete", func() {
+		a.Routing(
+			a.DELETE("/:id"),
+		)
+		a.Description("Delete tracker configuration.")
+		a.Params(func() {
+			a.Param("id", d.String, "id")
+		})
+		a.Response(d.OK)
+		a.Response(d.BadRequest, func() {
+			a.Media(d.ErrorMedia)
+		})
+		a.Response(d.InternalServerError)
+		a.Response(d.NotFound)
+	})
+	a.Action("update", func() {
+		a.Routing(
+			a.PUT("/:id"),
+		)
+		a.Description("Update tracker configuration.")
+		a.Payload(UpdateTrackerAlternatePayload)
+		a.Response(d.OK, func() {
+			a.Media(Tracker)
+		})
+		a.Response(d.BadRequest, func() {
+			a.Media(d.ErrorMedia)
+		})
+		a.Response(d.InternalServerError)
+		a.Response(d.NotFound)
+	})
+
+})
+
+var _ = a.Resource("trackerquery", func() {
+	a.BasePath("/trackerqueries")
+	a.Action("show", func() {
+		a.Routing(
+			a.GET("/:id"),
+		)
+		a.Description("Retrieve tracker configuration for the given id.")
+		a.Params(func() {
+			a.Param("id", d.String, "id")
+		})
+		a.Response(d.OK, func() {
+			a.Media(TrackerQuery)
+		})
+		a.Response(d.BadRequest, func() {
+			a.Media(d.ErrorMedia)
+		})
+		a.Response(d.InternalServerError)
+		a.Response(d.NotFound)
+	})
+
+	a.Action("create", func() {
+		a.Routing(
+			a.POST(""),
+		)
+		a.Description("Add new tracker query.")
+		a.Payload(CreateTrackerQueryAlternatePayload)
+		a.Response(d.Created, "/trackerqueries/.*", func() {
+			a.Media(TrackerQuery)
+		})
+		a.Response(d.BadRequest, func() {
+			a.Media(d.ErrorMedia)
+		})
+		a.Response(d.InternalServerError)
+		a.Response(d.NotFound)
+	})
+	a.Action("update", func() {
+		a.Routing(
+			a.PUT("/:id"),
+		)
+		a.Description("Update tracker query.")
+		a.Payload(UpdateTrackerQueryAlternatePayload)
+		a.Response(d.OK, func() {
+			a.Media(TrackerQuery)
+		})
+		a.Response(d.BadRequest, func() {
+			a.Media(d.ErrorMedia)
+		})
+		a.Response(d.InternalServerError)
+		a.Response(d.NotFound)
 	})
 
 })

--- a/design/user_types.go
+++ b/design/user_types.go
@@ -1,44 +1,44 @@
 package design
 
 import (
-	. "github.com/goadesign/goa/design"
-	. "github.com/goadesign/goa/design/apidsl"
+	d "github.com/goadesign/goa/design"
+	a "github.com/goadesign/goa/design/apidsl"
 )
 
 // CreateWorkItemPayload defines the structure of work item payload
-var CreateWorkItemPayload = Type("CreateWorkItemPayload", func() {
-	Attribute("type", String, "The type of the newly created work item", func() {
-		Example("system.userstory")
+var CreateWorkItemPayload = a.Type("CreateWorkItemPayload", func() {
+	a.Attribute("type", d.String, "The type of the newly created work item", func() {
+		a.Example("system.userstory")
 	})
-	Attribute("fields", HashOf(String, Any), "The field values, must conform to the type", func() {
-		Example(map[string]interface{}{"system.creator": "user-ref", "system.state": "new", "system.title": "Example story"})
+	a.Attribute("fields", a.HashOf(d.String, d.Any), "The field values, must conform to the type", func() {
+		a.Example(map[string]interface{}{"system.creator": "user-ref", "system.state": "new", "system.title": "Example story"})
 	})
-	Required("type", "fields")
+	a.Required("type", "fields")
 })
 
 // UpdateWorkItemPayload has been added because the design.WorkItem could
 // not be used since it mandated the presence of the ID in the payload
 // which ideally should be optional. The ID should be passed on to REST URL.
-var UpdateWorkItemPayload = Type("UpdateWorkItemPayload", func() {
-	Attribute("type", String, "The type of the newly created work item", func() {
-		Example("system.userstory")
+var UpdateWorkItemPayload = a.Type("UpdateWorkItemPayload", func() {
+	a.Attribute("type", d.String, "The type of the newly created work item", func() {
+		a.Example("system.userstory")
 	})
-	Attribute("fields", HashOf(String, Any), "The field values, must conform to the type", func() {
-		Example(map[string]interface{}{"system.creator": "user-ref", "system.state": "new", "system.title": "Example story"})
+	a.Attribute("fields", a.HashOf(d.String, d.Any), "The field values, must conform to the type", func() {
+		a.Example(map[string]interface{}{"system.creator": "user-ref", "system.state": "new", "system.title": "Example story"})
 	})
-	Attribute("version", Integer, "Version for optimistic concurrency control", func() {
-		Example(0)
+	a.Attribute("version", d.Integer, "Version for optimistic concurrency control", func() {
+		a.Example(0)
 	})
-	Required("type", "fields", "version")
+	a.Required("type", "fields", "version")
 })
 
 // CreateWorkItemTypePayload explains how input payload should look like
-var CreateWorkItemTypePayload = Type("CreateWorkItemTypePayload", func() {
-	Attribute("name", String, "Readable name of the type like Task, Issue, Bug, Epic etc.", func() {
-		Example("Epic")
+var CreateWorkItemTypePayload = a.Type("CreateWorkItemTypePayload", func() {
+	a.Attribute("name", d.String, "Readable name of the type like Task, Issue, Bug, Epic etc.", func() {
+		a.Example("Epic")
 	})
-	Attribute("fields", HashOf(String, fieldDefinition), "Type fields those must be followed by respective Work Items.", func() {
-		Example(map[string]interface{}{
+	a.Attribute("fields", a.HashOf(d.String, fieldDefinition), "Type fields those must be followed by respective Work Items.", func() {
+		a.Example(map[string]interface{}{
 			"system.administrator": map[string]interface{}{
 				"Type": map[string]interface{}{
 					"Kind": "string",
@@ -47,58 +47,58 @@ var CreateWorkItemTypePayload = Type("CreateWorkItemTypePayload", func() {
 			},
 		})
 	})
-	Attribute("extendedTypeName", String, "If newly created type extends any existing type", func() {
-		Example("(optional field)Parent type name")
+	a.Attribute("extendedTypeName", d.String, "If newly created type extends any existing type", func() {
+		a.Example("(optional field)Parent type name")
 	})
-	Required("name", "fields")
+	a.Required("name", "fields")
 })
 
 // CreateTrackerAlternatePayload defines the structure of tracker payload for create
-var CreateTrackerAlternatePayload = Type("CreateTrackerAlternatePayload", func() {
-	Attribute("url", String, "URL of the tracker", func() {
-		Example("https://api.github.com/")
+var CreateTrackerAlternatePayload = a.Type("CreateTrackerAlternatePayload", func() {
+	a.Attribute("url", d.String, "URL of the tracker", func() {
+		a.Example("https://api.github.com/")
 	})
-	Attribute("type", String, "Type of the tracker", func() {
-		Example("github")
+	a.Attribute("type", d.String, "Type of the tracker", func() {
+		a.Example("github")
 	})
-	Required("url", "type")
+	a.Required("url", "type")
 })
 
 // UpdateTrackerAlternatePayload defines the structure of tracker payload for update
-var UpdateTrackerAlternatePayload = Type("UpdateTrackerAlternatePayload", func() {
-	Attribute("url", String, "URL of the tracker", func() {
-		Example("https://api.github.com/")
+var UpdateTrackerAlternatePayload = a.Type("UpdateTrackerAlternatePayload", func() {
+	a.Attribute("url", d.String, "URL of the tracker", func() {
+		a.Example("https://api.github.com/")
 	})
-	Attribute("type", String, "Type of the tracker", func() {
-		Example("github")
+	a.Attribute("type", d.String, "Type of the tracker", func() {
+		a.Example("github")
 	})
-	Required("url", "type")
+	a.Required("url", "type")
 })
 
 // CreateTrackerQueryAlternatePayload defines the structure of tracker query payload for create
-var CreateTrackerQueryAlternatePayload = Type("CreateTrackerQueryAlternatePayload", func() {
-	Attribute("query", String, "Search query", func() {
-		Example("is:open is:issue user:almighty")
+var CreateTrackerQueryAlternatePayload = a.Type("CreateTrackerQueryAlternatePayload", func() {
+	a.Attribute("query", d.String, "Search query", func() {
+		a.Example("is:open is:issue user:almighty")
 	})
-	Attribute("schedule", String, "Schedule for fetch and import", func() {
-		Example("0 0/15 * * * *")
+	a.Attribute("schedule", d.String, "Schedule for fetch and import", func() {
+		a.Example("0 0/15 * * * *")
 	})
-	Attribute("trackerID", String, "Tracker ID", func() {
-		Example("1")
+	a.Attribute("trackerID", d.String, "Tracker ID", func() {
+		a.Example("1")
 	})
-	Required("query", "schedule", "trackerID")
+	a.Required("query", "schedule", "trackerID")
 })
 
 // UpdateTrackerQueryAlternatePayload defines the structure of tracker query payload for update
-var UpdateTrackerQueryAlternatePayload = Type("UpdateTrackerQueryAlternatePayload", func() {
-	Attribute("query", String, "Search query", func() {
-		Example("is:open is:issue user:almighty")
+var UpdateTrackerQueryAlternatePayload = a.Type("UpdateTrackerQueryAlternatePayload", func() {
+	a.Attribute("query", d.String, "Search query", func() {
+		a.Example("is:open is:issue user:almighty")
 	})
-	Attribute("schedule", String, "Schedule for fetch and import", func() {
-		Example("0 0/15 * * * *")
+	a.Attribute("schedule", d.String, "Schedule for fetch and import", func() {
+		a.Example("0 0/15 * * * *")
 	})
-	Attribute("trackerID", String, "Tracker ID", func() {
-		Example("1")
+	a.Attribute("trackerID", d.String, "Tracker ID", func() {
+		a.Example("1")
 	})
-	Required("query", "schedule", "trackerID")
+	a.Required("query", "schedule", "trackerID")
 })


### PR DESCRIPTION
**To be clear upfront: I'm NOT removing the dot-imports simply because
there's some warning about good Go practices on imports!**

I found that no editor could autocomplete or jump to the definition of
any of the words in the modified files. Being sick of jumping to the
online reference of GOA, I decided to take the bumpy road and live with
a DSL that looks a little bit less readable than with the dot-import.

The benefit is, that we get auto-completion and can jump to the definition
of all the GOA symbols now. Plus, we are informed about all other
errors one can make while writing GOA design files.

With migration to JSON API ahead of us we're in desperate need of
control over all files in the design folder.

@tsmaeder @aslakknutsen I'd be happy if you can approve this! Please unassign yourselves if you don't want to approve this.

I've done no code change except adding the package name `apidsl.` or `design.` to the calls to GOA parts. 
