### PR TITLE
Expose ConversionError type using exported method

### DIFF
--- a/models/errors.go
+++ b/models/errors.go
@@ -2,9 +2,9 @@ package models
 
 import "fmt"
 
-const(
+const (
 	stBadParameterErrorMsg = "Bad value for parameter '%s': '%v'"
-	stNotFoundErrorMsg = "%s with id '%s' not found"
+	stNotFoundErrorMsg     = "%s with id '%s' not found"
 )
 
 type simpleError struct {
@@ -15,14 +15,10 @@ func (err simpleError) Error() string {
 	return err.message
 }
 
-func NewSimpleError(msg string) simpleError {
-	return simpleError{message: msg}
-}
-
+// NewInternalError returns the custom defined error of type NewInternalError.
 func NewInternalError(msg string) InternalError {
-	return InternalError{simpleError: NewSimpleError(msg)}
+	return InternalError{simpleError{msg}}
 }
-
 
 // InternalError means that the operation failed for some internal, unexpected reason
 type InternalError struct {
@@ -43,6 +39,11 @@ type BadParameterError struct {
 // Error implements the error interface
 func (err BadParameterError) Error() string {
 	return fmt.Sprintf(stBadParameterErrorMsg, err.parameter, err.value)
+}
+
+// NewConversionError returns the custom defined error of type NewConversionError.
+func NewConversionError(msg string) ConversionError {
+	return ConversionError{simpleError{msg}}
 }
 
 // ConversionError error means something went wrong converting between different representations

--- a/models/errors_blackbox_test.go
+++ b/models/errors_blackbox_test.go
@@ -7,19 +7,19 @@ import (
 	"github.com/almighty/almighty-core/resource"
 )
 
-func TestNewSimpleError(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-	err := models.NewSimpleError("Error reading database values")
-
-	// not sure what assertion to do here
-	t.Log(err)
-}
-
 func TestNewInternalError(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
 	err := models.NewInternalError("System disk could not be read")
+
+	// not sure what assertion to do here.
+	t.Log(err)
+}
+
+func TestNewConversionError(t *testing.T) {
+	t.Parallel()
+	resource.Require(t, resource.UnitTest)
+	err := models.NewConversionError("Couldn't convert workitem")
 
 	// not sure what assertion to do here.
 	t.Log(err)


### PR DESCRIPTION
Why:
All the exported error types in models/errors.go depend on models.simpleError type which is non-exported and therefore the exported error types are not usable unless invoked from the same package or if the errors.go is copied over the other specific package.

What:
Added method to access the non-exported methods.

This is an additional sub-task which was missed when https://github.com/almighty/almighty-core/commit/bf4f6bc40233a2311220e7266d078fb9b20d7699 when merged.

Fixes #309