### PR TITLE
WIP Fix #533 - Include related resources by default in all actions and endpoints that deal with work item links

### DIFF
--- a/design/media_types.go
+++ b/design/media_types.go
@@ -363,7 +363,7 @@ var WorkItemLink = a.MediaType("application/vnd.work-item-link+json", func() {
 	a.Description(`Defines a connection between two work items`)
 	a.Attributes(func() {
 		a.Attribute("data", WorkItemLinkData)
-		a.Attribute("included", a.ArrayOf(WorkItemLinkTypeData))
+		a.Attribute("included", a.ArrayOf(d.Any), "An array of mixed types (source + target WI, link type, link category, WI types)")
 		a.Required("data")
 	})
 	a.View("default", func() {
@@ -381,7 +381,7 @@ var WorkItemLinkArray = a.MediaType("application/vnd.work-item-link-array+json",
 	a.Attributes(func() {
 		a.Attribute("meta", WorkItemLinkArrayMeta)
 		a.Attribute("data", a.ArrayOf(WorkItemLinkData))
-		a.Attribute("included", a.ArrayOf(WorkItemLinkTypeData))
+		a.Attribute("included", a.ArrayOf(d.Any), "An array of mixed types (source + target WIs, link types, link categories, WI types)")
 		a.Required("data")
 	})
 	a.View("default", func() {


### PR DESCRIPTION
Changes the "included" JSONAPI array for work item links to include an array of mixed values (in Goa: `d.Any`, in Go: `[]interface{}`). This allows us to include work items, work item types, work item link types, and work item link categories in the responses for CRUL operations.

When the UI fetches a link today, it only gets the source and target's work item ID. After that it has to make multiple additional requests to get the work item type or the source and the target. The idea of this PR is that UI doesn't have to do any more requests than necessary to get all the information of a link or an array of links in one response.

**NOTE:** Currently, only include the work item link types and work item link categories in the `included` array. For the other resources to be included, they need to be converted to JSONAPI first (see #559).