### PR TITLE
Fixes #454 (fix for searching on un-registered url:port)

### DIFF
--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -230,6 +230,7 @@ func parseSearchString(rawSearchString string) searchKeyword {
 			searchQueryFromURL := getSearchQueryFromURLString(part)
 			res.words = append(res.words, searchQueryFromURL)
 		} else {
+			part = sanitizeURL(part)
 			res.words = append(res.words, part+":*")
 		}
 	}

--- a/search_blackbox_test.go
+++ b/search_blackbox_test.go
@@ -172,3 +172,27 @@ func TestUnregisteredURLWithPort(t *testing.T) {
 	assert.Equal(t, expectedDescription, r.Fields[models.SystemDescription])
 	test.DeleteWorkitemOK(t, nil, nil, wiController, wiResult.ID)
 }
+
+func TestUnwantedCharactersRelatedToSearchLogic(t *testing.T) {
+	resource.Require(t, resource.Database)
+	service := getServiceAsUser()
+	wiController := NewWorkitemController(service, gormapplication.NewGormDB(DB))
+	expectedDescription := "Related to http://example-domain:8080/different-path/ok issue"
+	wiPayload := app.CreateWorkItemPayload{
+		Type: models.SystemBug,
+		Fields: map[string]interface{}{
+			models.SystemTitle:       "specialwordforsearch_new",
+			models.SystemDescription: expectedDescription,
+			models.SystemCreator:     "baijum",
+			models.SystemState:       "closed"},
+	}
+
+	_, wiResult := test.CreateWorkitemCreated(t, service.Context, service, wiController, &wiPayload)
+
+	controller := NewSearchController(service, gormapplication.NewGormDB(DB))
+	// add url: in the query, that is not expected by the code hence need to make sure it gives expected result.
+	q := `http://url:some-random-other-domain:8080/different-path/`
+	_, sr := test.ShowSearchOK(t, nil, nil, controller, nil, nil, q)
+	assert.Equal(t, 0, len(sr.Data))
+	test.DeleteWorkitemOK(t, nil, nil, wiController, wiResult.ID)
+}

--- a/search_blackbox_test.go
+++ b/search_blackbox_test.go
@@ -147,3 +147,28 @@ func TestSearchURLWithoutPort(t *testing.T) {
 	assert.Equal(t, expectedDescription, r.Fields[models.SystemDescription])
 	test.DeleteWorkitemOK(t, nil, nil, wiController, wiResult.ID)
 }
+
+func TestUnregisteredURLWithPort(t *testing.T) {
+	resource.Require(t, resource.Database)
+	service := getServiceAsUser()
+	wiController := NewWorkitemController(service, gormapplication.NewGormDB(DB))
+	expectedDescription := "Related to http://some-other-domain:8080/different-path/154687364529310/ok issue"
+	wiPayload := app.CreateWorkItemPayload{
+		Type: models.SystemBug,
+		Fields: map[string]interface{}{
+			models.SystemTitle:       "specialwordforsearch_new",
+			models.SystemDescription: expectedDescription,
+			models.SystemCreator:     "baijum",
+			models.SystemState:       "closed"},
+	}
+
+	_, wiResult := test.CreateWorkitemCreated(t, service.Context, service, wiController, &wiPayload)
+
+	controller := NewSearchController(service, gormapplication.NewGormDB(DB))
+	q := `http://some-other-domain:8080/different-path/`
+	_, sr := test.ShowSearchOK(t, nil, nil, controller, nil, nil, q)
+	assert.NotEqual(t, 0, len(sr.Data))
+	r := sr.Data[0]
+	assert.Equal(t, expectedDescription, r.Fields[models.SystemDescription])
+	test.DeleteWorkitemOK(t, nil, nil, wiController, wiResult.ID)
+}


### PR DESCRIPTION
Fixes #454 

- Trim prefix "http protocols"
- Escape ":"
- Trim trailing slashes