### PR TITLE
Remove some endpoints

### DIFF
--- a/design/work-item-link.go
+++ b/design/work-item-link.go
@@ -129,9 +129,6 @@ var _ = a.Resource("work-item-link", func() {
 var _ = a.Resource("work-item-relationships-links", func() {
 	a.BasePath("/relationships/links")
 	a.Parent("workitem")
-	a.Action("show", showWorkItemLink)
-	a.Action("delete", deleteWorkItemLink)
-	a.Action("update", updateWorkItemLink)
 	a.Action("list", func() {
 		listWorkItemLinks()
 		a.Description("List work item links associated with the given work item (either as source or as target work item).")


### PR DESCRIPTION
As discussed with @aslakknutsen, these endpoints have been removed:

 - DELETE /workitems/{id}/relationships/links/{linkId} (delete work-item-relationships-links)
 - GET /workitems/{id}/relationships/links/{linkId} (show work-item-relationships-links)
 - PATCH /workitems/{id}/relationships/links/{linkId} (update work-item-relationships-links)

@sanbornsen confirmed, that they are not in use at the moment.