### PR TITLE
Fix #518

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -101,6 +101,9 @@ func getMigrations() migrations {
 	// Version 8
 	m = append(m, steps{executeSQLFile("008-soft-delete-or-resurrect.sql")})
 
+	// Version 9
+	m = append(m, steps{executeSQLFile("009-drop-wit-trigger.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/009-drop-wit-trigger.sql
+++ b/migration/sql-files/009-drop-wit-trigger.sql
@@ -1,0 +1,4 @@
+-- See https://github.com/almighty/almighty-core/issues/518 for an explanation
+-- why these triggers were problematic.
+DROP TRIGGER update_WI_after_WILT_trigger ON work_item_types;
+DROP FUNCTION update_WI_after_WIT();


### PR DESCRIPTION
This removes the update trigger that is fired on a change to the `work_item_types.deleted_at` SQL column. Originally this trigger should soft delete or resurrect work items who's type was soft deleted.

It solves slow startup time which was caused by too many changes on all work items.
