### PR TITLE
Export NotFoundError and BadParameter error

### DIFF
--- a/models/errors.go
+++ b/models/errors.go
@@ -41,6 +41,11 @@ func (err BadParameterError) Error() string {
 	return fmt.Sprintf(stBadParameterErrorMsg, err.parameter, err.value)
 }
 
+// NewBadParameterError returns the custom defined error of type NewBadParameterError.
+func NewBadParameterError(param string, value interface{}) BadParameterError {
+	return BadParameterError{parameter: param, value: value}
+}
+
 // NewConversionError returns the custom defined error of type NewConversionError.
 func NewConversionError(msg string) ConversionError {
 	return ConversionError{simpleError{msg}}
@@ -59,4 +64,9 @@ type NotFoundError struct {
 
 func (err NotFoundError) Error() string {
 	return fmt.Sprintf(stNotFoundErrorMsg, err.entity, err.ID)
+}
+
+// NewNotFoundError returns the custom defined error of type NewNotFoundError.
+func NewNotFoundError(entity string, id string) NotFoundError {
+	return NotFoundError{entity: entity, ID: id}
 }

--- a/models/errors_blackbox_test.go
+++ b/models/errors_blackbox_test.go
@@ -1,10 +1,12 @@
 package models_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/resource"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewInternalError(t *testing.T) {
@@ -23,4 +25,23 @@ func TestNewConversionError(t *testing.T) {
 
 	// not sure what assertion to do here.
 	t.Log(err)
+}
+
+func TestNewBadParameterError(t *testing.T) {
+	t.Parallel()
+	resource.Require(t, resource.UnitTest)
+	param := "assigness"
+	value := 10
+	err := models.NewBadParameterError(param, value)
+	assert.Equal(t, fmt.Sprintf("Bad value for parameter '%s': '%v'", param, value), err.Error())
+
+}
+
+func TestNewNotFoundError(t *testing.T) {
+	t.Parallel()
+	resource.Require(t, resource.UnitTest)
+	param := "assigness"
+	value := "10"
+	err := models.NewNotFoundError(param, value)
+	assert.Equal(t, fmt.Sprintf("%s with id '%s' not found", param, value), err.Error())
 }


### PR DESCRIPTION
Why?: so that its usable from other packages.

What?: Added a exported method which returns the error type

fixes #444