### PR TITLE
Outsource errors from "models" package into its own "errors" package and use it.

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,4 +1,4 @@
-package models
+package errors
 
 import "fmt"
 

--- a/errors/errors_blackbox_test.go
+++ b/errors/errors_blackbox_test.go
@@ -1,10 +1,10 @@
-package models_test
+package errors_test
 
 import (
 	"fmt"
 	"testing"
 
-	"github.com/almighty/almighty-core/models"
+	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/stretchr/testify/assert"
 )
@@ -12,7 +12,7 @@ import (
 func TestNewInternalError(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
-	err := models.NewInternalError("System disk could not be read")
+	err := errors.NewInternalError("System disk could not be read")
 
 	// not sure what assertion to do here.
 	t.Log(err)
@@ -21,7 +21,7 @@ func TestNewInternalError(t *testing.T) {
 func TestNewConversionError(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
-	err := models.NewConversionError("Couldn't convert workitem")
+	err := errors.NewConversionError("Couldn't convert workitem")
 
 	// not sure what assertion to do here.
 	t.Log(err)
@@ -33,9 +33,9 @@ func TestNewBadParameterError(t *testing.T) {
 	param := "assigness"
 	value := 10
 	expectedValue := 11
-	err := models.NewBadParameterError(param, value)
+	err := errors.NewBadParameterError(param, value)
 	assert.Equal(t, fmt.Sprintf("Bad value for parameter '%s': '%v'", param, value), err.Error())
-	err = models.NewBadParameterError(param, value).Expected(expectedValue)
+	err = errors.NewBadParameterError(param, value).Expected(expectedValue)
 	assert.Equal(t, fmt.Sprintf("Bad value for parameter '%s': '%v' (expected: '%v')", param, value, expectedValue), err.Error())
 }
 
@@ -44,6 +44,6 @@ func TestNewNotFoundError(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	param := "assigness"
 	value := "10"
-	err := models.NewNotFoundError(param, value)
+	err := errors.NewNotFoundError(param, value)
 	assert.Equal(t, fmt.Sprintf("%s with id '%s' not found", param, value), err.Error())
 }

--- a/errors/errors_whitebox_test.go
+++ b/errors/errors_whitebox_test.go
@@ -1,4 +1,4 @@
-package models
+package errors
 
 import (
 	"fmt"

--- a/jsonapi/error_handler.go
+++ b/jsonapi/error_handler.go
@@ -7,9 +7,9 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/almighty/almighty-core/models"
+	"github.com/almighty/almighty-core/errors"
 	"github.com/goadesign/goa"
-	"github.com/pkg/errors"
+	goaerrors "github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -37,7 +37,7 @@ func ErrorHandler(service *goa.Service, verbose bool) goa.Middleware {
 			if e == nil {
 				return nil
 			}
-			cause := errors.Cause(e)
+			cause := goaerrors.Cause(e)
 			status := http.StatusInternalServerError
 			var respBody interface{}
 			respBody, status = ErrorToJSONAPIErrors(e)
@@ -62,7 +62,7 @@ func ErrorHandler(service *goa.Service, verbose bool) goa.Middleware {
 				goa.LogError(ctx, "uncaught error", "err", fmt.Sprintf("%+v", e), "id", reqID, "msg", respBody)
 				if !verbose {
 					rw.Header().Set("Content-Type", goa.ErrorMediaIdentifier)
-					msg := models.NewInternalError(fmt.Sprintf("%s [%s]", http.StatusText(http.StatusInternalServerError), reqID))
+					msg := errors.NewInternalError(fmt.Sprintf("%s [%s]", http.StatusText(http.StatusInternalServerError), reqID))
 					//respBody = goa.ErrInternal(msg)
 					respBody, status = ErrorToJSONAPIErrors(msg)
 					// Preserve the ID of the original error as that's what gets logged, the client

--- a/jsonapi/jsonapi_utility.go
+++ b/jsonapi/jsonapi_utility.go
@@ -5,9 +5,9 @@ import (
 	"strconv"
 
 	"github.com/almighty/almighty-core/app"
-	"github.com/almighty/almighty-core/models"
+	"github.com/almighty/almighty-core/errors"
 	"github.com/goadesign/goa"
-	"github.com/pkg/errors"
+	goaerrors "github.com/pkg/errors"
 )
 
 const (
@@ -31,23 +31,23 @@ func ErrorToJSONAPIError(err error) (app.JSONAPIError, int) {
 	var statusCode int
 	var id *string
 	switch err.(type) {
-	case models.NotFoundError:
+	case errors.NotFoundError:
 		code = ErrorCodeNotFound
 		title = "Not found error"
 		statusCode = http.StatusNotFound
-	case models.ConversionError:
+	case errors.ConversionError:
 		code = ErrorCodeConversionError
 		title = "Conversion error"
 		statusCode = http.StatusBadRequest
-	case models.BadParameterError:
+	case errors.BadParameterError:
 		code = ErrorCodeBadParameter
 		title = "Bad parameter error"
 		statusCode = http.StatusBadRequest
-	case models.VersionConflictError:
+	case errors.VersionConflictError:
 		code = ErrorCodeVersionConflict
 		title = "Version conflict error"
 		statusCode = http.StatusBadRequest
-	case models.InternalError:
+	case errors.InternalError:
 		code = ErrorCodeInternalError
 		title = "Internal error"
 		statusCode = http.StatusInternalServerError
@@ -56,7 +56,7 @@ func ErrorToJSONAPIError(err error) (app.JSONAPIError, int) {
 		title = "Unknown error"
 		statusCode = http.StatusInternalServerError
 
-		cause := errors.Cause(err)
+		cause := goaerrors.Cause(err)
 		if err, ok := cause.(goa.ServiceError); ok {
 			statusCode = err.ResponseStatus()
 			idStr := err.Token()

--- a/jsonapi/jsonapi_utility.go
+++ b/jsonapi/jsonapi_utility.go
@@ -7,7 +7,7 @@ import (
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/errors"
 	"github.com/goadesign/goa"
-	goaerrors "github.com/pkg/errors"
+	pkgerrors "github.com/pkg/errors"
 )
 
 const (
@@ -56,7 +56,7 @@ func ErrorToJSONAPIError(err error) (app.JSONAPIError, int) {
 		title = "Unknown error"
 		statusCode = http.StatusInternalServerError
 
-		cause := goaerrors.Cause(err)
+		cause := pkgerrors.Cause(err)
 		if err, ok := cause.(goa.ServiceError); ok {
 			statusCode = err.ResponseStatus()
 			idStr := err.Token()

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/almighty/almighty-core/app"
+	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/models"
 	"github.com/jinzhu/gorm"
 	"golang.org/x/net/context"
@@ -237,7 +238,7 @@ func BootstrapWorkItemLinking(ctx context.Context, linkCatRepo *models.GormWorkI
 func createOrUpdateWorkItemLinkCategory(ctx context.Context, linkCatRepo *models.GormWorkItemLinkCategoryRepository, name string, description string) error {
 	cat, err := linkCatRepo.LoadCategoryFromDB(ctx, name)
 	switch err.(type) {
-	case models.NotFoundError:
+	case errors.NotFoundError:
 		_, err := linkCatRepo.Create(ctx, &name, &description)
 		if err != nil {
 			return err
@@ -271,7 +272,7 @@ func createOrUpdateWorkItemLinkType(ctx context.Context, linkCatRepo *models.Gor
 	}
 
 	switch err.(type) {
-	case models.NotFoundError:
+	case errors.NotFoundError:
 		_, err := linkTypeRepo.Create(ctx, lt.Name, lt.Description, lt.SourceTypeName, lt.TargetTypeName, lt.ForwardName, lt.ReverseName, lt.Topology, lt.LinkCategoryID)
 		if err != nil {
 			return err
@@ -350,7 +351,7 @@ func createOrUpdatePlannerItemExtention(typeName string, ctx context.Context, wi
 func createOrUpdateType(typeName string, extendedTypeName *string, fields map[string]app.FieldDefinition, ctx context.Context, witr *models.GormWorkItemTypeRepository, db *gorm.DB) error {
 	wit, err := witr.LoadTypeFromDB(typeName)
 	switch err.(type) {
-	case models.NotFoundError:
+	case errors.NotFoundError:
 		_, err := witr.Create(ctx, extendedTypeName, typeName, fields)
 		if err != nil {
 			return err

--- a/models/undoable_wi_repo.go
+++ b/models/undoable_wi_repo.go
@@ -11,6 +11,7 @@ import (
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/criteria"
+	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/jinzhu/gorm"
 )
@@ -39,14 +40,14 @@ func (r *UndoableWorkItemRepository) Save(ctx context.Context, wi app.WorkItem) 
 	id, err := strconv.ParseUint(wi.ID, 10, 64)
 	if err != nil {
 		// treating this as a not found error: the fact that we're using number internal is implementation detail
-		return nil, NewNotFoundError("work item", wi.ID)
+		return nil, errors.NewNotFoundError("work item", wi.ID)
 	}
 
 	log.Printf("loading work item %d", id)
 	old := WorkItem{}
 	db := r.wrapped.db.First(&old, id)
 	if db.Error != nil {
-		return nil, NewInternalError(fmt.Sprintf("could not load %s, %s", wi.ID, db.Error.Error()))
+		return nil, errors.NewInternalError(fmt.Sprintf("could not load %s, %s", wi.ID, db.Error.Error()))
 	}
 
 	res, err := r.wrapped.Save(ctx, wi)
@@ -64,14 +65,14 @@ func (r *UndoableWorkItemRepository) Delete(ctx context.Context, ID string) erro
 	id, err := strconv.ParseUint(ID, 10, 64)
 	if err != nil {
 		// treating this as a not found error: the fact that we're using number internal is implementation detail
-		return NewNotFoundError("work item", ID)
+		return errors.NewNotFoundError("work item", ID)
 	}
 
 	log.Printf("loading work item %d", id)
 	old := WorkItem{}
 	db := r.wrapped.db.First(&old, id)
 	if db.Error != nil {
-		return NewInternalError(fmt.Sprintf("could not load %s, %s", ID, db.Error.Error()))
+		return errors.NewInternalError(fmt.Sprintf("could not load %s, %s", ID, db.Error.Error()))
 	}
 
 	err = r.wrapped.Delete(ctx, ID)
@@ -94,7 +95,7 @@ func (r *UndoableWorkItemRepository) Create(ctx context.Context, typeID string, 
 	id, err := strconv.ParseUint(result.ID, 10, 64)
 	if err != nil {
 		// treating this as a not found error: the fact that we're using number internal is implementation detail
-		return nil, NewNotFoundError("work item", result.ID)
+		return nil, errors.NewNotFoundError("work item", result.ID)
 	}
 
 	toDelete := WorkItem{ID: id}

--- a/models/work-item-link-type-repository.go
+++ b/models/work-item-link-type-repository.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/almighty/almighty-core/app"
+	"github.com/almighty/almighty-core/errors"
 	"github.com/jinzhu/gorm"
 	satoriuuid "github.com/satori/go.uuid"
 )
@@ -42,14 +43,14 @@ func (r *GormWorkItemLinkTypeRepository) Create(ctx context.Context, name string
 	linkCategory := WorkItemLinkCategory{}
 	db := r.db.Where("id=?", linkType.LinkCategoryID).Find(&linkCategory)
 	if db.RecordNotFound() {
-		return nil, NewBadParameterError("work item link category", linkType.LinkCategoryID)
+		return nil, errors.NewBadParameterError("work item link category", linkType.LinkCategoryID)
 	}
 	if db.Error != nil {
-		return nil, NewInternalError(fmt.Sprintf("Failed to find work item link category: %s", db.Error.Error()))
+		return nil, errors.NewInternalError(fmt.Sprintf("Failed to find work item link category: %s", db.Error.Error()))
 	}
 	db = r.db.Create(linkType)
 	if db.Error != nil {
-		return nil, NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error.Error())
 	}
 	// Convert the created link type entry into a JSONAPI response
 	result := ConvertLinkTypeFromModel(*linkType)
@@ -62,17 +63,17 @@ func (r *GormWorkItemLinkTypeRepository) Load(ctx context.Context, ID string) (*
 	id, err := satoriuuid.FromString(ID)
 	if err != nil {
 		// treat as not found: clients don't know it must be a UUID
-		return nil, NewNotFoundError("work item link type", ID)
+		return nil, errors.NewNotFoundError("work item link type", ID)
 	}
 	log.Printf("loading work item link type %s", id.String())
 	res := WorkItemLinkType{}
 	db := r.db.Model(&res).Where("id=?", ID).First(&res)
 	if db.RecordNotFound() {
 		log.Printf("not found work item link type, res=%v", res)
-		return nil, NewNotFoundError("work item link type", id.String())
+		return nil, errors.NewNotFoundError("work item link type", id.String())
 	}
 	if db.Error != nil {
-		return nil, NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error.Error())
 	}
 	// Convert the created link type entry into a JSONAPI response
 	result := ConvertLinkTypeFromModel(res)
@@ -88,10 +89,10 @@ func (r *GormWorkItemLinkTypeRepository) LoadTypeFromDBByNameAndCategory(name st
 	db := r.db.Model(&res).Where("name=? AND link_category_id=?", name, categoryId.String()).First(&res)
 	if db.RecordNotFound() {
 		log.Printf("not found, res=%v", res)
-		return nil, NewNotFoundError("work item link type", name)
+		return nil, errors.NewNotFoundError("work item link type", name)
 	}
 	if db.Error != nil {
-		return nil, NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error.Error())
 	}
 	return &res, nil
 }
@@ -103,10 +104,10 @@ func (r *GormWorkItemLinkTypeRepository) LoadTypeFromDBByID(ID satoriuuid.UUID) 
 	db := r.db.Model(&res).Where("ID=?", ID.String()).First(&res)
 	if db.RecordNotFound() {
 		log.Printf("not found, res=%v", res)
-		return nil, NewNotFoundError("work item link type", ID.String())
+		return nil, errors.NewNotFoundError("work item link type", ID.String())
 	}
 	if db.Error != nil {
-		return nil, NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error.Error())
 	}
 	return &res, nil
 }
@@ -140,7 +141,7 @@ func (r *GormWorkItemLinkTypeRepository) Delete(ctx context.Context, ID string) 
 	id, err := satoriuuid.FromString(ID)
 	if err != nil {
 		// treat as not found: clients don't know it must be a UUID
-		return NewNotFoundError("work item link type", ID)
+		return errors.NewNotFoundError("work item link type", ID)
 	}
 	var cat = WorkItemLinkType{
 		ID: id,
@@ -148,10 +149,10 @@ func (r *GormWorkItemLinkTypeRepository) Delete(ctx context.Context, ID string) 
 	log.Printf("work item link type to delete %v\n", cat)
 	db := r.db.Delete(&cat)
 	if db.Error != nil {
-		return NewInternalError(db.Error.Error())
+		return errors.NewInternalError(db.Error.Error())
 	}
 	if db.RowsAffected == 0 {
-		return NewNotFoundError("work item link type", id.String())
+		return errors.NewNotFoundError("work item link type", id.String())
 	}
 	return nil
 }
@@ -161,19 +162,19 @@ func (r *GormWorkItemLinkTypeRepository) Delete(ctx context.Context, ID string) 
 func (r *GormWorkItemLinkTypeRepository) Save(ctx context.Context, lt app.WorkItemLinkType) (*app.WorkItemLinkType, error) {
 	res := WorkItemLinkType{}
 	if lt.Data.ID == nil {
-		return nil, NewBadParameterError("work item link type", nil)
+		return nil, errors.NewBadParameterError("work item link type", nil)
 	}
 	db := r.db.Model(&res).Where("id=?", *lt.Data.ID).First(&res)
 	if db.RecordNotFound() {
 		log.Printf("work item link type not found, res=%v", res)
-		return nil, NewNotFoundError("work item link type", *lt.Data.ID)
+		return nil, errors.NewNotFoundError("work item link type", *lt.Data.ID)
 	}
 	if db.Error != nil {
 		log.Print(db.Error.Error())
-		return nil, NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error.Error())
 	}
 	if lt.Data.Attributes.Version == nil || res.Version != *lt.Data.Attributes.Version {
-		return nil, NewVersionConflictError("version conflict")
+		return nil, errors.NewVersionConflictError("version conflict")
 	}
 	if err := ConvertLinkTypeToModel(lt, &res); err != nil {
 		return nil, err
@@ -182,7 +183,7 @@ func (r *GormWorkItemLinkTypeRepository) Save(ctx context.Context, lt app.WorkIt
 	db = db.Save(&res)
 	if db.Error != nil {
 		log.Print(db.Error.Error())
-		return nil, NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error.Error())
 	}
 	log.Printf("updated work item link type to %v\n", res)
 	result := ConvertLinkTypeFromModel(res)

--- a/models/work-item-link-type.go
+++ b/models/work-item-link-type.go
@@ -3,6 +3,7 @@ package models
 import (
 	"github.com/almighty/almighty-core/app"
 	convert "github.com/almighty/almighty-core/convert"
+	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"
 	satoriuuid "github.com/satori/go.uuid"
 )
@@ -108,25 +109,25 @@ func (self WorkItemLinkType) Equal(u convert.Equaler) bool {
 // cannot be used for the creation of a new work item link type.
 func (t *WorkItemLinkType) CheckValidForCreation() error {
 	if t.Name == "" {
-		return NewBadParameterError("name", t.Name)
+		return errors.NewBadParameterError("name", t.Name)
 	}
 	if t.SourceTypeName == "" {
-		return NewBadParameterError("source_type_name", t.SourceTypeName)
+		return errors.NewBadParameterError("source_type_name", t.SourceTypeName)
 	}
 	if t.TargetTypeName == "" {
-		return NewBadParameterError("target_type_name", t.TargetTypeName)
+		return errors.NewBadParameterError("target_type_name", t.TargetTypeName)
 	}
 	if t.ForwardName == "" {
-		return NewBadParameterError("forward_name", t.ForwardName)
+		return errors.NewBadParameterError("forward_name", t.ForwardName)
 	}
 	if t.ReverseName == "" {
-		return NewBadParameterError("reverse_name", t.ReverseName)
+		return errors.NewBadParameterError("reverse_name", t.ReverseName)
 	}
 	if err := CheckValidTopology(t.Topology); err != nil {
 		return err
 	}
 	if t.LinkCategoryID == satoriuuid.Nil {
-		return NewBadParameterError("link_category_id", t.LinkCategoryID)
+		return errors.NewBadParameterError("link_category_id", t.LinkCategoryID)
 	}
 	return nil
 }
@@ -135,7 +136,7 @@ func (t *WorkItemLinkType) CheckValidForCreation() error {
 // otherwise a BadParameterError is returned.
 func CheckValidTopology(t string) error {
 	if t != TopologyNetwork && t != TopologyDirectedNetwork && t != TopologyDependency && t != TopologyTree {
-		return NewBadParameterError("topolgy", t).Expected(TopologyNetwork + "|" + TopologyDirectedNetwork + "|" + TopologyDependency + "|" + TopologyTree)
+		return errors.NewBadParameterError("topolgy", t).Expected(TopologyNetwork + "|" + TopologyDirectedNetwork + "|" + TopologyDependency + "|" + TopologyTree)
 	}
 	return nil
 }
@@ -192,20 +193,20 @@ func ConvertLinkTypeToModel(in app.WorkItemLinkType, out *WorkItemLinkType) erro
 		if err != nil {
 			//log.Printf("Error when converting %s to UUID: %s", *in.Data.ID, err.Error())
 			// treat as not found: clients don't know it must be a UUID
-			return NewNotFoundError("work item link type", id.String())
+			return errors.NewNotFoundError("work item link type", id.String())
 		}
 		out.ID = id
 	}
 
 	if in.Data.Type != EndpointWorkItemLinkTypes {
-		return NewBadParameterError("data.type", in.Data.Type).Expected(EndpointWorkItemLinkTypes)
+		return errors.NewBadParameterError("data.type", in.Data.Type).Expected(EndpointWorkItemLinkTypes)
 	}
 
 	if attrs != nil {
 		// If the name is not nil, it MUST NOT be empty
 		if attrs.Name != nil {
 			if *attrs.Name == "" {
-				return NewBadParameterError("data.attributes.name", *attrs.Name)
+				return errors.NewBadParameterError("data.attributes.name", *attrs.Name)
 			}
 			out.Name = *attrs.Name
 		}
@@ -221,7 +222,7 @@ func ConvertLinkTypeToModel(in app.WorkItemLinkType, out *WorkItemLinkType) erro
 		// If the forwardName is not nil, it MUST NOT be empty
 		if attrs.ForwardName != nil {
 			if *attrs.ForwardName == "" {
-				return NewBadParameterError("data.attributes.forward_name", *attrs.ForwardName)
+				return errors.NewBadParameterError("data.attributes.forward_name", *attrs.ForwardName)
 			}
 			out.ForwardName = *attrs.ForwardName
 		}
@@ -229,7 +230,7 @@ func ConvertLinkTypeToModel(in app.WorkItemLinkType, out *WorkItemLinkType) erro
 		// If the ReverseName is not nil, it MUST NOT be empty
 		if attrs.ReverseName != nil {
 			if *attrs.ReverseName == "" {
-				return NewBadParameterError("data.attributes.reverse_name", *attrs.ReverseName)
+				return errors.NewBadParameterError("data.attributes.reverse_name", *attrs.ReverseName)
 			}
 			out.ReverseName = *attrs.ReverseName
 		}
@@ -246,17 +247,17 @@ func ConvertLinkTypeToModel(in app.WorkItemLinkType, out *WorkItemLinkType) erro
 		d := rel.LinkCategory.Data
 		// If the the link category is not nil, it MUST be "workitemlinkcategories"
 		if d.Type != EndpointWorkItemLinkCategories {
-			return NewBadParameterError("data.relationships.link_category.data.type", d.Type).Expected(EndpointWorkItemLinkCategories)
+			return errors.NewBadParameterError("data.relationships.link_category.data.type", d.Type).Expected(EndpointWorkItemLinkCategories)
 		}
 		// The the link category MUST NOT be empty
 		if d.ID == "" {
-			return NewBadParameterError("data.relationships.link_category.data.id", d.ID)
+			return errors.NewBadParameterError("data.relationships.link_category.data.id", d.ID)
 		}
 		out.LinkCategoryID, err = satoriuuid.FromString(d.ID)
 		if err != nil {
 			//log.Printf("Error when converting %s to UUID: %s", in.Data.ID, err.Error())
 			// treat as not found: clients don't know it must be a UUID
-			return NotFoundError{entity: "work item link category", ID: d.ID}
+			return errors.NewNotFoundError("work item link category", d.ID)
 		}
 	}
 
@@ -264,11 +265,11 @@ func ConvertLinkTypeToModel(in app.WorkItemLinkType, out *WorkItemLinkType) erro
 		d := rel.SourceType.Data
 		// If the the link type is not nil, it MUST be "workitemlinktypes"
 		if d.Type != EndpointWorkItemTypes {
-			return NewBadParameterError("data.relationships.source_type.data.type", d.Type).Expected(EndpointWorkItemTypes)
+			return errors.NewBadParameterError("data.relationships.source_type.data.type", d.Type).Expected(EndpointWorkItemTypes)
 		}
 		// The the link type MUST NOT be empty
 		if d.ID == "" {
-			return NewBadParameterError("data.relationships.source_type.data.id", d.ID)
+			return errors.NewBadParameterError("data.relationships.source_type.data.id", d.ID)
 		}
 		out.SourceTypeName = d.ID
 	}
@@ -277,11 +278,11 @@ func ConvertLinkTypeToModel(in app.WorkItemLinkType, out *WorkItemLinkType) erro
 		d := rel.TargetType.Data
 		// If the the link type is not nil, it MUST be "workitemlinktypes"
 		if d.Type != EndpointWorkItemTypes {
-			return NewBadParameterError("data.relationships.target_type.data.type", d.Type).Expected(EndpointWorkItemTypes)
+			return errors.NewBadParameterError("data.relationships.target_type.data.type", d.Type).Expected(EndpointWorkItemTypes)
 		}
 		// The the link type MUST NOT be empty
 		if d.ID == "" {
-			return NewBadParameterError("data.relationships.target_type.data.id", d.ID)
+			return errors.NewBadParameterError("data.relationships.target_type.data.id", d.ID)
 		}
 		out.TargetTypeName = d.ID
 	}

--- a/models/work-item-link.go
+++ b/models/work-item-link.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/almighty/almighty-core/app"
 	convert "github.com/almighty/almighty-core/convert"
+	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"
 	satoriuuid "github.com/satori/go.uuid"
 )
@@ -56,7 +57,7 @@ func (self WorkItemLink) Equal(u convert.Equaler) bool {
 // cannot be used for the creation of a new work item link.
 func (t *WorkItemLink) CheckValidForCreation() error {
 	if satoriuuid.Equal(t.LinkTypeID, satoriuuid.Nil) {
-		return NewBadParameterError("link_type_id", t.LinkTypeID)
+		return errors.NewBadParameterError("link_type_id", t.LinkTypeID)
 	}
 	return nil
 }
@@ -110,13 +111,13 @@ func ConvertLinkToModel(in app.WorkItemLink, out *WorkItemLink) error {
 		if err != nil {
 			//log.Printf("Error when converting %s to UUID: %s", *in.Data.ID, err.Error())
 			// treat as not found: clients don't know it must be a UUID
-			return NewNotFoundError("work item link", id.String())
+			return errors.NewNotFoundError("work item link", id.String())
 		}
 		out.ID = id
 	}
 
 	if in.Data.Type != EndpointWorkItemLinks {
-		return NewBadParameterError("data.type", in.Data.Type).Expected(EndpointWorkItemLinks)
+		return errors.NewBadParameterError("data.type", in.Data.Type).Expected(EndpointWorkItemLinks)
 	}
 
 	if attrs != nil {
@@ -129,16 +130,16 @@ func ConvertLinkToModel(in app.WorkItemLink, out *WorkItemLink) error {
 		d := rel.LinkType.Data
 		// If the the link category is not nil, it MUST be "workitemlinktypes"
 		if d.Type != EndpointWorkItemLinkTypes {
-			return NewBadParameterError("data.relationships.link_type.data.type", d.Type).Expected(EndpointWorkItemLinkTypes)
+			return errors.NewBadParameterError("data.relationships.link_type.data.type", d.Type).Expected(EndpointWorkItemLinkTypes)
 		}
 		// The the link type id MUST NOT be empty
 		if d.ID == "" {
-			return NewBadParameterError("data.relationships.link_type.data.id", d.ID)
+			return errors.NewBadParameterError("data.relationships.link_type.data.id", d.ID)
 		}
 		if out.LinkTypeID, err = satoriuuid.FromString(d.ID); err != nil {
 			//log.Printf("Error when converting %s to UUID: %s", in.Data.ID, err.Error())
 			// treat as not found: clients don't know it must be a UUID
-			return NewNotFoundError("work item link type", d.ID)
+			return errors.NewNotFoundError("work item link type", d.ID)
 		}
 	}
 
@@ -146,14 +147,14 @@ func ConvertLinkToModel(in app.WorkItemLink, out *WorkItemLink) error {
 		d := rel.Source.Data
 		// If the the source type is not nil, it MUST be "workitems"
 		if d.Type != EndpointWorkItems {
-			return NewBadParameterError("data.relationships.source.data.type", d.Type).Expected(EndpointWorkItems)
+			return errors.NewBadParameterError("data.relationships.source.data.type", d.Type).Expected(EndpointWorkItems)
 		}
 		// The the work item id MUST NOT be empty
 		if d.ID == "" {
-			return NewBadParameterError("data.relationships.source.data.id", d.ID)
+			return errors.NewBadParameterError("data.relationships.source.data.id", d.ID)
 		}
 		if out.SourceID, err = strconv.ParseUint(d.ID, 10, 64); err != nil {
-			return NewBadParameterError("data.relationships.source.data.id", d.ID)
+			return errors.NewBadParameterError("data.relationships.source.data.id", d.ID)
 		}
 	}
 
@@ -161,14 +162,14 @@ func ConvertLinkToModel(in app.WorkItemLink, out *WorkItemLink) error {
 		d := rel.Target.Data
 		// If the the target type is not nil, it MUST be "workitems"
 		if d.Type != EndpointWorkItems {
-			return NewBadParameterError("data.relationships.target.data.type", d.Type).Expected(EndpointWorkItems)
+			return errors.NewBadParameterError("data.relationships.target.data.type", d.Type).Expected(EndpointWorkItems)
 		}
 		// The the work item id MUST NOT be empty
 		if d.ID == "" {
-			return NewBadParameterError("data.relationships.target.data.id", d.ID)
+			return errors.NewBadParameterError("data.relationships.target.data.id", d.ID)
 		}
 		if out.TargetID, err = strconv.ParseUint(d.ID, 10, 64); err != nil {
-			return NewBadParameterError("data.relationships.target.data.id", d.ID)
+			return errors.NewBadParameterError("data.relationships.target.data.id", d.ID)
 		}
 	}
 

--- a/models/workitem_repository.go
+++ b/models/workitem_repository.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/criteria"
+	"github.com/almighty/almighty-core/errors"
 	"github.com/jinzhu/gorm"
 )
 
@@ -22,17 +23,17 @@ func (r *GormWorkItemRepository) LoadFromDB(ID string) (*WorkItem, error) {
 	id, err := strconv.ParseUint(ID, 10, 64)
 	if err != nil {
 		// treating this as a not found error: the fact that we're using number internal is implementation detail
-		return nil, NotFoundError{"work item", ID}
+		return nil, errors.NewNotFoundError("work item", ID)
 	}
 	log.Printf("loading work item %d", id)
 	res := WorkItem{}
 	tx := r.db.First(&res, id)
 	if tx.RecordNotFound() {
 		log.Printf("not found, res=%v", res)
-		return nil, NotFoundError{"work item", ID}
+		return nil, errors.NewNotFoundError("work item", ID)
 	}
 	if tx.Error != nil {
-		return nil, InternalError{simpleError{tx.Error.Error()}}
+		return nil, errors.NewInternalError(tx.Error.Error())
 	}
 	return &res, nil
 }
@@ -46,11 +47,11 @@ func (r *GormWorkItemRepository) Load(ctx context.Context, ID string) (*app.Work
 	}
 	wiType, err := r.wir.LoadTypeFromDB(res.Type)
 	if err != nil {
-		return nil, InternalError{simpleError{err.Error()}}
+		return nil, errors.NewInternalError(err.Error())
 	}
 	result, err := wiType.ConvertFromModel(*res)
 	if err != nil {
-		return nil, ConversionError{simpleError{err.Error()}}
+		return nil, errors.NewConversionError(err.Error())
 	}
 	return result, nil
 }
@@ -62,16 +63,16 @@ func (r *GormWorkItemRepository) Delete(ctx context.Context, ID string) error {
 	id, err := strconv.ParseUint(ID, 10, 64)
 	if err != nil {
 		// treat as not found: clients don't know it must be a number
-		return NotFoundError{entity: "work item", ID: ID}
+		return errors.NewNotFoundError("work item", ID)
 	}
 	workItem.ID = id
 	tx := r.db.Delete(workItem)
 
 	if err = tx.Error; err != nil {
-		return InternalError{simpleError{err.Error()}}
+		return errors.NewInternalError(err.Error())
 	}
 	if tx.RowsAffected == 0 {
-		return NotFoundError{entity: "work item", ID: ID}
+		return errors.NewNotFoundError("work item", ID)
 	}
 
 	return nil
@@ -83,25 +84,25 @@ func (r *GormWorkItemRepository) Save(ctx context.Context, wi app.WorkItem) (*ap
 	res := WorkItem{}
 	id, err := strconv.ParseUint(wi.ID, 10, 64)
 	if err != nil {
-		return nil, NotFoundError{entity: "work item", ID: wi.ID}
+		return nil, errors.NewNotFoundError("work item", wi.ID)
 	}
 
 	log.Printf("looking for id %d", id)
 	tx := r.db.First(&res, id)
 	if tx.RecordNotFound() {
 		log.Printf("not found, res=%v", res)
-		return nil, NotFoundError{entity: "work item", ID: wi.ID}
+		return nil, errors.NewNotFoundError("work item", wi.ID)
 	}
 	if tx.Error != nil {
-		return nil, InternalError{simpleError{err.Error()}}
+		return nil, errors.NewInternalError(err.Error())
 	}
 	if res.Version != wi.Version {
-		return nil, VersionConflictError{simpleError{"version conflict"}}
+		return nil, errors.NewVersionConflictError("version conflict")
 	}
 
 	wiType, err := r.wir.LoadTypeFromDB(wi.Type)
 	if err != nil {
-		return nil, NewBadParameterError("Type", wi.Type)
+		return nil, errors.NewBadParameterError("Type", wi.Type)
 	}
 
 	newWi := WorkItem{
@@ -116,22 +117,22 @@ func (r *GormWorkItemRepository) Save(ctx context.Context, wi app.WorkItem) (*ap
 		var err error
 		newWi.Fields[fieldName], err = fieldDef.ConvertToModel(fieldName, fieldValue)
 		if err != nil {
-			return nil, NewBadParameterError(fieldName, fieldValue)
+			return nil, errors.NewBadParameterError(fieldName, fieldValue)
 		}
 	}
 
 	tx = tx.Where("Version = ?", wi.Version).Save(&newWi)
 	if err := tx.Error; err != nil {
 		log.Print(err.Error())
-		return nil, InternalError{simpleError{err.Error()}}
+		return nil, errors.NewInternalError(err.Error())
 	}
 	if tx.RowsAffected == 0 {
-		return nil, VersionConflictError{simpleError{"version conflict"}}
+		return nil, errors.NewVersionConflictError("version conflict")
 	}
 	log.Printf("updated item to %v\n", newWi)
 	result, err := wiType.ConvertFromModel(newWi)
 	if err != nil {
-		return nil, InternalError{simpleError{err.Error()}}
+		return nil, errors.NewInternalError(err.Error())
 	}
 	return result, nil
 }
@@ -141,7 +142,7 @@ func (r *GormWorkItemRepository) Save(ctx context.Context, wi app.WorkItem) (*ap
 func (r *GormWorkItemRepository) Create(ctx context.Context, typeID string, fields map[string]interface{}, creator string) (*app.WorkItem, error) {
 	wiType, err := r.wir.LoadTypeFromDB(typeID)
 	if err != nil {
-		return nil, NewBadParameterError("type", typeID)
+		return nil, errors.NewBadParameterError("type", typeID)
 	}
 	wi := WorkItem{
 		Type:   typeID,
@@ -153,18 +154,18 @@ func (r *GormWorkItemRepository) Create(ctx context.Context, typeID string, fiel
 		var err error
 		wi.Fields[fieldName], err = fieldDef.ConvertToModel(fieldName, fieldValue)
 		if err != nil {
-			return nil, NewBadParameterError(fieldName, fieldValue)
+			return nil, errors.NewBadParameterError(fieldName, fieldValue)
 		}
 	}
 	tx := r.db
 
 	if err = tx.Create(&wi).Error; err != nil {
-		return nil, InternalError{simpleError{err.Error()}}
+		return nil, errors.NewInternalError(err.Error())
 	}
 	log.Printf("created item %v\n", wi)
 	result, err := wiType.ConvertFromModel(wi)
 	if err != nil {
-		return nil, ConversionError{simpleError{err.Error()}}
+		return nil, errors.NewConversionError(err.Error())
 	}
 
 	return result, nil
@@ -175,7 +176,7 @@ func (r *GormWorkItemRepository) Create(ctx context.Context, typeID string, fiel
 func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, criteria criteria.Expression, start *int, limit *int) ([]WorkItem, uint64, error) {
 	where, parameters, compileError := Compile(criteria)
 	if compileError != nil {
-		return nil, 0, NewBadParameterError("expression", criteria)
+		return nil, 0, errors.NewBadParameterError("expression", criteria)
 	}
 
 	log.Printf("executing query: '%s' with params %v", where, parameters)
@@ -184,13 +185,13 @@ func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, criteria c
 	orgDB := db
 	if start != nil {
 		if *start < 0 {
-			return nil, 0, NewBadParameterError("start", *start)
+			return nil, 0, errors.NewBadParameterError("start", *start)
 		}
 		db = db.Offset(*start)
 	}
 	if limit != nil {
 		if *limit <= 0 {
-			return nil, 0, NewBadParameterError("limit", *limit)
+			return nil, 0, errors.NewBadParameterError("limit", *limit)
 		}
 		db = db.Limit(*limit)
 	}
@@ -206,7 +207,7 @@ func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, criteria c
 	value := WorkItem{}
 	columns, err := rows.Columns()
 	if err != nil {
-		return nil, 0, InternalError{simpleError{err.Error()}}
+		return nil, 0, errors.NewInternalError(err.Error())
 	}
 
 	// need to set up a result for Scan() in order to extract total count.
@@ -225,7 +226,7 @@ func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, criteria c
 		if first {
 			first = false
 			if err = rows.Scan(columnValues...); err != nil {
-				return nil, 0, InternalError{simpleError{err.Error()}}
+				return nil, 0, errors.NewInternalError(err.Error())
 			}
 		}
 		result = append(result, value)
@@ -258,11 +259,11 @@ func (r *GormWorkItemRepository) List(ctx context.Context, criteria criteria.Exp
 	for index, value := range result {
 		wiType, err := r.wir.LoadTypeFromDB(value.Type)
 		if err != nil {
-			return nil, 0, InternalError{simpleError{err.Error()}}
+			return nil, 0, errors.NewInternalError(err.Error())
 		}
 		res[index], err = wiType.ConvertFromModel(value)
 		if err != nil {
-			return nil, 0, ConversionError{simpleError{err.Error()}}
+			return nil, 0, errors.NewConversionError(err.Error())
 		}
 	}
 

--- a/models/workitemtype_repository_blackbox_test.go
+++ b/models/workitemtype_repository_blackbox_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/models"
 	"github.com/stretchr/testify/assert"
@@ -51,7 +52,7 @@ func (s *workItemTypeRepoBlackBoxTest) TestCreateLoadWIT() {
 	assert.NotNil(s.T(), wit)
 
 	wit3, err := s.repo.Create(context.Background(), nil, "foo.bar", map[string]app.FieldDefinition{})
-	assert.IsType(s.T(), models.BadParameterError{}, err)
+	assert.IsType(s.T(), errors.BadParameterError{}, err)
 	assert.Nil(s.T(), wit3)
 
 	wit2, err := s.repo.Load(context.Background(), "foo.bar")

--- a/search.go
+++ b/search.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/jsonapi"
-	"github.com/almighty/almighty-core/models"
 	"github.com/goadesign/goa"
 )
 
@@ -59,7 +59,7 @@ func (c *SearchController) Show(ctx *app.ShowSearchContext) error {
 		count := int(c)
 		if err != nil {
 			switch err := err.(type) {
-			case models.BadParameterError:
+			case errors.BadParameterError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error listing work items: %s", err.Error())))
 				return ctx.BadRequest(jerrors)
 			default:

--- a/work-item-link.go
+++ b/work-item-link.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/models"
 	"github.com/goadesign/goa"
@@ -42,7 +43,7 @@ func (c *WorkItemLinkController) Create(ctx *app.CreateWorkItemLinkContext) erro
 		cat, err := appl.WorkItemLinks().Create(ctx.Context, model.SourceID, model.TargetID, model.LinkTypeID)
 		if err != nil {
 			switch err.(type) {
-			case models.NotFoundError:
+			case errors.NotFoundError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(err.Error()))
 				return ctx.BadRequest(jerrors)
 			default:

--- a/workitem.2.go
+++ b/workitem.2.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/models"
 	query "github.com/almighty/almighty-core/query/simple"
@@ -137,7 +138,7 @@ func (c *Workitem2Controller) List(ctx *app.ListWorkitem2Context) error {
 		count := int(c)
 		if err != nil {
 			switch err := err.(type) {
-			case models.BadParameterError:
+			case errors.BadParameterError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error listing work items: %s", err.Error())))
 				return ctx.BadRequest(jerrors)
 			default:
@@ -228,13 +229,13 @@ func (c *Workitem2Controller) Update(ctx *app.UpdateWorkitem2Context) error {
 		wi, err := appl.WorkItems2().Save(ctx, toSave)
 		if err != nil {
 			switch err := err.(type) {
-			case models.BadParameterError:
+			case errors.BadParameterError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
 				return ctx.BadRequest(jerrors)
-			case models.NotFoundError:
+			case errors.NotFoundError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrNotFound(err.Error()))
 				return ctx.NotFound(jerrors)
-			case models.VersionConflictError:
+			case errors.VersionConflictError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
 				return ctx.BadRequest(jerrors)
 			default:

--- a/workitem.go
+++ b/workitem.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/login"
-	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/query/simple"
 )
 
@@ -106,7 +106,7 @@ func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
 
 		if err != nil {
 			switch err := err.(type) {
-			case models.BadParameterError, models.ConversionError:
+			case errors.BadParameterError, errors.ConversionError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(err.Error()))
 				return ctx.BadRequest(jerrors)
 			default:
@@ -145,7 +145,7 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 
 		if err != nil {
 			switch err := err.(type) {
-			case models.BadParameterError, models.ConversionError:
+			case errors.BadParameterError, errors.ConversionError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(err.Error()))
 				return ctx.BadRequest(jerrors)
 			default:


### PR DESCRIPTION
This allows for packages to use errors without causing a cyclic import.

@aslakknutsen @tsmaeder please review! Thx.