### PR TITLE
Bug in `workitemtype_repository.Create(...)` method (#609)

### DIFF
--- a/workitem/workitemtype_repository.go
+++ b/workitem/workitemtype_repository.go
@@ -75,7 +75,7 @@ func (r *GormWorkItemTypeRepository) Create(ctx context.Context, extendedTypeNam
 	path := pathSep + name
 	if extendedTypeName != nil {
 		extendedType := WorkItemType{}
-		db := r.db.First(&extendedType, extendedTypeName)
+		db := r.db.First(&extendedType, "name = ?", extendedTypeName)
 		if db.RecordNotFound() {
 			log.Printf("not found, res=%v", extendedType)
 			return nil, errors.NewBadParameterError("extendedTypeName", *extendedTypeName)

--- a/workitem/workitemtype_repository_blackbox_test.go
+++ b/workitem/workitemtype_repository_blackbox_test.go
@@ -94,3 +94,32 @@ func (s *workItemTypeRepoBlackBoxTest) TestCreateLoadWITWithList() {
 	assert.Nil(s.T(), field.Type.BaseType)
 	assert.Nil(s.T(), field.Type.Values)
 }
+
+func (s *workItemTypeRepoBlackBoxTest) TestCreateWITWithBaseType() {
+	bt := "string"
+	basetype := "foo.bar"
+	baseWit, err := s.repo.Create(context.Background(), nil, basetype, map[string]app.FieldDefinition{
+		"foo": app.FieldDefinition{
+			Required: true,
+			Type: &app.FieldType{
+				ComponentType: &bt,
+				Kind:          string(workitem.KindList),
+			},
+		},
+	})
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), baseWit)
+	extendedWit, err := s.repo.Create(context.Background(), &basetype, "foo.baz", map[string]app.FieldDefinition{})
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), extendedWit)
+	// the Field 'foo' must exist since it is inherited from the base work item type
+	assert.NotNil(s.T(), extendedWit.Fields["foo"])
+}
+
+func (s *workItemTypeRepoBlackBoxTest) TestDoNotCreateWITWithMissingBaseType() {
+	basetype := "unknown"
+	extendedWit, err := s.repo.Create(context.Background(), &basetype, "foo.baz", map[string]app.FieldDefinition{})
+	// expect an error as the given base type does not exist
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), extendedWit)
+}


### PR DESCRIPTION
Added missing `name = ?`criteria in the where clause.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/almighty/almighty-core/610)
<!-- Reviewable:end -->
