### PR TITLE
Stored Github User information should be updated #537

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -85,7 +85,23 @@ func (err NotFoundError) Error() string {
 	return fmt.Sprintf(stNotFoundErrorMsg, err.entity, err.ID)
 }
 
-// NewNotFoundError returns the custom defined error of type NewNotFoundError.
+// NewNotFoundError returns the custom defined error of type NotFoundError.
 func NewNotFoundError(entity string, id string) NotFoundError {
 	return NotFoundError{entity: entity, ID: id}
+}
+
+// IdentityError is an error that can occur when the user identity could not be retrieved during the login
+type IdentityError struct {
+	Code    int
+	Message interface{}
+}
+
+// IdentityError implements the error interface
+func (err IdentityError) Error() string {
+	return fmt.Sprintf("%v", err.Message)
+}
+
+// NewIdentityError returns the custom defined error of type IdentityError.
+func NewIdentityError(code int, message interface{}) *IdentityError {
+	return &IdentityError{Code: code, Message: message}
 }

--- a/login/service_whitebox_test.go
+++ b/login/service_whitebox_test.go
@@ -2,147 +2,194 @@ package login
 
 import (
 	"fmt"
+	"log"
 	"testing"
 	"time"
 
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/configuration"
+	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/almighty/almighty-core/token"
+	"github.com/jinzhu/gorm"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2/github"
 )
 
-var loginService *gitHubOAuth
+type serviceWhiteBoxTest struct {
+	gormsupport.DBTestSuite
+	loginService       *gitHubOAuth
+	identityRepository account.IdentityRepository
+	userRepository     account.UserRepository
+}
 
-func setup() {
+func TestRunServiceWhiteBoxTest(t *testing.T) {
+	suite.Run(t, &serviceWhiteBoxTest{DBTestSuite: gormsupport.NewDBTestSuite("../config.yaml")})
+}
 
+func (s *serviceWhiteBoxTest) SetupTest() {
 	var err error
 	if err = configuration.Setup(""); err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
-
 	oauth := &oauth2.Config{
 		ClientID:     configuration.GetGithubClientID(),
 		ClientSecret: configuration.GetGithubSecret(),
 		Scopes:       []string{"user:email"},
 		Endpoint:     github.Endpoint,
 	}
-
 	publicKey, err := token.ParsePublicKey([]byte(configuration.GetTokenPublicKey()))
 	if err != nil {
 		panic(err)
 	}
-
 	privateKey, err := token.ParsePrivateKey([]byte(configuration.GetTokenPrivateKey()))
 	if err != nil {
 		panic(err)
 	}
-
 	tokenManager := token.NewManager(publicKey, privateKey)
-	userRepository := account.NewUserRepository(nil)
-	identityRepository := account.NewIdentityRepository(nil)
-	loginService = &gitHubOAuth{
+	s.userRepository = account.NewUserRepository(s.DB)
+	s.identityRepository = account.NewIdentityRepository(s.DB)
+	s.loginService = &gitHubOAuth{
 		config:       oauth,
-		identities:   identityRepository,
-		users:        userRepository,
+		identities:   s.identityRepository,
+		users:        s.userRepository,
 		tokenManager: tokenManager,
 	}
+	s.DB.LogMode(true)
+
 }
 
-func tearDown() {
-	loginService = nil
-}
-
-func TestValidOAuthAccessToken(t *testing.T) {
-	resource.Require(t, resource.UnitTest)
-	setup()
-	defer tearDown()
-
+func (s *serviceWhiteBoxTest) TestValidOAuthAccessToken() {
+	resource.Require(s.T(), resource.UnitTest)
 	accessToken := &oauth2.Token{
 		AccessToken: configuration.GetGithubAuthToken(),
 		TokenType:   "Bearer",
 	}
-	emails, err := loginService.getUserEmails(context.Background(), accessToken)
+	emails, err := s.loginService.getUserEmails(context.Background(), accessToken)
 	var trials int // Number of tries to reach GitHub
 	if err != nil {
 		for trials = 0; trials < 10; trials++ {
-			emails, err = loginService.getUserEmails(context.Background(), accessToken)
+			emails, err = s.loginService.getUserEmails(context.Background(), accessToken)
 			if err == nil {
-				assert.NotEmpty(t, emails)
+				assert.NotEmpty(s.T(), emails)
 				break
 			}
 			time.Sleep(5 * time.Second) // Pause before the next retry
 		}
 		if trials == 10 {
-			t.Error("Test failed, Maximum Retry limit reached", err) // Test failed after trial for 10 times
+			s.T().Error("Test failed, Maximum Retry limit reached", err) // Test failed after trial for 10 times
 		}
 	} else {
-		assert.NotEmpty(t, emails)
+		assert.NotEmpty(s.T(), emails)
 	}
 }
 
-func TestInvalidOAuthAccessToken(t *testing.T) {
-	resource.Require(t, resource.UnitTest)
-	setup()
-	defer tearDown()
-
-	if loginService == nil {
-		setup()
-	}
-
+func (s *serviceWhiteBoxTest) TestInvalidOAuthAccessToken() {
+	resource.Require(s.T(), resource.UnitTest)
 	invalidAccessToken := "7423742yuuiy-INVALID-73842342389h"
-
 	accessToken := &oauth2.Token{
 		AccessToken: invalidAccessToken,
 		TokenType:   "Bearer",
 	}
-
-	emails, err := loginService.getUserEmails(context.Background(), accessToken)
-	assert.Nil(t, err)
-	assert.Empty(t, emails)
+	emails, err := s.loginService.getUserEmails(context.Background(), accessToken)
+	assert.Nil(s.T(), err)
+	assert.Empty(s.T(), emails)
 }
 
-func TestGetUserEmails(t *testing.T) {
-	resource.Require(t, resource.UnitTest)
+func (s *serviceWhiteBoxTest) TestGetUserEmails() {
+	resource.Require(s.T(), resource.UnitTest)
+	accessToken := &oauth2.Token{
+		AccessToken: configuration.GetGithubAuthToken(),
+		TokenType:   "Bearer",
+	}
+	githubEmails, err := s.loginService.getUserEmails(context.Background(), accessToken)
+	s.T().Log(githubEmails)
+	require.Nil(s.T(), err)
+	assert.NotNil(s.T(), githubEmails)
+	assert.NotEmpty(s.T(), githubEmails)
+}
 
-	setup()
-	defer tearDown()
+func (s *serviceWhiteBoxTest) TestGetUser() {
+	resource.Require(s.T(), resource.UnitTest)
+	accessToken := &oauth2.Token{
+		AccessToken: configuration.GetGithubAuthToken(),
+		TokenType:   "Bearer",
+	}
+	githubUser, err := s.loginService.getUser(context.Background(), accessToken)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), githubUser)
+	s.T().Log(githubUser)
+}
+
+func (s *serviceWhiteBoxTest) TestFilterPrimaryEmail() {
+	resource.Require(s.T(), resource.UnitTest)
+	s.T().Skip("Not implemented")
+}
+
+func (s *serviceWhiteBoxTest) TestCreateUser() {
+	resource.Require(s.T(), resource.Database)
+	defer gormsupport.DeleteCreatedEntities(s.DB)()
+	s.removeUserIfExists("sbose78@gmail.com")
 
 	accessToken := &oauth2.Token{
 		AccessToken: configuration.GetGithubAuthToken(),
 		TokenType:   "Bearer",
 	}
-
-	githubEmails, err := loginService.getUserEmails(context.Background(), accessToken)
-	t.Log(githubEmails)
-	assert.Nil(t, err)
-	assert.NotNil(t, githubEmails)
-	assert.NotEmpty(t, githubEmails)
+	identity, err := s.loginService.retrieveUserIdentity(context.Background(), accessToken)
+	require.Nil(s.T(), err)
+	assert.NotNil(s.T(), identity.FullName)
+	assert.Regexp(s.T(), "https://avatars.githubusercontent.com/u/...", identity.ImageURL)
+	storedIdentity, _ := s.identityRepository.Load(context.Background(), identity.ID)
+	require.NotNil(s.T(), storedIdentity)
+	assert.NotNil(s.T(), storedIdentity.FullName)
+	assert.NotNil(s.T(), storedIdentity.ImageURL)
 }
 
-func TestGetUser(t *testing.T) {
-	resource.Require(t, resource.UnitTest)
-	setup()
-	defer tearDown()
-
+func (s *serviceWhiteBoxTest) TestUpdateUser() {
+	resource.Require(s.T(), resource.Database)
+	defer gormsupport.DeleteCreatedEntities(s.DB)()
+	// preload db with an identity
+	s.removeUserIfExists("sbose78@gmail.com")
+	existingUser := account.User{Email: "sbose78@gmail.com"}
+	existingIdentity := account.Identity{Emails: []account.User{existingUser}}
+	s.identityRepository.Create(context.Background(), &existingIdentity)
+	// verify that the identify exists, but without any fullname and avatar URL
+	storedIdentity, _ := s.identityRepository.Load(context.Background(), existingIdentity.ID)
+	require.NotNil(s.T(), storedIdentity)
+	require.Equal(s.T(), "", storedIdentity.FullName)
+	require.Equal(s.T(), "", storedIdentity.ImageURL)
 	accessToken := &oauth2.Token{
 		AccessToken: configuration.GetGithubAuthToken(),
 		TokenType:   "Bearer",
 	}
+	identity, err := s.loginService.retrieveUserIdentity(context.Background(), accessToken)
+	require.Nil(s.T(), err)
+	assert.Equal(s.T(), identity.ID, storedIdentity.ID)
+	assert.NotNil(s.T(), identity.FullName)
+	assert.Regexp(s.T(), "https://avatars.githubusercontent.com/u/...", identity.ImageURL)
+	storedIdentity, _ = s.identityRepository.Load(context.Background(), identity.ID)
+	require.NotNil(s.T(), storedIdentity)
+	assert.NotNil(s.T(), storedIdentity.FullName)
+	assert.NotNil(s.T(), storedIdentity.ImageURL)
 
-	githubUser, err := loginService.getUser(context.Background(), accessToken)
-	assert.Nil(t, err)
-	assert.NotNil(t, githubUser)
-	t.Log(githubUser)
 }
 
-func TestFilterPrimaryEmail(t *testing.T) {
-	resource.Require(t, resource.UnitTest)
-
-	t.Skip("Not implemented")
+func (s *serviceWhiteBoxTest) removeUserIfExists(email string) {
+	// remove identity if it already exists
+	storedUsers, _ := s.userRepository.Query(account.UserWithIdentity(), func(db *gorm.DB) *gorm.DB {
+		return db.Where("email = ?", email)
+	})
+	if len(storedUsers) > 0 {
+		for i, _ := range storedUsers {
+			log.Println("Removing identify " + storedUsers[i].Identity.FullName + " (" + storedUsers[i].Identity.ID.String() + ")")
+			s.DB.Unscoped().Delete(storedUsers[i])
+			s.DB.Unscoped().Delete(storedUsers[i].Identity)
+		}
+	}
 }


### PR DESCRIPTION
Update on previous commit: fullname and avatar URL from GitHub
are stored in the identity during the update.

Added some tests in `login/service_whitebox_test.go` to verify
that the identity is created or updated. The test removes the
existing identity and users if it exists.
Using the `gormsupport.DBTestSuite` required some changes on all
tests in the file.

Fixes #537 
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
