### PR TITLE
Add Comments to WorkItem API

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -1,5 +1,7 @@
 package application
 
+import "github.com/almighty/almighty-core/comment"
+
 //An Application stands for a particular implementation of the business logic of our application
 type Application interface {
 	WorkItems() WorkItemRepository
@@ -12,6 +14,7 @@ type Application interface {
 	WorkItemLinkCategories() WorkItemLinkCategoryRepository
 	WorkItemLinkTypes() WorkItemLinkTypeRepository
 	WorkItemLinks() WorkItemLinkRepository
+	WorkItemComments() comment.Repository
 }
 
 // A Transaction abstracts a database transaction. The repositories created for the transaction object make changes inside the the transaction

--- a/comment/comment.go
+++ b/comment/comment.go
@@ -1,0 +1,70 @@
+package comment
+
+import (
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/almighty/almighty-core/gormsupport"
+	"github.com/goadesign/goa"
+	"github.com/jinzhu/gorm"
+	uuid "github.com/satori/go.uuid"
+)
+
+// Comment describes a single comment
+type Comment struct {
+	gormsupport.Lifecycle
+	ID        uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"` // This is the ID PK field
+	ParentID  string
+	CreatedBy uuid.UUID `sql:"type:uuid"` // Belongs To Identity
+	Body      string
+}
+
+// Repository describes interactions with comments
+type Repository interface {
+	Create(ctx context.Context, u *Comment) error
+	List(ctx context.Context, parent string) ([]*Comment, error)
+}
+
+// NewCommentRepository creates a new storage type.
+func NewCommentRepository(db *gorm.DB) Repository {
+	return &GormCommentRepository{db: db}
+}
+
+// GormCommentRepository is the implementation of the storage interface for Comments.
+type GormCommentRepository struct {
+	db *gorm.DB
+}
+
+// TableName overrides the table name settings in Gorm to force a specific table name
+// in the database.
+func (m *GormCommentRepository) TableName() string {
+	return "comments"
+}
+
+// Create creates a new record.
+func (m *GormCommentRepository) Create(ctx context.Context, u *Comment) error {
+	defer goa.MeasureSince([]string{"goa", "db", "comment", "create"}, time.Now())
+
+	u.ID = uuid.NewV4()
+
+	err := m.db.Create(u).Error
+	if err != nil {
+		goa.LogError(ctx, "error adding Comment", "error", err.Error())
+		return err
+	}
+
+	return nil
+}
+
+// List all comments related to a single item
+func (m *GormCommentRepository) List(ctx context.Context, parent string) ([]*Comment, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "comment", "query"}, time.Now())
+	var objs []*Comment
+
+	err := m.db.Table(m.TableName()).Where("parent_id = ?", parent).Order("created_at").Find(&objs).Error
+	if err != nil && err != gorm.ErrRecordNotFound {
+		return nil, err
+	}
+	return objs, nil
+}

--- a/comment/comment_test.go
+++ b/comment/comment_test.go
@@ -1,0 +1,95 @@
+package comment_test
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/almighty/almighty-core/comment"
+	"github.com/almighty/almighty-core/gormsupport"
+	"github.com/almighty/almighty-core/resource"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/suite"
+)
+
+type TestCommentRepository struct {
+	gormsupport.DBTestSuite
+
+	clean func()
+}
+
+func TestRunCommentRepository(t *testing.T) {
+	suite.Run(t, &TestCommentRepository{DBTestSuite: gormsupport.NewDBTestSuite("../config.yaml")})
+}
+
+func (test *TestCommentRepository) SetupTest() {
+	test.clean = gormsupport.DeleteCreatedEntities(test.DB)
+}
+
+func (test *TestCommentRepository) TearDownTest() {
+	test.clean()
+}
+
+func (test *TestCommentRepository) TestCreateComment() {
+	t := test.T()
+	resource.Require(t, resource.Database)
+
+	repo := comment.NewCommentRepository(test.DB)
+
+	c := &comment.Comment{
+		ParentID:  "A",
+		Body:      "Test A",
+		CreatedBy: uuid.NewV4(),
+	}
+
+	repo.Create(context.Background(), c)
+	if c.ID == uuid.Nil {
+		t.Errorf("Comment was not created, ID nil")
+	}
+
+	if c.CreatedAt.After(time.Now()) {
+		t.Errorf("Comment was not created, CreatedAt after Now()?")
+	}
+}
+
+func (test *TestCommentRepository) TestListComments() {
+	t := test.T()
+	resource.Require(t, resource.Database)
+
+	repo := comment.NewCommentRepository(test.DB)
+
+	parentID := "A"
+	body := "Test A"
+
+	cs := []*comment.Comment{
+		&comment.Comment{
+			ParentID:  parentID,
+			Body:      body,
+			CreatedBy: uuid.NewV4(),
+		},
+		&comment.Comment{
+			ParentID:  "B",
+			Body:      "Test B",
+			CreatedBy: uuid.NewV4(),
+		},
+	}
+
+	for _, c := range cs {
+		repo.Create(context.Background(), c)
+	}
+
+	cl, err := repo.List(context.Background(), parentID)
+	if err != nil {
+		t.Error("Failed to List", err.Error())
+	}
+
+	if len(cl) != 1 {
+		t.Error("List returned more then expected based on parentID")
+	}
+
+	c := cl[0]
+	if c.Body != body {
+		t.Error("List returned unexpected comment")
+	}
+}

--- a/design/comments.go
+++ b/design/comments.go
@@ -1,0 +1,136 @@
+package design
+
+import (
+	d "github.com/goadesign/goa/design"
+	a "github.com/goadesign/goa/design/apidsl"
+)
+
+var comment = a.Type("Comment", func() {
+	a.Description(`JSONAPI store for the data of a comment.  See also http://jsonapi.org/format/#document-resource-object`)
+	a.Attribute("type", d.String, func() {
+		a.Enum("comments")
+	})
+	a.Attribute("id", d.UUID, "ID of comment", func() {
+		a.Example("40bbdd3d-8b5d-4fd6-ac90-7236b669af04")
+	})
+	a.Attribute("attributes", commentAttributes)
+	a.Attribute("relationships", commentRelationships)
+	a.Required("type", "attributes")
+})
+
+var createComment = a.Type("CreateComment", func() {
+	a.Description(`JSONAPI store for the data of a comment.  See also http://jsonapi.org/format/#document-resource-object`)
+	a.Attribute("type", d.String, func() {
+		a.Enum("comments")
+	})
+	a.Attribute("attributes", createCommentAttributes)
+	a.Required("type", "attributes")
+})
+
+var commentAttributes = a.Type("CommentAttributes", func() {
+	a.Description(`JSONAPI store for all the "attributes" of a comment. +See also see http://jsonapi.org/format/#document-resource-object-attributes`)
+	a.Attribute("created-at", d.DateTime, "When the comment was created", func() {
+		a.Example("2016-11-29T23:18:14Z")
+	})
+	a.Attribute("body", d.String, "The comment body", func() {
+		a.Example("This is really interesting")
+	})
+})
+
+var createCommentAttributes = a.Type("CreateCommentAttributes", func() {
+	a.Description(`JSONAPI store for all the "attributes" for creating a comment. +See also see http://jsonapi.org/format/#document-resource-object-attributes`)
+	a.Attribute("body", d.String, "The comment body", func() {
+		a.MinLength(1) // Empty comment not allowed
+		a.Example("This is really interesting")
+	})
+	a.Required("body")
+})
+
+var commentRelationships = a.Type("CommentRelations", func() {
+	a.Attribute("created-by", commentCreatedBy, "This defines the created by relation")
+})
+
+var commentCreatedBy = a.Type("CommentCreatedBy", func() {
+	a.Attribute("data", identityRelationData)
+	a.Required("data")
+})
+
+var identityRelationData = a.Type("IdentityRelationData", func() {
+	a.Attribute("id", d.UUID, "unique id for the user identity")
+	a.Attribute("type", d.String, "type of the user identity", func() {
+		a.Enum("identities")
+	})
+	a.Required("type")
+})
+
+var commentArray = a.MediaType("application/vnd.comments+json", func() {
+	a.TypeName("CommentArray")
+	a.Description("Holds the response of comments")
+	a.Attribute("meta", a.HashOf(d.String, d.Any))
+	a.Attribute("data", a.ArrayOf(comment))
+
+	a.Required("data")
+
+	a.View("default", func() {
+		a.Attribute("data")
+		a.Attribute("meta")
+	})
+})
+
+var commentSingle = a.MediaType("application/vnd.comment+json", func() {
+	a.TypeName("CommentSingle")
+	a.Description("Holds the response of a single comment")
+	a.Attribute("data", comment)
+
+	a.Required("data")
+
+	a.View("default", func() {
+		a.Attribute("data")
+	})
+})
+
+var createSingleComment = a.MediaType("application/vnd.comments-create+json", func() {
+	a.TypeName("CreateSingleComment")
+	a.Description("Holds the create data for a comment")
+	a.Attribute("data", createComment)
+
+	a.Required("data")
+
+	a.View("default", func() {
+		a.Attribute("data")
+	})
+})
+
+var _ = a.Resource("work-item-comments", func() {
+	a.BasePath("/relationships/comments")
+	a.Parent("workitem")
+
+	a.Action("list", func() {
+		a.Routing(
+			a.GET(""),
+		)
+		a.Description("List comments associated with the given work item")
+		a.Response(d.OK, func() {
+			a.Media(commentArray)
+		})
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+	})
+
+	a.Action("create", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.POST(""),
+		)
+		a.Description("List comments associated with the given work item")
+		a.Response(d.OK, func() {
+			a.Media(commentSingle)
+		})
+		a.Payload(createSingleComment)
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+	})
+})

--- a/gormapplication/application.go
+++ b/gormapplication/application.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/comment"
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/remoteworkitem"
 	"github.com/almighty/almighty-core/search"
@@ -98,6 +99,11 @@ func (g *GormBase) WorkItemLinkTypes() application.WorkItemLinkTypeRepository {
 // WorkItemLinks returns a work item link repository
 func (g *GormBase) WorkItemLinks() application.WorkItemLinkRepository {
 	return models.NewWorkItemLinkRepository(g.db)
+}
+
+// WorkItemComments returns a work item comments repository
+func (g *GormBase) WorkItemComments() comment.Repository {
+	return comment.NewCommentRepository(g.db)
 }
 
 func (g *GormBase) DB() *gorm.DB {

--- a/main.go
+++ b/main.go
@@ -199,6 +199,10 @@ func main() {
 	workItemLinkCtrl := NewWorkItemLinkController(service, appDB)
 	app.MountWorkItemLinkController(service, workItemLinkCtrl)
 
+	// Mount "work item comments" controller
+	workItemCommentsCtrl := NewWorkItemCommentsController(service, appDB)
+	app.MountWorkItemCommentsController(service, workItemCommentsCtrl)
+
 	// Mount "tracker" controller
 	c5 := NewTrackerController(service, appDB, scheduler)
 	app.MountTrackerController(service, c5)

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -104,6 +104,9 @@ func getMigrations() migrations {
 	// Version 9
 	m = append(m, steps{executeSQLFile("009-drop-wit-trigger.sql")})
 
+	// Version 10
+	m = append(m, steps{executeSQLFile("010-comments.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/010-comments.sql
+++ b/migration/sql-files/010-comments.sql
@@ -1,0 +1,11 @@
+CREATE TABLE comments (
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone,
+    deleted_at timestamp with time zone,
+    id uuid primary key DEFAULT uuid_generate_v4() NOT NULL,
+    parent_id text,
+    body text,
+    created_by uuid
+);
+
+CREATE INDEX ix_parent_id ON comments USING btree (parent_id);

--- a/test/db.go
+++ b/test/db.go
@@ -1,6 +1,9 @@
 package test
 
-import "github.com/almighty/almighty-core/application"
+import (
+	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/comment"
+)
 
 func NewMockDB() *MockDB {
 	return &MockDB{wir: &WorkItemRepository{}}
@@ -40,6 +43,10 @@ func (db *MockDB) WorkItemLinkTypes() application.WorkItemLinkTypeRepository {
 func (db *MockDB) WorkItemLinks() application.WorkItemLinkRepository {
 	return nil
 }
+func (db *MockDB) WorkItemComments() comment.Repository {
+	return nil
+}
+
 func (db *MockDB) Commit() error {
 	return nil
 }

--- a/work-item-comments.go
+++ b/work-item-comments.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"github.com/almighty/almighty-core/app"
+	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/comment"
+	"github.com/almighty/almighty-core/jsonapi"
+	"github.com/almighty/almighty-core/login"
+	"github.com/goadesign/goa"
+	uuid "github.com/satori/go.uuid"
+)
+
+// WorkItemCommentsController implements the work-item-comments resource.
+type WorkItemCommentsController struct {
+	*goa.Controller
+	db application.DB
+}
+
+// NewWorkItemCommentsController creates a work-item-relationships-comments controller.
+func NewWorkItemCommentsController(service *goa.Service, db application.DB) *WorkItemCommentsController {
+	return &WorkItemCommentsController{Controller: service.NewController("WorkItemRelationshipsCommentsController"), db: db}
+}
+
+// Create runs the create action.
+func (c *WorkItemCommentsController) Create(ctx *app.CreateWorkItemCommentsContext) error {
+	return application.Transactional(c.db, func(appl application.Application) error {
+		_, err := appl.WorkItems().Load(ctx, ctx.ID)
+		if err != nil {
+			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(err.Error()))
+			return ctx.NotFound(jerrors)
+		}
+
+		currentUser, err := login.ContextIdentity(ctx)
+		if err != nil {
+			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(err.Error()))
+			return ctx.Unauthorized(jerrors)
+		}
+
+		currentUserID, err := uuid.FromString(currentUser)
+		if err != nil {
+			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(err.Error()))
+			return ctx.Unauthorized(jerrors)
+		}
+
+		reqComment := ctx.Payload.Data
+
+		newComment := comment.Comment{
+			ParentID:  ctx.ID,
+			Body:      reqComment.Attributes.Body,
+			CreatedBy: currentUserID,
+		}
+
+		err = appl.WorkItemComments().Create(ctx, &newComment)
+		if err != nil {
+			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(err.Error()))
+			return ctx.InternalServerError(jerrors)
+		}
+
+		res := &app.CommentSingle{
+			Data: toAPI(&newComment),
+		}
+		return ctx.OK(res)
+	})
+}
+
+// List runs the list action.
+func (c *WorkItemCommentsController) List(ctx *app.ListWorkItemCommentsContext) error {
+	return application.Transactional(c.db, func(appl application.Application) error {
+		_, err := appl.WorkItems().Load(ctx, ctx.ID)
+		if err != nil {
+			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(err.Error()))
+			return ctx.NotFound(jerrors)
+		}
+
+		res := &app.CommentArray{}
+		res.Data = []*app.Comment{}
+
+		comments, err := appl.WorkItemComments().List(ctx, ctx.ID)
+		if err != nil {
+			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(err.Error()))
+			return ctx.InternalServerError(jerrors)
+		}
+		for _, comment := range comments {
+			res.Data = append(res.Data, toAPI(comment))
+		}
+
+		return ctx.OK(res)
+	})
+}
+
+func toAPI(comment *comment.Comment) *app.Comment {
+	return &app.Comment{
+		Type: "comments",
+		ID:   &comment.ID,
+		Attributes: &app.CommentAttributes{
+			Body:      &comment.Body,
+			CreatedAt: &comment.CreatedAt,
+		},
+		Relationships: &app.CommentRelations{
+			CreatedBy: &app.CommentCreatedBy{
+				Data: &app.IdentityRelationData{
+					Type: "identities",
+					ID:   &comment.CreatedBy,
+				},
+			},
+		},
+	}
+}

--- a/work-item-comments_test.go
+++ b/work-item-comments_test.go
@@ -1,0 +1,209 @@
+package main_test
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	. "github.com/almighty/almighty-core"
+	"github.com/almighty/almighty-core/account"
+	"github.com/almighty/almighty-core/app"
+	"github.com/almighty/almighty-core/app/test"
+	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/comment"
+	"github.com/almighty/almighty-core/gormapplication"
+	"github.com/almighty/almighty-core/gormsupport"
+	"github.com/almighty/almighty-core/models"
+	"github.com/almighty/almighty-core/resource"
+	testsupport "github.com/almighty/almighty-core/test"
+	almtoken "github.com/almighty/almighty-core/token"
+	"github.com/goadesign/goa"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type TestCommentREST struct {
+	gormsupport.DBTestSuite
+
+	db    *gormapplication.GormDB
+	clean func()
+}
+
+func TestRunCommentREST(t *testing.T) {
+	suite.Run(t, &TestCommentREST{DBTestSuite: gormsupport.NewDBTestSuite("config.yaml")})
+}
+
+func (rest *TestCommentREST) SetupTest() {
+	rest.db = gormapplication.NewGormDB(rest.DB)
+	rest.clean = gormsupport.DeleteCreatedEntities(rest.DB)
+}
+
+func (rest *TestCommentREST) TearDownTest() {
+	rest.clean()
+}
+
+func (rest *TestCommentREST) SecuredController() (*goa.Service, *WorkItemCommentsController) {
+	pub, _ := almtoken.ParsePublicKey([]byte(almtoken.RSAPublicKey))
+	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
+
+	svc := testsupport.ServiceAsUser("WorkItemComment-Service", almtoken.NewManager(pub, priv), account.TestIdentity)
+	return svc, NewWorkItemCommentsController(svc, rest.db)
+}
+
+func (rest *TestCommentREST) UnSecuredController() (*goa.Service, *WorkItemCommentsController) {
+	svc := goa.New("WorkItemComment-Service")
+	return svc, NewWorkItemCommentsController(svc, rest.db)
+}
+
+func (rest *TestCommentREST) TestSuccessCreateSingleComment() {
+	t := rest.T()
+	resource.Require(t, resource.Database)
+
+	wiid, err := createWorkItem(rest.db)
+	if err != nil {
+		t.Error(err)
+	}
+
+	p := createComment("Test")
+
+	svc, ctrl := rest.SecuredController()
+	_, c := test.CreateWorkItemCommentsOK(t, svc.Context, svc, ctrl, wiid, p)
+	assertComment(t, c.Data)
+}
+
+func (rest *TestCommentREST) TestListCommentsByParentWorkItem() {
+	t := rest.T()
+	resource.Require(t, resource.Database)
+
+	wiid, err := createWorkItem(rest.db)
+	if err != nil {
+		t.Error(err)
+	}
+	application.Transactional(rest.db, func(app application.Application) error {
+		repo := app.WorkItemComments()
+		repo.Create(context.Background(), &comment.Comment{ParentID: wiid, Body: "Test 1", CreatedBy: uuid.NewV4()})
+		repo.Create(context.Background(), &comment.Comment{ParentID: wiid, Body: "Test 2", CreatedBy: uuid.NewV4()})
+		repo.Create(context.Background(), &comment.Comment{ParentID: wiid, Body: "Test 3", CreatedBy: uuid.NewV4()})
+		repo.Create(context.Background(), &comment.Comment{ParentID: wiid + "_other", Body: "Test 1", CreatedBy: uuid.NewV4()})
+		return nil
+	})
+
+	svc, ctrl := rest.UnSecuredController()
+	_, cs := test.ListWorkItemCommentsOK(t, svc.Context, svc, ctrl, wiid)
+	if len(cs.Data) != 3 {
+		t.Error("Listed comments of wrong length")
+	}
+	assertComment(t, cs.Data[0])
+}
+
+func (rest *TestCommentREST) TestEmptyListCommentsByParentWorkItem() {
+	t := rest.T()
+	resource.Require(t, resource.Database)
+
+	wiid, err := createWorkItem(rest.db)
+	if err != nil {
+		t.Error(err)
+	}
+
+	svc, ctrl := rest.UnSecuredController()
+	_, cs := test.ListWorkItemCommentsOK(t, svc.Context, svc, ctrl, wiid)
+	if len(cs.Data) != 0 {
+		t.Error("Listed comments of wrong length")
+	}
+}
+
+func (rest *TestCommentREST) TestCreateSingleCommentMissingWorkItem() {
+	t := rest.T()
+	resource.Require(t, resource.Database)
+
+	p := createComment("Test")
+
+	svc, ctrl := rest.SecuredController()
+	test.CreateWorkItemCommentsNotFound(t, svc.Context, svc, ctrl, "0000000", p)
+}
+
+func (rest *TestCommentREST) TestCreateSingleNoAuthorized() {
+	t := rest.T()
+	resource.Require(t, resource.Database)
+
+	wiid, err := createWorkItem(rest.db)
+	if err != nil {
+		t.Error(err)
+	}
+
+	p := createComment("Test")
+
+	svc, ctrl := rest.UnSecuredController()
+	test.CreateWorkItemCommentsUnauthorized(t, svc.Context, svc, ctrl, wiid, p)
+}
+
+// Can not be tested via normal Goa testing framework as setting empty body on CreateCommentAttributes is
+// validated before Request to service is made. Validate model and assume it will be validated before hitting
+// service when mounted. Test to show intent.
+func (rest *TestCommentREST) TestShouldNotCreateEmptyBody() {
+	t := rest.T()
+
+	p := createComment("")
+	err := p.Validate()
+	if err == nil {
+		t.Error("Should not allow empty body", err)
+	}
+}
+
+func (rest *TestCommentREST) TestListCommentsByMissingParentWorkItem() {
+	t := rest.T()
+	resource.Require(t, resource.Database)
+
+	svc, ctrl := rest.SecuredController()
+	test.ListWorkItemCommentsNotFound(t, svc.Context, svc, ctrl, "0000000")
+}
+
+func assertComment(t *testing.T, c *app.Comment) {
+	assert.NotNil(t, c)
+	assert.Equal(t, "comments", c.Type)
+	assert.NotNil(t, c.ID)
+	assert.NotNil(t, c.Attributes.Body)
+	assert.NotNil(t, c.Attributes.CreatedAt)
+	assert.WithinDuration(t, time.Now(), *c.Attributes.CreatedAt, 2*time.Second)
+	assert.NotNil(t, c.Relationships)
+	assert.NotNil(t, c.Relationships.CreatedBy)
+	assert.Equal(t, "identities", c.Relationships.CreatedBy.Data.Type)
+	assert.NotNil(t, c.Relationships.CreatedBy.Data.ID)
+}
+
+func createComment(body string) *app.CreateWorkItemCommentsPayload {
+	return &app.CreateWorkItemCommentsPayload{
+		Data: &app.CreateComment{
+			Type: "comments",
+			Attributes: &app.CreateCommentAttributes{
+				Body: body,
+			},
+		},
+	}
+}
+
+func createWorkItem(db *gormapplication.GormDB) (string, error) {
+	var wiid string
+	err := application.Transactional(db, func(appl application.Application) error {
+		repo := appl.WorkItems()
+		wi, err := repo.Create(
+			context.Background(),
+			models.SystemBug,
+			map[string]interface{}{
+				models.SystemTitle: "A",
+				models.SystemState: "new",
+			},
+			uuid.NewV4().String())
+		if err != nil {
+			return err
+		}
+		wiid = wi.ID
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return wiid, nil
+}


### PR DESCRIPTION
Stores created-at, created-by and body.

Create comment (Secured):
POST /api/workitems/n/relationships/comments

List comments:
GET /api/workitems/n/relationships/comments

Related #348
Related #349