### PR TITLE
Fix log message for not found WIT

### DIFF
--- a/workitemtype.go
+++ b/workitemtype.go
@@ -34,7 +34,7 @@ func (c *WorkitemtypeController) Show(ctx *app.ShowWorkitemtypeContext) error {
 		if err != nil {
 			switch err.(type) {
 			case models.NotFoundError:
-				log.Printf("not found, id=%s", ctx.Name)
+				log.Printf("not found, name=%s", ctx.Name)
 				return goa.ErrNotFound(err.Error())
 			default:
 				return err


### PR DESCRIPTION
A work item type (WIT) is not identified by it's ID but its name, hence
the log message needed to be changed.
