### PR TITLE
Add special ID:0 handling to WorkItem Repository Delete|Save|Load

### DIFF
--- a/models/workitem_repository.go
+++ b/models/workitem_repository.go
@@ -21,7 +21,7 @@ type GormWorkItemRepository struct {
 // LoadFromDB returns the work item with the given ID in model representation.
 func (r *GormWorkItemRepository) LoadFromDB(ID string) (*WorkItem, error) {
 	id, err := strconv.ParseUint(ID, 10, 64)
-	if err != nil {
+	if err != nil || id == 0 {
 		// treating this as a not found error: the fact that we're using number internal is implementation detail
 		return nil, errors.NewNotFoundError("work item", ID)
 	}
@@ -61,7 +61,7 @@ func (r *GormWorkItemRepository) Load(ctx context.Context, ID string) (*app.Work
 func (r *GormWorkItemRepository) Delete(ctx context.Context, ID string) error {
 	var workItem = WorkItem{}
 	id, err := strconv.ParseUint(ID, 10, 64)
-	if err != nil {
+	if err != nil || id == 0 {
 		// treat as not found: clients don't know it must be a number
 		return errors.NewNotFoundError("work item", ID)
 	}
@@ -83,7 +83,7 @@ func (r *GormWorkItemRepository) Delete(ctx context.Context, ID string) error {
 func (r *GormWorkItemRepository) Save(ctx context.Context, wi app.WorkItem) (*app.WorkItem, error) {
 	res := WorkItem{}
 	id, err := strconv.ParseUint(wi.ID, 10, 64)
-	if err != nil {
+	if err != nil || id == 0 {
 		return nil, errors.NewNotFoundError("work item", wi.ID)
 	}
 

--- a/models/workitem_repository_blackbox_test.go
+++ b/models/workitem_repository_blackbox_test.go
@@ -1,0 +1,84 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/errors"
+	"github.com/almighty/almighty-core/gormsupport"
+	"github.com/almighty/almighty-core/models"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/net/context"
+)
+
+type workItemRepoBlackBoxTest struct {
+	gormsupport.DBTestSuite
+	repo application.WorkItemRepository
+}
+
+func TestRunWorkTypeRepoBlackBoxTest(t *testing.T) {
+	suite.Run(t, &workItemRepoBlackBoxTest{DBTestSuite: gormsupport.NewDBTestSuite("../config.yaml")})
+}
+
+func (s *workItemRepoBlackBoxTest) SetupTest() {
+	s.repo = models.NewWorkItemRepository(s.DB)
+}
+
+func (s *workItemRepoBlackBoxTest) TestFailDeleteZeroID() {
+	defer gormsupport.DeleteCreatedEntities(s.DB)()
+
+	// Create at least 1 item to avoid RowsEffectedCheck
+	_, err := s.repo.Create(
+		context.Background(), "system.bug",
+		map[string]interface{}{
+			models.SystemTitle: "Title",
+			models.SystemState: models.SystemStateNew,
+		}, "xx")
+
+	if err != nil {
+		s.T().Error("Could not create workitem", err)
+	}
+
+	err = s.repo.Delete(context.Background(), "0")
+	require.IsType(s.T(), errors.NotFoundError{}, err)
+}
+
+func (s *workItemRepoBlackBoxTest) TestFailSaveZeroID() {
+	defer gormsupport.DeleteCreatedEntities(s.DB)()
+
+	// Create at least 1 item to avoid RowsEffectedCheck
+	wi, err := s.repo.Create(
+		context.Background(), "system.bug",
+		map[string]interface{}{
+			models.SystemTitle: "Title",
+			models.SystemState: models.SystemStateNew,
+		}, "xx")
+
+	if err != nil {
+		s.T().Error("Could not create workitem", err)
+	}
+	wi.ID = "0"
+
+	_, err = s.repo.Save(context.Background(), *wi)
+	require.IsType(s.T(), errors.NotFoundError{}, err)
+}
+
+func (s *workItemRepoBlackBoxTest) TestFaiLoadZeroID() {
+	defer gormsupport.DeleteCreatedEntities(s.DB)()
+
+	// Create at least 1 item to avoid RowsEffectedCheck
+	_, err := s.repo.Create(
+		context.Background(), "system.bug",
+		map[string]interface{}{
+			models.SystemTitle: "Title",
+			models.SystemState: models.SystemStateNew,
+		}, "xx")
+
+	if err != nil {
+		s.T().Error("Could not create workitem", err)
+	}
+
+	_, err = s.repo.Load(context.Background(), "0")
+	require.IsType(s.T(), errors.NotFoundError{}, err)
+}


### PR DESCRIPTION
0 is handled in Gorm as a Zero value and it assumes no value is set,
and generate no WHERE clause.

e.g.

```
UPDATE "work_items" SET deleted_at='2016-12-07T05:05:11+01:00'  WHERE "work_items".deleted_at IS NUL
```

> Delete ALL workitems not allready deleted