### PR TITLE
Use WIT cache instead of fetching same WITs from DB many times

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func main() {
 	// Make sure the database is populated with the correct types (e.g. system.bug etc.)
 	if configuration.GetPopulateCommonTypes() {
 		if err := models.Transactional(db, func(tx *gorm.DB) error {
-			return migration.PopulateCommonTypes(context.Background(), tx, models.NewWorkItemTypeRepository(tx))
+			return migration.PopulateCommonTypes(context.Background(), tx, models.NewWorkItemTypeRepository(tx, nil))
 		}); err != nil {
 			panic(err.Error())
 		}
@@ -127,7 +127,7 @@ func main() {
 	}
 
 	// Scheduler to fetch and import remote tracker items
-	scheduler = remoteworkitem.NewScheduler(db)
+	scheduler = remoteworkitem.NewScheduler(db, models.NewWorkItemTypeCache())
 	defer scheduler.Stop()
 	scheduler.ScheduleAllQueries()
 

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -310,7 +310,6 @@ func PopulateCommonTypes(ctx context.Context, db *gorm.DB, witr *models.GormWork
 	if err := createOrUpdatePlannerItemExtention(models.SystemBug, ctx, witr, db); err != nil {
 		return err
 	}
-	witr.ClearCache() // Clear the WIT cache after updating existing WITs
 	return nil
 }
 
@@ -382,7 +381,11 @@ func createOrUpdateType(typeName string, extendedTypeName *string, fields map[st
 		wit.Path = path
 
 		db = db.Save(wit)
-		return db.Error
+		if dbErr := db.Error; dbErr != nil {
+			witr.Cache.Delete(wit.Name)
+			return dbErr
+		}
+		witr.Cache.Put(*wit)
 	}
 	return nil
 }

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -310,6 +310,7 @@ func PopulateCommonTypes(ctx context.Context, db *gorm.DB, witr *models.GormWork
 	if err := createOrUpdatePlannerItemExtention(models.SystemBug, ctx, witr, db); err != nil {
 		return err
 	}
+	witr.ClearCache() // Clear the WIT cache after updating existing WITs
 	return nil
 }
 

--- a/models/work-item-link-repository.go
+++ b/models/work-item-link-repository.go
@@ -20,11 +20,11 @@ const (
 )
 
 // NewWorkItemLinkRepository creates a work item link repository based on gorm
-func NewWorkItemLinkRepository(db *gorm.DB) *GormWorkItemLinkRepository {
+func NewWorkItemLinkRepository(db *gorm.DB, witCache *WorkItemTypeCache) *GormWorkItemLinkRepository {
 	return &GormWorkItemLinkRepository{
 		db:                   db,
-		workItemRepo:         NewWorkItemRepository(db),
-		workItemTypeRepo:     NewWorkItemTypeRepository(db),
+		workItemRepo:         NewWorkItemRepository(db, witCache),
+		workItemTypeRepo:     NewWorkItemTypeRepository(db, witCache),
 		workItemLinkTypeRepo: NewWorkItemLinkTypeRepository(db),
 	}
 }

--- a/models/workitemtype_cache.go
+++ b/models/workitemtype_cache.go
@@ -1,0 +1,32 @@
+package models
+
+import "sync"
+
+// WorkItemTypeCache represents WorkItemType cache
+type WorkItemTypeCache struct {
+	cache   map[string]WorkItemType
+	mapLock sync.RWMutex
+}
+
+// NewWorkItemTypeCache constructs WorkItemTypeCache
+func NewWorkItemTypeCache() *WorkItemTypeCache {
+	witCache := WorkItemTypeCache{}
+	witCache.cache = make(map[string]WorkItemType)
+	return &witCache
+}
+
+// Get returns WorkItemType by name.
+// The second value (ok) is a bool that is true if the WorkItemType exists in the cache, and false if not.
+func (c *WorkItemTypeCache) Get(typeName string) (WorkItemType, bool) {
+	c.mapLock.RLock()
+	defer c.mapLock.RUnlock()
+	w, ok := c.cache[typeName]
+	return w, ok
+}
+
+// Put puts a work item type to the cache
+func (c *WorkItemTypeCache) Put(wit WorkItemType) {
+	c.mapLock.Lock()
+	defer c.mapLock.Unlock()
+	c.cache[wit.Name] = wit
+}

--- a/models/workitemtype_cache.go
+++ b/models/workitemtype_cache.go
@@ -30,3 +30,10 @@ func (c *WorkItemTypeCache) Put(wit WorkItemType) {
 	defer c.mapLock.Unlock()
 	c.cache[wit.Name] = wit
 }
+
+// Clear clears the cache
+func (c *WorkItemTypeCache) Clear() {
+	c.mapLock.Lock()
+	defer c.mapLock.Unlock()
+	c.cache = make(map[string]WorkItemType)
+}

--- a/models/workitemtype_cache.go
+++ b/models/workitemtype_cache.go
@@ -37,3 +37,10 @@ func (c *WorkItemTypeCache) Clear() {
 	defer c.mapLock.Unlock()
 	c.cache = make(map[string]WorkItemType)
 }
+
+// Delete a type from the cache
+func (c *WorkItemTypeCache) Delete(typeName string) {
+	c.mapLock.Lock()
+	defer c.mapLock.Unlock()
+	delete(c.cache, typeName)
+}

--- a/models/workitemtype_cache_blackbox_test.go
+++ b/models/workitemtype_cache_blackbox_test.go
@@ -1,0 +1,64 @@
+package models_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/almighty/almighty-core/models"
+	"github.com/almighty/almighty-core/resource"
+	"github.com/stretchr/testify/assert"
+)
+
+var cache = models.NewWorkItemTypeCache()
+
+func TestNotExistingType(t *testing.T) {
+	t.Parallel()
+	resource.Require(t, resource.UnitTest)
+
+	_, ok := cache.Get("notexists")
+	assert.False(t, ok)
+}
+
+func TestReadingWriting(t *testing.T) {
+	t.Parallel()
+	resource.Require(t, resource.UnitTest)
+
+	_, ok := cache.Get("type1")
+	assert.False(t, ok)
+
+	wit := models.WorkItemType{}
+	wit.Name = "type1"
+	cache.Put(wit)
+
+	cachedWit, ok := cache.Get("type1")
+	assert.True(t, ok)
+	assert.Equal(t, wit, cachedWit)
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	t.Parallel()
+	resource.Require(t, resource.UnitTest)
+
+	wit := models.WorkItemType{}
+	wit.Name = "type1"
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 3000; i++ {
+			cache.Put(wit)
+		}
+	}()
+	cache.Put(wit)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			cachedWit, ok := cache.Get("type1")
+			assert.True(t, ok)
+			assert.Equal(t, wit, cachedWit)
+		}
+	}()
+	wg.Wait()
+}

--- a/models/workitemtype_cache_blackbox_test.go
+++ b/models/workitemtype_cache_blackbox_test.go
@@ -15,7 +15,7 @@ func TestNotExistingType(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
 
-	_, ok := cache.Get("notexists")
+	_, ok := cache.Get("testNotExistingType")
 	assert.False(t, ok)
 }
 
@@ -23,24 +23,36 @@ func TestReadingWriting(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
 
-	_, ok := cache.Get("type1")
+	_, ok := cache.Get("testReadingWriting")
 	assert.False(t, ok)
 
-	wit := models.WorkItemType{}
-	wit.Name = "type1"
+	wit := models.WorkItemType{Name: "testReadingWriting"}
 	cache.Put(wit)
 
-	cachedWit, ok := cache.Get("type1")
+	cachedWit, ok := cache.Get("testReadingWriting")
 	assert.True(t, ok)
 	assert.Equal(t, wit, cachedWit)
+}
+
+func TestClear(t *testing.T) {
+	t.Parallel()
+	resource.Require(t, resource.UnitTest)
+
+	c := models.NewWorkItemTypeCache()
+	c.Put(models.WorkItemType{Name: "testClear"})
+	_, ok := c.Get("testClear")
+	assert.True(t, ok)
+
+	c.Clear()
+	_, ok = c.Get("testClear")
+	assert.False(t, ok)
 }
 
 func TestConcurrentAccess(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
 
-	wit := models.WorkItemType{}
-	wit.Name = "type1"
+	wit := models.WorkItemType{Name: "testConcurrentAccess"}
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -55,7 +67,7 @@ func TestConcurrentAccess(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 1000; i++ {
-			cachedWit, ok := cache.Get("type1")
+			cachedWit, ok := cache.Get("testConcurrentAccess")
 			assert.True(t, ok)
 			assert.Equal(t, wit, cachedWit)
 		}

--- a/models/workitemtype_cache_blackbox_test.go
+++ b/models/workitemtype_cache_blackbox_test.go
@@ -48,6 +48,25 @@ func TestClear(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestDelete(t *testing.T) {
+	t.Parallel()
+	resource.Require(t, resource.UnitTest)
+
+	c := models.NewWorkItemTypeCache()
+	c.Put(models.WorkItemType{Name: "toDelete"})
+	c.Put(models.WorkItemType{Name: "toPersist"})
+	_, ok := c.Get("toDelete")
+	assert.True(t, ok)
+	_, ok = c.Get("toPersist")
+	assert.True(t, ok)
+
+	c.Delete("toDelete")
+	_, ok = c.Get("toDelete")
+	assert.False(t, ok)
+	_, ok = c.Get("toPersist")
+	assert.True(t, ok)
+}
+
 func TestConcurrentAccess(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)

--- a/models/workitemtype_repository.go
+++ b/models/workitemtype_repository.go
@@ -27,7 +27,7 @@ func NewWorkItemTypeRepository(db *gorm.DB, witCache *WorkItemTypeCache) *GormWo
 // GormWorkItemTypeRepository implements WorkItemTypeRepository using gorm
 type GormWorkItemTypeRepository struct {
 	db    *gorm.DB
-	cache *WorkItemTypeCache
+	Cache *WorkItemTypeCache
 }
 
 // Load returns the work item for the given id
@@ -45,7 +45,7 @@ func (r *GormWorkItemTypeRepository) Load(ctx context.Context, name string) (*ap
 // LoadTypeFromDB return work item type for the given id
 func (r *GormWorkItemTypeRepository) LoadTypeFromDB(name string) (*WorkItemType, error) {
 	log.Printf("loading work item type %s", name)
-	res, ok := r.cache.Get(name)
+	res, ok := r.Cache.Get(name)
 	if !ok {
 		log.Printf("Work item type %s doesn't exist in the cache. Loading from DB...", name)
 		res = WorkItemType{}
@@ -58,15 +58,10 @@ func (r *GormWorkItemTypeRepository) LoadTypeFromDB(name string) (*WorkItemType,
 		if err := db.Error; err != nil {
 			return nil, InternalError{simpleError{err.Error()}}
 		}
-		r.cache.Put(res)
+		r.Cache.Put(res)
 	}
 
 	return &res, nil
-}
-
-// ClearCache clears the work item type cache
-func (r *GormWorkItemTypeRepository) ClearCache() {
-	r.cache.Clear()
 }
 
 // Create creates a new work item in the repository

--- a/models/workitemtype_repository.go
+++ b/models/workitemtype_repository.go
@@ -62,6 +62,11 @@ func (r *GormWorkItemTypeRepository) LoadTypeFromDB(name string) (*WorkItemType,
 	return &res, nil
 }
 
+// ClearCache clears the work item type cache
+func (r *GormWorkItemTypeRepository) ClearCache() {
+	cache.Clear()
+}
+
 // Create creates a new work item in the repository
 // returns BadParameterError, ConversionError or InternalError
 func (r *GormWorkItemTypeRepository) Create(ctx context.Context, extendedTypeName *string, name string, fields map[string]app.FieldDefinition) (*app.WorkItemType, error) {

--- a/models/workitemtype_repository_blackbox_test.go
+++ b/models/workitemtype_repository_blackbox_test.go
@@ -26,7 +26,7 @@ func TestRunWorkItemTypeRepoBlackBoxTest(t *testing.T) {
 
 func (s *workItemTypeRepoBlackBoxTest) SetupTest() {
 	s.undoScript = &gormsupport.DBScript{}
-	s.repo = models.NewUndoableWorkItemTypeRepository(models.NewWorkItemTypeRepository(s.DB), s.undoScript)
+	s.repo = models.NewUndoableWorkItemTypeRepository(models.NewWorkItemTypeRepository(s.DB, nil), s.undoScript)
 	db2 := s.DB.Unscoped().Delete(models.WorkItemType{Name: "foo.bar"})
 
 	if db2.Error != nil {

--- a/remoteworkitem/scheduler.go
+++ b/remoteworkitem/scheduler.go
@@ -20,14 +20,15 @@ type trackerSchedule struct {
 
 // Scheduler represents scheduler
 type Scheduler struct {
-	db *gorm.DB
+	db       *gorm.DB
+	witCache *models.WorkItemTypeCache
 }
 
 var cr *cron.Cron
 
 // NewScheduler creates a new Scheduler
-func NewScheduler(db *gorm.DB) *Scheduler {
-	s := Scheduler{db: db}
+func NewScheduler(db *gorm.DB, witCache *models.WorkItemTypeCache) *Scheduler {
+	s := Scheduler{db, witCache}
 	return &s
 }
 
@@ -58,7 +59,7 @@ func (s *Scheduler) ScheduleAllQueries() {
 						return err
 					}
 					// Convert the remote item into a local work item and persist in the DB.
-					_, err = convert(tx, tq.TrackerID, i, tq.TrackerType)
+					_, err = convert(tx, s.witCache, tq.TrackerID, i, tq.TrackerType)
 					return err
 				})
 			}

--- a/remoteworkitem/scheduler_test.go
+++ b/remoteworkitem/scheduler_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/almighty/almighty-core/configuration"
+	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/jinzhu/gorm"
 	_ "github.com/lib/pq"
@@ -33,9 +34,13 @@ func TestMain(m *testing.M) {
 func TestNewScheduler(t *testing.T) {
 	resource.Require(t, resource.Database)
 
-	s := NewScheduler(db)
+	witCache := models.NewWorkItemTypeCache()
+	s := NewScheduler(db, witCache)
 	if s.db != db {
 		t.Error("DB not set as an attribute")
+	}
+	if s.witCache != witCache {
+		t.Error("WitCache not set as an attribute")
 	}
 	s.Stop()
 }

--- a/remoteworkitem/trackeritem_repository.go
+++ b/remoteworkitem/trackeritem_repository.go
@@ -29,11 +29,11 @@ func upload(db *gorm.DB, tID int, item TrackerItemContent) error {
 }
 
 // Map a remote work item into an ALM work item and persist it into the database.
-func convert(db *gorm.DB, tID int, item TrackerItemContent, provider string) (*app.WorkItem, error) {
+func convert(db *gorm.DB, witCache *models.WorkItemTypeCache, tID int, item TrackerItemContent, provider string) (*app.WorkItem, error) {
 	remoteID := item.ID
 	content := string(item.Content)
 
-	wir := models.NewWorkItemRepository(db)
+	wir := models.NewWorkItemRepository(db, witCache)
 	ti := TrackerItem{Item: content, RemoteItemID: remoteID, TrackerID: uint64(tID)}
 
 	// Converting the remote item to a local work item

--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -38,8 +38,8 @@ type GormSearchRepository struct {
 }
 
 // NewGormSearchRepository creates a new search repository
-func NewGormSearchRepository(db *gorm.DB) *GormSearchRepository {
-	return &GormSearchRepository{db, models.NewWorkItemTypeRepository(db)}
+func NewGormSearchRepository(db *gorm.DB, witCache *models.WorkItemTypeCache) *GormSearchRepository {
+	return &GormSearchRepository{db, models.NewWorkItemTypeRepository(db, witCache)}
 }
 
 func generateSearchQuery(q string) (string, error) {

--- a/search/search_repository_blackbox_test.go
+++ b/search/search_repository_blackbox_test.go
@@ -27,9 +27,10 @@ func (s *searchRepositoryBlackboxTest) TestRestrictByType() {
 	resource.Require(s.T(), resource.Database)
 	undoScript := &gormsupport.DBScript{}
 	defer undoScript.Run(s.DB)
-	typeRepo := models.NewUndoableWorkItemTypeRepository(models.NewWorkItemTypeRepository(s.DB), undoScript)
-	wiRepo := models.NewUndoableWorkItemRepository(models.NewWorkItemRepository(s.DB), undoScript)
-	searchRepo := search.NewGormSearchRepository(s.DB)
+	witCache := models.NewWorkItemTypeCache()
+	typeRepo := models.NewUndoableWorkItemTypeRepository(models.NewWorkItemTypeRepository(s.DB, witCache), undoScript)
+	wiRepo := models.NewUndoableWorkItemRepository(models.NewWorkItemRepository(s.DB, witCache), undoScript)
+	searchRepo := search.NewGormSearchRepository(s.DB, nil)
 
 	ctx := context.Background()
 	res, count, err := searchRepo.SearchFullText(ctx, "TestRestrictByType", nil, nil)

--- a/search/search_repository_whitebox_test.go
+++ b/search/search_repository_whitebox_test.go
@@ -34,7 +34,7 @@ type SearchTestDescriptor struct {
 
 func (s *searchRepositoryWhiteboxTest) TestSearchByText() {
 
-	wir := models.NewWorkItemRepository(s.DB)
+	wir := models.NewWorkItemRepository(s.DB, nil)
 
 	testDataSet := []SearchTestDescriptor{
 		{
@@ -127,7 +127,7 @@ func (s *searchRepositoryWhiteboxTest) TestSearchByText() {
 			searchString = searchString + workItemURLInSearchString
 			searchString = fmt.Sprintf("\"%s\"", searchString)
 			s.T().Log("using search string: " + searchString)
-			sr := NewGormSearchRepository(tx)
+			sr := NewGormSearchRepository(tx, nil)
 			var start, limit int = 0, 100
 			workItemList, _, err := sr.SearchFullText(context.Background(), searchString, &start, &limit)
 			if err != nil {
@@ -200,7 +200,7 @@ func stringInSlice(str string, list []string) bool {
 func (s *searchRepositoryWhiteboxTest) TestSearchByID() {
 
 	models.Transactional(s.DB, func(tx *gorm.DB) error {
-		wir := models.NewWorkItemRepository(tx)
+		wir := models.NewWorkItemRepository(tx, nil)
 
 		workItem := app.WorkItem{Fields: make(map[string]interface{})}
 
@@ -227,7 +227,7 @@ func (s *searchRepositoryWhiteboxTest) TestSearchByID() {
 			s.T().Fatal("Couldnt create test data")
 		}
 
-		sr := NewGormSearchRepository(tx)
+		sr := NewGormSearchRepository(tx, nil)
 
 		var start, limit int = 0, 100
 		searchString := "id:" + createdWorkItem.ID

--- a/work-item-link-blackbox_test.go
+++ b/work-item-link-blackbox_test.go
@@ -74,7 +74,7 @@ func (s *workItemLinkSuite) SetupSuite() {
 
 	// Make sure the database is populated with the correct types (e.g. system.bug etc.)
 	if err := models.Transactional(DB, func(tx *gorm.DB) error {
-		return migration.PopulateCommonTypes(context.Background(), tx, models.NewWorkItemTypeRepository(tx))
+		return migration.PopulateCommonTypes(context.Background(), tx, models.NewWorkItemTypeRepository(tx, nil))
 	}); err != nil {
 		panic(err.Error())
 	}

--- a/work-item-link-category-blackbox_test.go
+++ b/work-item-link-category-blackbox_test.go
@@ -53,7 +53,7 @@ func (s *workItemLinkCategorySuite) SetupSuite() {
 
 	// Make sure the database is populated with the correct types (e.g. system.bug etc.)
 	if err := models.Transactional(DB, func(tx *gorm.DB) error {
-		return migration.PopulateCommonTypes(context.Background(), tx, models.NewWorkItemTypeRepository(tx))
+		return migration.PopulateCommonTypes(context.Background(), tx, models.NewWorkItemTypeRepository(tx, nil))
 	}); err != nil {
 		panic(err.Error())
 	}

--- a/work-item-link-type-blackbox_test.go
+++ b/work-item-link-type-blackbox_test.go
@@ -55,7 +55,7 @@ func (s *workItemLinkTypeSuite) SetupSuite() {
 
 	// Make sure the database is populated with the correct types (e.g. system.bug etc.)
 	if err := models.Transactional(DB, func(tx *gorm.DB) error {
-		return migration.PopulateCommonTypes(context.Background(), tx, models.NewWorkItemTypeRepository(tx))
+		return migration.PopulateCommonTypes(context.Background(), tx, models.NewWorkItemTypeRepository(tx, nil))
 	}); err != nil {
 		panic(err.Error())
 	}

--- a/workitem_whitebox_test.go
+++ b/workitem_whitebox_test.go
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 		// Make sure the database is populated with the correct types (e.g. system.bug etc.)
 		if configuration.GetPopulateCommonTypes() {
 			if err := models.Transactional(DB, func(tx *gorm.DB) error {
-				return migration.PopulateCommonTypes(context.Background(), tx, models.NewWorkItemTypeRepository(tx))
+				return migration.PopulateCommonTypes(context.Background(), tx, models.NewWorkItemTypeRepository(tx, nil))
 			}); err != nil {
 				panic(err.Error())
 			}
@@ -47,7 +47,7 @@ func TestMain(m *testing.M) {
 		}
 
 		// RemoteWorkItemScheduler now available for all other test cases
-		RwiScheduler = remoteworkitem.NewScheduler(DB)
+		RwiScheduler = remoteworkitem.NewScheduler(DB, nil)
 	}
 	os.Exit(func() int {
 		c := m.Run()

--- a/workitemtype_blackbox_test.go
+++ b/workitemtype_blackbox_test.go
@@ -58,7 +58,7 @@ func (s *WorkItemTypeSuite) SetupSuite() {
 	// Make sure the database is populated with the correct types (e.g. system.bug etc.)
 	if configuration.GetPopulateCommonTypes() {
 		if err := models.Transactional(s.db, func(tx *gorm.DB) error {
-			return migration.PopulateCommonTypes(context.Background(), tx, models.NewWorkItemTypeRepository(tx))
+			return migration.PopulateCommonTypes(context.Background(), tx, models.NewWorkItemTypeRepository(tx, nil))
 		}); err != nil {
 			panic(err.Error())
 		}


### PR DESCRIPTION
Fixes #242

This approach uses synchronized map instead of groupcache (see https://github.com/almighty/almighty-core/pull/359)  