### PR TITLE
Remove security from GET /api/identities

### DIFF
--- a/design/resources.go
+++ b/design/resources.go
@@ -205,7 +205,6 @@ var _ = a.Resource("identity", func() {
 	a.BasePath("/identities")
 
 	a.Action("list", func() {
-		a.Security("jwt")
 		a.Routing(
 			a.GET(""),
 		)


### PR DESCRIPTION
UI use API as a pre fetch list to resolve users, if the endpoint
is secured no users can be displayed when viewer is not authorized.

* Update test case to not delete the whole identities table during start
* Assume there can be more than test controlled identities in the DB