### PR TITLE
Extract Common Fields in WIT's to Base Type

### DIFF
--- a/design/media_types.go
+++ b/design/media_types.go
@@ -111,7 +111,7 @@ var fieldDefinition = a.Type("fieldDefinition", func() {
 	})
 })
 
-// fieldType is the datatype of a single field in a work item tepy
+// fieldType is the datatype of a single field in a work item type
 var fieldType = a.Type("fieldType", func() {
 	a.Description("A fieldType describes the values a particular field can hold")
 	a.Attribute("kind", d.String, "The constant indicating the kind of type, for example 'string' or 'enum' or 'instant'")

--- a/design/media_types.go
+++ b/design/media_types.go
@@ -129,15 +129,18 @@ var workItemType = a.MediaType("application/vnd.workitemtype+json", func() {
 	a.Attribute("version", d.Integer, "Version for optimistic concurrency control")
 	a.Attribute("name", d.String, "User Readable Name of this item type")
 	a.Attribute("fields", a.HashOf(d.String, fieldDefinition), "Definitions of fields in this work item type")
+	a.Attribute("parentPath", d.String, "The names of the parent types separated with '/' or just '/' if no parents")
 
 	a.Required("version")
 	a.Required("name")
 	a.Required("fields")
+	a.Required("parentPath")
 
 	a.View("default", func() {
 		a.Attribute("version")
 		a.Attribute("name")
 		a.Attribute("fields")
+		a.Attribute("parentPath")
 	})
 	a.View("link", func() {
 		a.Attribute("name")

--- a/design/media_types.go
+++ b/design/media_types.go
@@ -129,18 +129,15 @@ var workItemType = a.MediaType("application/vnd.workitemtype+json", func() {
 	a.Attribute("version", d.Integer, "Version for optimistic concurrency control")
 	a.Attribute("name", d.String, "User Readable Name of this item type")
 	a.Attribute("fields", a.HashOf(d.String, fieldDefinition), "Definitions of fields in this work item type")
-	a.Attribute("parentPath", d.String, "The names of the parent types separated with '/' or just '/' if no parents")
 
 	a.Required("version")
 	a.Required("name")
 	a.Required("fields")
-	a.Required("parentPath")
 
 	a.View("default", func() {
 		a.Attribute("version")
 		a.Attribute("name")
 		a.Attribute("fields")
-		a.Attribute("parentPath")
 	})
 	a.View("link", func() {
 		a.Attribute("name")

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -285,12 +285,7 @@ func createOrUpdateType(typeName string, extendedTypeName *string, fields map[st
 			if err != nil {
 				return err
 			}
-			path = extendedWit.ParentPath
-			if path == "/" {
-				path = path + *extendedTypeName
-			} else {
-				path = path + "/" + *extendedTypeName
-			}
+			path = "/" + *extendedTypeName
 			//load fields from the extended type
 			err = loadFields(ctx, extendedWit, fields)
 			if err != nil {

--- a/models/workitemtype.go
+++ b/models/workitemtype.go
@@ -17,6 +17,9 @@ const (
 	SystemAssignee     = "system.assignee"
 	SystemCreator      = "system.creator"
 
+	// base item type with common fields for planner item types like userstory, experience, bug, feature, etc.
+	SystemPlannerItem = "system.planneritem"
+
 	SystemUserStory        = "system.userstory"
 	SystemValueProposition = "system.valueproposition"
 	SystemFundamental      = "system.fundamental"

--- a/models/workitemtype_repository.go
+++ b/models/workitemtype_repository.go
@@ -147,10 +147,9 @@ func compatibleFields(existing FieldDefinition, new FieldDefinition) bool {
 // converts from models to app representation
 func convertTypeFromModels(t *WorkItemType) app.WorkItemType {
 	var converted = app.WorkItemType{
-		Name:       t.Name,
-		Version:    t.Version,
-		Fields:     map[string]*app.FieldDefinition{},
-		ParentPath: t.ParentPath,
+		Name:    t.Name,
+		Version: t.Version,
+		Fields:  map[string]*app.FieldDefinition{},
 	}
 	for name, def := range t.Fields {
 		ct := convertFieldTypeFromModels(def.Type)

--- a/models/workitemtype_repository.go
+++ b/models/workitemtype_repository.go
@@ -73,7 +73,11 @@ func (r *GormWorkItemTypeRepository) Create(ctx context.Context, extendedTypeNam
 		for key, value := range extendedType.Fields {
 			allFields[key] = value
 		}
-		path = extendedType.ParentPath + "/" + extendedType.Name
+		if extendedType.ParentPath == "/" {
+			path = "/" + extendedType.Name
+		} else {
+			path = extendedType.ParentPath + "/" + extendedType.Name
+		}
 	}
 
 	// now process new fields, checking whether they are ok to add.
@@ -143,9 +147,10 @@ func compatibleFields(existing FieldDefinition, new FieldDefinition) bool {
 // converts from models to app representation
 func convertTypeFromModels(t *WorkItemType) app.WorkItemType {
 	var converted = app.WorkItemType{
-		Name:    t.Name,
-		Version: t.Version,
-		Fields:  map[string]*app.FieldDefinition{},
+		Name:       t.Name,
+		Version:    t.Version,
+		Fields:     map[string]*app.FieldDefinition{},
+		ParentPath: t.ParentPath,
 	}
 	for name, def := range t.Fields {
 		ct := convertFieldTypeFromModels(def.Type)


### PR DESCRIPTION
A new base type **system.planneritem** is created.
This base type has all common fields such as:
- system.remote_item_id
- system.title
- system.description
- system.state
- system.assignee
- system.creator

which are inherited via **extendedTypeName="system.planneritem"** by the default types when the types are created/updated:
- system.userstory
- system.valueproposition
- system.fundamental
- system.experience
- system.feature
- system.bug

Fixes #288

**TODO:**
- add some tests
