### PR TITLE
Fix #586 Unique work item links

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -111,6 +111,9 @@ func getMigrations() migrations {
 
 	// Version 11
 	m = append(m, steps{executeSQLFile("011-projects.sql")})
+
+	// Version 12
+	m = append(m, steps{executeSQLFile("012-unique-work-item-links.sql")})
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/012-unique-work-item-links.sql
+++ b/migration/sql-files/012-unique-work-item-links.sql
@@ -1,0 +1,16 @@
+-- Delete duplicate links in existence and keep only one
+-- See here: https://wiki.postgresql.org/wiki/Deleting_duplicates
+DELETE FROM work_item_links
+WHERE id IN (
+    SELECT id
+    FROM (
+        SELECT id, ROW_NUMBER() OVER (partition BY link_type_id, source_id, target_id ORDER BY id) AS rnum
+        FROM work_item_links
+    ) t
+    WHERE t.rnum > 1
+);
+
+-- From now on ensure we only have ONE link with the same source, target and
+-- link type in existence. If a link has been deleted (deleted_at != NULL) then
+-- we can recreate the link with the source, target and link type again.
+CREATE UNIQUE INDEX work_item_links_unique_idx ON work_item_links (source_id, target_id, link_type_id) WHERE deleted_at IS NULL;

--- a/work-item-link-blackbox_test.go
+++ b/work-item-link-blackbox_test.go
@@ -341,6 +341,16 @@ func (s *workItemLinkSuite) TestCreateAndDeleteWorkItemLink() {
 	_ = test.DeleteWorkItemLinkOK(s.T(), nil, nil, s.workItemLinkCtrl, *workItemLink.Data.ID)
 }
 
+// Check if #586 is fixed.
+func (s *workItemLinkSuite) TestCreateAndDeleteWorkItemLinkBadRequestDueToUniqueViolation() {
+	createPayload1 := CreateWorkItemLink(s.bug1ID, s.bug2ID, s.bugBlockerLinkTypeID)
+	_, workItemLink1 := test.CreateWorkItemLinkCreated(s.T(), nil, nil, s.workItemLinkCtrl, createPayload1)
+	require.NotNil(s.T(), workItemLink1)
+	s.deleteWorkItemLinks = append(s.deleteWorkItemLinks, *workItemLink1.Data.ID)
+	createPayload2 := CreateWorkItemLink(s.bug1ID, s.bug2ID, s.bugBlockerLinkTypeID)
+	_, _ = test.CreateWorkItemLinkBadRequest(s.T(), nil, nil, s.workItemLinkCtrl, createPayload2)
+}
+
 // Same for /api/workitems/:id/relationships/links
 func (s *workItemLinkSuite) TestCreateAndDeleteWorkItemRelationshipsLink() {
 	createPayload := CreateWorkItemLink(s.bug1ID, s.bug2ID, s.bugBlockerLinkTypeID)

--- a/work-item-link.go
+++ b/work-item-link.go
@@ -246,6 +246,9 @@ func createWorkItemLink(ctx *workItemLinkContext, funcs createWorkItemLinkFuncs,
 		case errors.NotFoundError:
 			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(err.Error()))
 			return funcs.BadRequest(jerrors)
+		case errors.BadParameterError:
+			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(err.Error()))
+			return funcs.BadRequest(jerrors)
 		default:
 			jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(err)
 			return ctx.ResponseData.Service.Send(ctx.Context, httpStatusCode, jerrors)
@@ -262,9 +265,7 @@ func createWorkItemLink(ctx *workItemLinkContext, funcs createWorkItemLinkFuncs,
 
 // Create runs the create action.
 func (c *WorkItemLinkController) Create(ctx *app.CreateWorkItemLinkContext) error {
-	return application.Transactional(c.db, func(appl application.Application) error {
-		return createWorkItemLink(newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkHref), ctx, ctx.Payload)
-	})
+	return createWorkItemLink(newWorkItemLinkContext(ctx.Context, c.db, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkHref), ctx, ctx.Payload)
 }
 
 type deleteWorkItemLinkFuncs interface {

--- a/workitem/link/link-repository.go
+++ b/workitem/link/link-repository.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/errors"
+	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/jinzhu/gorm"
 	satoriuuid "github.com/satori/go.uuid"
@@ -101,6 +102,10 @@ func (r *GormWorkItemLinkRepository) Create(ctx context.Context, sourceID, targe
 	}
 	db := r.db.Create(link)
 	if db.Error != nil {
+		if gormsupport.IsUniqueViolation(db.Error, "work_item_links_unique_idx") {
+			// TODO(kwk): Make NewBadParameterError a variadic function to avoid this ugliness ;)
+			return nil, errors.NewBadParameterError("data.relationships.source_id + data.relationships.target_id + data.relationships.link_type_id", sourceID).Expected("unique")
+		}
 		return nil, errors.NewInternalError(db.Error.Error())
 	}
 	// Convert the created link type entry into a JSONAPI response


### PR DESCRIPTION
* Deletes existing duplicate WI links on database level
* Installs a unique key to allow for only one existing WI of the same type with the same source and target
* Checks for unique key violation on creation of WI link and returns BadRequest

Fix #586
