### PR TITLE
Added BadParameter.Expected() function

### DIFF
--- a/models/errors.go
+++ b/models/errors.go
@@ -3,8 +3,9 @@ package models
 import "fmt"
 
 const (
-	stBadParameterErrorMsg = "Bad value for parameter '%s': '%v'"
-	stNotFoundErrorMsg     = "%s with id '%s' not found"
+	stBadParameterErrorMsg         = "Bad value for parameter '%s': '%v'"
+	stBadParameterErrorExpectedMsg = "Bad value for parameter '%s': '%v' (expected: '%v')"
+	stNotFoundErrorMsg             = "%s with id '%s' not found"
 )
 
 type simpleError struct {
@@ -32,18 +33,31 @@ type VersionConflictError struct {
 
 // BadParameterError means that a parameter was not as required
 type BadParameterError struct {
-	parameter string
-	value     interface{}
+	parameter        string
+	value            interface{}
+	expectedValue    interface{}
+	hasExpectedValue bool
 }
 
 // Error implements the error interface
 func (err BadParameterError) Error() string {
+	if err.hasExpectedValue {
+		return fmt.Sprintf(stBadParameterErrorExpectedMsg, err.parameter, err.value, err.expectedValue)
+	}
 	return fmt.Sprintf(stBadParameterErrorMsg, err.parameter, err.value)
+
+}
+
+// Expected sets the optional expectedValue parameter on the BadParameterError
+func (err BadParameterError) Expected(expexcted interface{}) BadParameterError {
+	err.expectedValue = expexcted
+	err.hasExpectedValue = true
+	return err
 }
 
 // NewBadParameterError returns the custom defined error of type NewBadParameterError.
-func NewBadParameterError(param string, value interface{}) BadParameterError {
-	return BadParameterError{parameter: param, value: value}
+func NewBadParameterError(param string, actual interface{}) BadParameterError {
+	return BadParameterError{parameter: param, value: actual}
 }
 
 // NewConversionError returns the custom defined error of type NewConversionError.

--- a/models/errors_blackbox_test.go
+++ b/models/errors_blackbox_test.go
@@ -32,9 +32,11 @@ func TestNewBadParameterError(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	param := "assigness"
 	value := 10
+	expectedValue := 11
 	err := models.NewBadParameterError(param, value)
 	assert.Equal(t, fmt.Sprintf("Bad value for parameter '%s': '%v'", param, value), err.Error())
-
+	err = models.NewBadParameterError(param, value).Expected(expectedValue)
+	assert.Equal(t, fmt.Sprintf("Bad value for parameter '%s': '%v' (expected: '%v')", param, value, expectedValue), err.Error())
 }
 
 func TestNewNotFoundError(t *testing.T) {

--- a/models/errors_whitebox_test.go
+++ b/models/errors_whitebox_test.go
@@ -20,6 +20,9 @@ func TestBadParameterError_Error(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	e := BadParameterError{parameter: "foo", value: "bar"}
 	assert.Equal(t, fmt.Sprintf(stBadParameterErrorMsg, e.parameter, e.value), e.Error())
+
+	e = BadParameterError{parameter: "foo", value: "bar", expectedValue: "foobar", hasExpectedValue: true}
+	assert.Equal(t, fmt.Sprintf(stBadParameterErrorExpectedMsg, e.parameter, e.value, e.expectedValue), e.Error())
 }
 
 func TestNotFoundError_Error(t *testing.T) {

--- a/models/workitem_repository.go
+++ b/models/workitem_repository.go
@@ -86,7 +86,7 @@ func (r *GormWorkItemRepository) Save(ctx context.Context, wi app.WorkItem) (*ap
 
 	wiType, err := r.wir.LoadTypeFromDB(ctx, wi.Type)
 	if err != nil {
-		return nil, BadParameterError{"Type", wi.Type}
+		return nil, NewBadParameterError("Type", wi.Type)
 	}
 
 	newWi := WorkItem{
@@ -101,7 +101,7 @@ func (r *GormWorkItemRepository) Save(ctx context.Context, wi app.WorkItem) (*ap
 		var err error
 		newWi.Fields[fieldName], err = fieldDef.ConvertToModel(fieldName, fieldValue)
 		if err != nil {
-			return nil, BadParameterError{fieldName, fieldValue}
+			return nil, NewBadParameterError(fieldName, fieldValue)
 		}
 	}
 
@@ -122,7 +122,7 @@ func (r *GormWorkItemRepository) Save(ctx context.Context, wi app.WorkItem) (*ap
 func (r *GormWorkItemRepository) Create(ctx context.Context, typeID string, fields map[string]interface{}, creator string) (*app.WorkItem, error) {
 	wiType, err := r.wir.LoadTypeFromDB(ctx, typeID)
 	if err != nil {
-		return nil, BadParameterError{parameter: "type", value: typeID}
+		return nil, NewBadParameterError("type", typeID)
 	}
 	wi := WorkItem{
 		Type:   typeID,
@@ -134,7 +134,7 @@ func (r *GormWorkItemRepository) Create(ctx context.Context, typeID string, fiel
 		var err error
 		wi.Fields[fieldName], err = fieldDef.ConvertToModel(fieldName, fieldValue)
 		if err != nil {
-			return nil, BadParameterError{fieldName, fieldValue}
+			return nil, NewBadParameterError(fieldName, fieldValue)
 		}
 	}
 	tx := r.db
@@ -156,7 +156,7 @@ func (r *GormWorkItemRepository) Create(ctx context.Context, typeID string, fiel
 func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, criteria criteria.Expression, start *int, limit *int) ([]WorkItem, uint64, error) {
 	where, parameters, compileError := Compile(criteria)
 	if compileError != nil {
-		return nil, 0, BadParameterError{"expression", criteria}
+		return nil, 0, NewBadParameterError("expression", criteria)
 	}
 
 	log.Printf("executing query: '%s' with params %v", where, parameters)
@@ -165,13 +165,13 @@ func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, criteria c
 	orgDB := db
 	if start != nil {
 		if *start < 0 {
-			return nil, 0, BadParameterError{"start", *start}
+			return nil, 0, NewBadParameterError("start", *start)
 		}
 		db = db.Offset(*start)
 	}
 	if limit != nil {
 		if *limit <= 0 {
-			return nil, 0, BadParameterError{"limit", *limit}
+			return nil, 0, NewBadParameterError("limit", *limit)
 		}
 		db = db.Limit(*limit)
 	}


### PR DESCRIPTION
This adds the possibility to specify an expected value for a bad parameter error.

When you create a `BadParameter` error using the `NewBadParameterError()` constructor function you call the `Expected()` method on the result to set an expected value:

```golang
models.NewBadParameterError(param, value).Expected(expectedValue)
```

The reason for this chaining approach is that sometimes you may not want to set an expected value.

