### PR TITLE
Escape round brackets from search-query-string

### DIFF
--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -139,7 +139,11 @@ func trimProtocolFromURLString(urlString string) string {
 }
 
 func escapeCharFromURLString(urlString string) string {
-	return strings.Replace(urlString, ":", "\\:", -1)
+	// Would like to replace following statements with some better piece of code if any.
+	urlString = strings.Replace(urlString, ":", "\\:", -1)
+	urlString = strings.Replace(urlString, "(", "\\(", -1)
+	urlString = strings.Replace(urlString, ")", "\\)", -1)
+	return urlString
 }
 
 // sanitizeURL does cleaning of URL

--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -139,11 +139,9 @@ func trimProtocolFromURLString(urlString string) string {
 }
 
 func escapeCharFromURLString(urlString string) string {
-	// Would like to replace following statements with some better piece of code if any.
-	urlString = strings.Replace(urlString, ":", "\\:", -1)
-	urlString = strings.Replace(urlString, "(", "\\(", -1)
-	urlString = strings.Replace(urlString, ")", "\\)", -1)
-	return urlString
+	// Replacer will escape `:` and `)` `(`.
+	var replacer = strings.NewReplacer(":", "\\:", "(", "\\(", ")", "\\)")
+	return replacer.Replace(urlString)
 }
 
 // sanitizeURL does cleaning of URL

--- a/search/search_repository_whitebox_test.go
+++ b/search/search_repository_whitebox_test.go
@@ -34,7 +34,6 @@ type SearchTestDescriptor struct {
 }
 
 func (s *searchRepositoryWhiteboxTest) TestSearchByText() {
-
 	wir := workitem.NewWorkItemRepository(s.DB)
 
 	testDataSet := []SearchTestDescriptor{
@@ -102,6 +101,30 @@ func (s *searchRepositoryWhiteboxTest) TestSearchByText() {
 			},
 			searchString:   `negative case `,
 			minimumResults: 0,
+		}, {
+			wi: app.WorkItem{
+				// search stirng with braces should be acceptable case
+				Fields: map[string]interface{}{
+					workitem.SystemTitle:     "Bug reported by administrator for input = (value)",
+					workitem.SystemCreator:   "pgore",
+					workitem.SystemAssignees: []string{"pranav"},
+					workitem.SystemState:     "new",
+				},
+			},
+			searchString:   `(value) `,
+			minimumResults: 1,
+		}, {
+			wi: app.WorkItem{
+				// search stirng with surrounding braces should be acceptable case
+				Fields: map[string]interface{}{
+					workitem.SystemTitle:     "trial for braces (pranav) {shoubhik} [aslak]",
+					workitem.SystemCreator:   "pgore",
+					workitem.SystemAssignees: []string{"pranav"},
+					workitem.SystemState:     "new",
+				},
+			},
+			searchString:   `(pranav) {shoubhik} [aslak] `,
+			minimumResults: 1,
 		},
 	}
 


### PR DESCRIPTION
Fixes #637 

Added escaping for round braces. Test udpated to expose the bug and add more test_data to check other brackets forms.

API call for search `./bin/alm-cli show search --q '(value)' -H localhost:8080 --pp`

Old Response
```
2017/01/09 11:51:23 [INFO] started id=4FsSPqKA GET=http://localhost:8080/api/search?q=%28value%29
2017/01/09 11:51:23 [INFO] completed id=4FsSPqKA status=500 time=22.055212ms
error: 500: {"errors":[{"code":"internal","detail":"pq: syntax error in tsquery: \"(value):*\"","id":"9QWiejgv","status":"500","title":"Internal Server Error"}]}
{"errors":[{"code":"unknown_error","detail":"pq: Could not complete operation in a failed transaction","status":"500","title":"Unknown error"}]}
```

New Response
```
2017/01/09 11:50:51 [INFO] started id=kp+L4myG GET=http://localhost:8080/api/search?q=%28value%29
2017/01/09 11:50:51 [INFO] completed id=kp+L4myG status=200 time=18.683388ms
{
    "data": [],
    "links": {
        "first": "http://localhost:8080/api/search?q=(value)\u0026page[offset]=0\u0026page[limit]=100",
        "last": "http://localhost:8080/api/search?q=(value)\u0026page[offset]=0\u0026page[limit]=0"
    },
    "meta": {
        "totalCount": 0
    }
}
```