### PR TITLE
Pass parameter array as varargs

### DIFF
--- a/models/workitem_repository.go
+++ b/models/workitem_repository.go
@@ -159,8 +159,8 @@ func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, criteria c
 	}
 
 	log.Printf("executing query: '%s' with params %v", where, parameters)
-
-	db := r.db.Model(&WorkItem{}).Where(where, parameters)
+ 
+	db := r.db.Model(&WorkItem{}).Where(where, parameters...)
 	orgDB := db
 	if start != nil {
 		if *start < 0 {

--- a/models/workitemtype_repository.go
+++ b/models/workitemtype_repository.go
@@ -115,7 +115,7 @@ func (r *GormWorkItemTypeRepository) List(ctx context.Context, start *int, limit
 	var parameters []interface{}
 
 	var rows []WorkItemType
-	db := r.db.Where(where, parameters)
+	db := r.db.Where(where, parameters...)
 	if start != nil {
 		db = db.Offset(*start)
 	}

--- a/remoteworkitem/tracker_repository.go
+++ b/remoteworkitem/tracker_repository.go
@@ -78,7 +78,7 @@ func (r *GormTrackerRepository) List(ctx context.Context, criteria criteria.Expr
 	log.Printf("executing query: %s", where)
 
 	var rows []Tracker
-	db := r.db.Where(where, parameters)
+	db := r.db.Where(where, parameters...)
 	if start != nil {
 		db = db.Offset(*start)
 	}


### PR DESCRIPTION
Pass "Where" paramters as a varargs instead of array.
Fix for #418 

