### PR TITLE
Use v1 branch of GOA

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9dfc8b8dc31f0ce495de5431d40c3ad9bc83fb21b358c00dc541b0a0bdd444da
-updated: 2016-10-17T01:11:50.617319377+02:00
+hash: dfb79a5282b1908b3ca2e8abe6e9c9132d2ff843ca60af27bc8a64125a8c2477
+updated: 2016-10-28T14:43:49.636800674+02:00
 imports:
 - name: bitbucket.org/pkg/inflect
   version: 8961c3750a47b8c0b3e118d52513b97adf85a7e8
@@ -18,12 +18,12 @@ imports:
 - name: github.com/dimfeld/httppath
   version: c8e499c3ef3c3e272ed8bdcc1ccf39f73c88debc
 - name: github.com/dimfeld/httptreemux
-  version: 4f42e68bc5bbcb4b4af4a7d811a1d5f4111be063
+  version: 5cb0ec25af2dd6a7d3718b5aa05dc48e192473bc
 - name: github.com/dnaeon/go-vcr
   version: 9d71b8a6df86e00127f96bc8dabc09856ab8afdb
   subpackages:
-  - cassette
   - recorder
+  - cassette
 - name: github.com/elazarl/go-bindata-assetfs
   version: 57eb5e1fc594ad4b0b1dbea7b286d299e0cb43c2
   subpackages:
@@ -31,7 +31,7 @@ imports:
 - name: github.com/fsnotify/fsnotify
   version: 629574ca2a5df945712d3079857300b5e4da0236
 - name: github.com/goadesign/goa
-  version: 114ecb88f11ee21dcb9130280b0a580ecf8f7569
+  version: ef268b43782720ba8e5b5474d529b3c88ca22173
   vcs: git
   subpackages:
   - client
@@ -191,7 +191,7 @@ imports:
   version: a83829b6f1293c91addabc89d0571c246397bbf4
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 2df174808ee097f90d259e432cc04442cf60be21
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ import:
 - package: github.com/dgrijalva/jwt-go
   version: ^3.0.0
 - package: github.com/goadesign/goa
-  version: 114ecb88f11ee21dcb9130280b0a580ecf8f7569
+  version: v1 
   vcs: git
   subpackages:
   - client


### PR DESCRIPTION
There's been a UUID issue that @aslakknutsen has fixed in his [PR](https://github.com/goadesign/goa/pull/841) in GOA: https://github.com/goadesign/goa/pull/841

This change makes sure we benefit of this change by using the v1 branch of GOA.

