### PR TITLE
Include ID field in WorktItem.Equals()

### DIFF
--- a/models/workitem.go
+++ b/models/workitem.go
@@ -30,7 +30,11 @@ func (wi WorkItem) Equal(u convert.Equaler) bool {
 	if !wi.Lifecycle.Equal(other.Lifecycle) {
 		return false
 	}
+
 	if wi.Type != other.Type {
+		return false
+	}
+	if wi.ID != other.ID {
 		return false
 	}
 	if wi.Version != other.Version {

--- a/models/workitem_blackbox_test.go
+++ b/models/workitem_blackbox_test.go
@@ -57,4 +57,15 @@ func TestWorkItem_Equal(t *testing.T) {
 	h := a
 	h.Fields = models.Fields{}
 	assert.False(t, a.Equal(h))
+
+	i := models.WorkItem{
+		ID:      0,
+		Type:    "foo",
+		Version: 0,
+		Fields: models.Fields{
+			"foo": "bar",
+		},
+	}
+	assert.True(t, a.Equal(i))
+	assert.True(t, i.Equal(a))
 }

--- a/models/workitem_blackbox_test.go
+++ b/models/workitem_blackbox_test.go
@@ -48,8 +48,13 @@ func TestWorkItem_Equal(t *testing.T) {
 	f.Version += 1
 	assert.False(t, a.Equal(f))
 
-	// Test fields difference
+	// Test ID difference
 	g := a
-	g.Fields = models.Fields{}
+	g.ID = 1
 	assert.False(t, a.Equal(g))
+
+	// Test fields difference
+	h := a
+	h.Fields = models.Fields{}
+	assert.False(t, a.Equal(h))
 }


### PR DESCRIPTION
@kwk noticed that we are not comparing id's in models.WorkItem.Equals(). Since we are using equals to compare items for testing, including the ID field seems to be the right thing.