### PR TITLE
WIP Fix 641

### DIFF
--- a/account/identity.go
+++ b/account/identity.go
@@ -7,6 +7,7 @@ import (
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"golang.org/x/net/context"
 )

--- a/account/identity.go
+++ b/account/identity.go
@@ -81,10 +81,10 @@ func (m *GormIdentityRepository) Load(ctx context.Context, id uuid.UUID) (*Ident
 	var native Identity
 	err := m.db.Table(m.TableName()).Where("id = ?", id).Find(&native).Error
 	if err == gorm.ErrRecordNotFound {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
-	return &native, err
+	return &native, errors.WithStack(err)
 }
 
 // Create creates a new record.
@@ -96,7 +96,7 @@ func (m *GormIdentityRepository) Create(ctx context.Context, model *Identity) er
 	err := m.db.Create(model).Error
 	if err != nil {
 		goa.LogError(ctx, "error adding Identity", "error", err.Error())
-		return err
+		return errors.WithStack(err)
 	}
 
 	return nil
@@ -109,11 +109,11 @@ func (m *GormIdentityRepository) Save(ctx context.Context, model *Identity) erro
 	obj, err := m.Load(ctx, model.ID)
 	if err != nil {
 		goa.LogError(ctx, "error updating Identity", "error", err.Error())
-		return err
+		return errors.WithStack(err)
 	}
 	err = m.db.Model(obj).Updates(model).Error
 
-	return err
+	return errors.WithStack(err)
 }
 
 // Delete removes a single record.
@@ -126,7 +126,7 @@ func (m *GormIdentityRepository) Delete(ctx context.Context, id uuid.UUID) error
 
 	if err != nil {
 		goa.LogError(ctx, "error deleting Identity", "error", err.Error())
-		return err
+		return errors.WithStack(err)
 	}
 
 	return nil
@@ -139,7 +139,7 @@ func (m *GormIdentityRepository) Query(funcs ...func(*gorm.DB) *gorm.DB) ([]*Ide
 
 	err := m.db.Scopes(funcs...).Table(m.TableName()).Find(&objs).Error
 	if err != nil && err != gorm.ErrRecordNotFound {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return objs, nil
 }
@@ -151,7 +151,7 @@ func (m *GormIdentityRepository) List(ctx context.Context) (*app.IdentityArray, 
 
 	err := m.db.Model(&Identity{}).Order("full_name").Find(&rows).Error
 	if err != nil && err != gorm.ErrRecordNotFound {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	res := app.IdentityArray{}
 	res.Data = make([]*app.IdentityData, len(rows))

--- a/account/user.go
+++ b/account/user.go
@@ -64,7 +64,7 @@ func (m *GormUserRepository) Load(ctx context.Context, id uuid.UUID) (*User, err
 		return nil, nil
 	}
 
-	return &native, err
+	return &native, errors.WithStack(err)
 }
 
 // Create creates a new record.
@@ -76,7 +76,7 @@ func (m *GormUserRepository) Create(ctx context.Context, u *User) error {
 	err := m.db.Create(u).Error
 	if err != nil {
 		goa.LogError(ctx, "error adding User", "error", err.Error())
-		return err
+		return errors.WithStack(err)
 	}
 
 	return nil
@@ -89,11 +89,11 @@ func (m *GormUserRepository) Save(ctx context.Context, model *User) error {
 	obj, err := m.Load(ctx, model.ID)
 	if err != nil {
 		goa.LogError(ctx, "error updating User", "error", err.Error())
-		return err
+		return errors.WithStack(err)
 	}
 	err = m.db.Model(obj).Updates(model).Error
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	return nil
 }
@@ -108,7 +108,7 @@ func (m *GormUserRepository) Delete(ctx context.Context, id uuid.UUID) error {
 
 	if err != nil {
 		goa.LogError(ctx, "error deleting User", "error", err.Error())
-		return err
+		return errors.WithStack(err)
 	}
 
 	return nil
@@ -121,7 +121,7 @@ func (m *GormUserRepository) Query(funcs ...func(*gorm.DB) *gorm.DB) ([]*User, e
 
 	err := m.db.Scopes(funcs...).Table(m.TableName()).Find(&objs).Error
 	if err != nil && err != gorm.ErrRecordNotFound {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return objs, nil
 }

--- a/account/user.go
+++ b/account/user.go
@@ -6,6 +6,7 @@ import (
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"golang.org/x/net/context"
 )

--- a/application/transaction.go
+++ b/application/transaction.go
@@ -1,5 +1,7 @@
 package application
 
+import "github.com/pkg/errors"
+
 // Transactional executes the given function in a transaction. If todo returns an error, the transaction is rolled back
 func Transactional(db DB, todo func(f Application) error) error {
 	var tx Transaction

--- a/application/transaction.go
+++ b/application/transaction.go
@@ -5,11 +5,11 @@ func Transactional(db DB, todo func(f Application) error) error {
 	var tx Transaction
 	var err error
 	if tx, err = db.BeginTransaction(); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	if err := todo(tx); err != nil {
 		tx.Rollback()
-		return err
+		return errors.WithStack(err)
 	}
 	return tx.Commit()
 }

--- a/comment/comment.go
+++ b/comment/comment.go
@@ -10,6 +10,7 @@ import (
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
+	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -55,7 +56,7 @@ func (m *GormCommentRepository) Create(ctx context.Context, u *Comment) error {
 	err := m.db.Create(u).Error
 	if err != nil {
 		goa.LogError(ctx, "error adding Comment", "error", err.Error())
-		return errors.WithStack(err)
+		return errs.WithStack(err)
 	}
 
 	return nil
@@ -87,7 +88,7 @@ func (m *GormCommentRepository) List(ctx context.Context, parent string) ([]*Com
 
 	err := m.db.Table(m.TableName()).Where("parent_id = ?", parent).Order("created_at").Find(&objs).Error
 	if err != nil && err != gorm.ErrRecordNotFound {
-		return nil, errors.WithStack(err)
+		return nil, errs.WithStack(err)
 	}
 	return objs, nil
 }

--- a/comment/comment.go
+++ b/comment/comment.go
@@ -55,7 +55,7 @@ func (m *GormCommentRepository) Create(ctx context.Context, u *Comment) error {
 	err := m.db.Create(u).Error
 	if err != nil {
 		goa.LogError(ctx, "error adding Comment", "error", err.Error())
-		return err
+		return errors.WithStack(err)
 	}
 
 	return nil
@@ -87,7 +87,7 @@ func (m *GormCommentRepository) List(ctx context.Context, parent string) ([]*Com
 
 	err := m.db.Table(m.TableName()).Where("parent_id = ?", parent).Order("created_at").Find(&objs).Error
 	if err != nil && err != gorm.ErrRecordNotFound {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return objs, nil
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -8,6 +8,11 @@ const (
 	stNotFoundErrorMsg             = "%s with id '%s' not found"
 )
 
+// Constants that can be used to identify internal server errors
+const (
+	ErrInternalDatabase = "database_error"
+)
+
 type simpleError struct {
 	message string
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -57,7 +57,7 @@ func (err BadParameterError) Error() string {
 func (err BadParameterError) Expected(expexcted interface{}) BadParameterError {
 	err.expectedValue = expexcted
 	err.hasExpectedValue = true
-	return err
+	return errors.WithStack(err)
 }
 
 // NewBadParameterError returns the custom defined error of type NewBadParameterError.

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -57,7 +57,7 @@ func (err BadParameterError) Error() string {
 func (err BadParameterError) Expected(expexcted interface{}) BadParameterError {
 	err.expectedValue = expexcted
 	err.hasExpectedValue = true
-	return errors.WithStack(err)
+	return err
 }
 
 // NewBadParameterError returns the custom defined error of type NewBadParameterError.

--- a/glide.yaml
+++ b/glide.yaml
@@ -77,6 +77,8 @@ import:
 - package: github.com/mitchellh/mapstructure
 - package: github.com/pelletier/go-toml
   version: ^0.3.5
+- package: github.com/pkg/errors
+  version: ^0.8.0
 - package: github.com/spf13/afero
 - package: github.com/spf13/cast
 - package: github.com/spf13/jwalterweatherman

--- a/gormapplication/application.go
+++ b/gormapplication/application.go
@@ -160,12 +160,12 @@ func (g *GormDB) BeginTransaction() (application.Transaction, error) {
 func (g *GormTransaction) Commit() error {
 	err := g.db.Commit().Error
 	g.db = nil
-	return err
+	return errors.WithStack(err)
 }
 
 // Rollback implements TransactionSupport
 func (g *GormTransaction) Rollback() error {
 	err := g.db.Rollback().Error
 	g.db = nil
-	return err
+	return errors.WithStack(err)
 }

--- a/gormapplication/application.go
+++ b/gormapplication/application.go
@@ -14,6 +14,7 @@ import (
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/almighty/almighty-core/workitem/link"
 	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
 )
 
 // A TXIsoLevel specifies the characteristics of the transaction

--- a/iteration/iteration.go
+++ b/iteration/iteration.go
@@ -61,7 +61,7 @@ func (m *GormIterationRepository) Create(ctx context.Context, u *Iteration) erro
 	err := m.db.Create(u).Error
 	if err != nil {
 		goa.LogError(ctx, "error adding Iteration", "error", err.Error())
-		return err
+		return errors.WithStack(err)
 	}
 
 	return nil
@@ -74,7 +74,7 @@ func (m *GormIterationRepository) List(ctx context.Context, spaceID uuid.UUID) (
 
 	err := m.db.Where("space_id = ?", spaceID).Find(&objs).Error
 	if err != nil && err != gorm.ErrRecordNotFound {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return objs, nil
 }

--- a/iteration/iteration.go
+++ b/iteration/iteration.go
@@ -7,6 +7,7 @@ import (
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
+	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"golang.org/x/net/context"
 )
@@ -61,7 +62,7 @@ func (m *GormIterationRepository) Create(ctx context.Context, u *Iteration) erro
 	err := m.db.Create(u).Error
 	if err != nil {
 		goa.LogError(ctx, "error adding Iteration", "error", err.Error())
-		return errors.WithStack(err)
+		return errs.WithStack(err)
 	}
 
 	return nil
@@ -74,7 +75,7 @@ func (m *GormIterationRepository) List(ctx context.Context, spaceID uuid.UUID) (
 
 	err := m.db.Where("space_id = ?", spaceID).Find(&objs).Error
 	if err != nil && err != gorm.ErrRecordNotFound {
-		return nil, errors.WithStack(err)
+		return nil, errs.WithStack(err)
 	}
 	return objs, nil
 }

--- a/jsonapi/error_handler.go
+++ b/jsonapi/error_handler.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/almighty/almighty-core/errors"
 	"github.com/goadesign/goa"
-	goaerrors "github.com/pkg/errors"
+	errs "github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -37,7 +37,7 @@ func ErrorHandler(service *goa.Service, verbose bool) goa.Middleware {
 			if e == nil {
 				return nil
 			}
-			cause := goaerrors.Cause(e)
+			cause := errs.Cause(e)
 			status := http.StatusInternalServerError
 			var respBody interface{}
 			respBody, status = ErrorToJSONAPIErrors(e)

--- a/jsonapi/jsonapi_utility.go
+++ b/jsonapi/jsonapi_utility.go
@@ -26,11 +26,11 @@ const (
 // This function knows about the models package and the errors from there
 // as well as goa error classes.
 func ErrorToJSONAPIError(err error) (app.JSONAPIError, int) {
-	detail := err.Error()
+	cause := errs.Cause(err)
+	detail := cause.Error()
 	var title, code string
 	var statusCode int
 	var id *string
-	cause := errs.Cause(err)
 	switch cause.(type) {
 	case errors.NotFoundError:
 		code = ErrorCodeNotFound

--- a/login/service.go
+++ b/login/service.go
@@ -2,10 +2,12 @@ package login
 
 import (
 	"encoding/json"
-	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"sync"
+
+	errs "github.com/pkg/errors"
 
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
@@ -144,11 +146,10 @@ func (keycloak keycloakOAuthProvider) getUser(ctx context.Context, token *oauth2
 	client := keycloak.config.Client(ctx, token)
 	resp, err := client.Get(configuration.GetKeycloakEndpointUserinfo())
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errs.WithStack(err)
 	}
 
 	var user openIDConnectUser
-
 	json.NewDecoder(resp.Body).Decode(&user)
 
 	return &user, nil
@@ -179,13 +180,13 @@ type openIDConnectUser struct {
 func ContextIdentity(ctx context.Context) (string, error) {
 	tm := ReadTokenManagerFromContext(ctx)
 	if tm == nil {
-		return "", errors.New("Missing token manager")
+		return "", errs.New("Missing token manager")
 	}
 	uuid, err := tm.Locate(ctx)
 	if err != nil {
 		// TODO : need a way to define user as Guest
-		log.Println("Guest User")
-		return "", errors.WithStack(err)
+		fmt.Println("Guest User")
+		return "", errs.WithStack(err)
 	}
 	return uuid.String(), nil
 }

--- a/login/service.go
+++ b/login/service.go
@@ -144,7 +144,7 @@ func (keycloak keycloakOAuthProvider) getUser(ctx context.Context, token *oauth2
 	client := keycloak.config.Client(ctx, token)
 	resp, err := client.Get(configuration.GetKeycloakEndpointUserinfo())
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	var user openIDConnectUser
@@ -184,8 +184,8 @@ func ContextIdentity(ctx context.Context) (string, error) {
 	uuid, err := tm.Locate(ctx)
 	if err != nil {
 		// TODO : need a way to define user as Guest
-		log.Println("Geust User")
-		return "", err
+		log.Println("Guest User")
+		return "", errors.WithStack(err)
 	}
 	return uuid.String(), nil
 }

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func main() {
 
 	var err error
 	if err = configuration.Setup(configFilePath); err != nil {
-		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+		panic(fmt.Sprintf("ERROR: Failed to setup the configuration: \n%+v", err))
 	}
 
 	if printConfig {
@@ -95,7 +95,7 @@ func main() {
 		}
 	}
 	if err != nil {
-		panic("Could not open connection to database")
+		panic(fmt.Sprintf("ERROR: Could not open connection to database: \n%+v", err))
 	}
 
 	if configuration.IsPostgresDeveloperModeEnabled() {
@@ -105,7 +105,7 @@ func main() {
 	// Migrate the schema
 	err = migration.Migrate(db.DB())
 	if err != nil {
-		panic(err.Error())
+		panic(fmt.Sprintf("ERROR: Failed migration: \n%+v", err))
 	}
 
 	// Nothing to here except exit, since the migration is already performed.
@@ -118,12 +118,12 @@ func main() {
 		if err := models.Transactional(db, func(tx *gorm.DB) error {
 			return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))
 		}); err != nil {
-			panic(err.Error())
+			panic(fmt.Sprintf("ERROR: Failed to populate common types: \n%+v", err))
 		}
 		if err := models.Transactional(db, func(tx *gorm.DB) error {
 			return migration.BootstrapWorkItemLinking(context.Background(), link.NewWorkItemLinkCategoryRepository(tx), link.NewWorkItemLinkTypeRepository(tx))
 		}); err != nil {
-			panic(err.Error())
+			panic(fmt.Sprintf("ERROR: Failed to bootstap work item linking: \n%+v", err))
 		}
 	}
 
@@ -144,11 +144,11 @@ func main() {
 
 	privateKey, err := token.ParsePrivateKey(configuration.GetTokenPrivateKey())
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("ERROR: Failed to parse private key: \n%+v", err))
 	}
 	publicKey, err := token.ParsePublicKey(configuration.GetTokenPublicKey())
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("ERROR: Failed to parse public token: \n%+v", err))
 	}
 
 	// Setup Account/Login/Security
@@ -266,7 +266,7 @@ func main() {
 func printUserInfo() {
 	u, err := user.Current()
 	if err != nil {
-		log.Printf("Failed to get current user: %s", err.Error())
+		fmt.Printf("ERROR: Failed to get current user: \n%+v", err)
 	} else {
 		log.Printf("Running as user name \"%s\" with UID %s.\n", u.Username, u.Uid)
 		/*

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -262,7 +262,8 @@ func BootstrapWorkItemLinking(ctx context.Context, linkCatRepo *link.GormWorkIte
 
 func createOrUpdateWorkItemLinkCategory(ctx context.Context, linkCatRepo *link.GormWorkItemLinkCategoryRepository, name string, description string) error {
 	cat, err := linkCatRepo.LoadCategoryFromDB(ctx, name)
-	switch err.(type) {
+	cause := errs.Cause(err)
+	switch cause.(type) {
 	case errors.NotFoundError:
 		_, err := linkCatRepo.Create(ctx, &name, &description)
 		if err != nil {
@@ -296,7 +297,8 @@ func createOrUpdateWorkItemLinkType(ctx context.Context, linkCatRepo *link.GormW
 		LinkCategoryID: cat.ID,
 	}
 
-	switch err.(type) {
+	cause := errs.Cause(err)
+	switch cause.(type) {
 	case errors.NotFoundError:
 		_, err := linkTypeRepo.Create(ctx, lt.Name, lt.Description, lt.SourceTypeName, lt.TargetTypeName, lt.ForwardName, lt.ReverseName, lt.Topology, lt.LinkCategoryID)
 		if err != nil {
@@ -387,7 +389,8 @@ func createOrUpdatePlannerItemExtension(typeName string, ctx context.Context, wi
 
 func createOrUpdateType(typeName string, extendedTypeName *string, fields map[string]app.FieldDefinition, ctx context.Context, witr *workitem.GormWorkItemTypeRepository, db *gorm.DB) error {
 	wit, err := witr.LoadTypeFromDB(typeName)
-	switch err.(type) {
+	cause := errs.Cause(err)
+	switch cause.(type) {
 	case errors.NotFoundError:
 		_, err := witr.Create(ctx, extendedTypeName, typeName, fields)
 		if err != nil {

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -166,10 +166,10 @@ func executeSQLFile(filename string) fn {
 	return func(db *sql.Tx) error {
 		data, err := Asset(filename)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 		_, err = db.Exec(string(data))
-		return err
+		return errors.WithStack(err)
 	}
 }
 
@@ -188,7 +188,7 @@ func migrateToNextVersion(tx *sql.Tx, nextVersion *int64, m migrations) error {
 	// iterator variable "version"
 	currentVersion, err := getCurrentVersion(tx)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	*nextVersion = currentVersion + 1
 	if *nextVersion >= int64(len(m)) {
@@ -246,16 +246,16 @@ func getCurrentVersion(db *sql.Tx) (int64, error) {
 // BootstrapWorkItemLinking makes sure the database is populated with the correct work item link stuff (e.g. category and some basic types)
 func BootstrapWorkItemLinking(ctx context.Context, linkCatRepo *link.GormWorkItemLinkCategoryRepository, linkTypeRepo *link.GormWorkItemLinkTypeRepository) error {
 	if err := createOrUpdateWorkItemLinkCategory(ctx, linkCatRepo, link.SystemWorkItemLinkCategorySystem, "The system category is reserved for link types that are to be manipulated by the system only."); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	if err := createOrUpdateWorkItemLinkCategory(ctx, linkCatRepo, link.SystemWorkItemLinkCategoryUser, "The user category is reserved for link types that can to be manipulated by the user."); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	if err := createOrUpdateWorkItemLinkType(ctx, linkCatRepo, linkTypeRepo, link.SystemWorkItemLinkTypeBugBlocker, "One bug blocks a planner item.", link.TopologyNetwork, "blocks", "blocked by", workitem.SystemBug, workitem.SystemPlannerItem, link.SystemWorkItemLinkCategorySystem); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	if err := createOrUpdateWorkItemLinkType(ctx, linkCatRepo, linkTypeRepo, link.SystemWorkItemLinkPlannerItemRelated, "One planner item or a subtype of it relates to another one.", link.TopologyNetwork, "relates to", "relates to", workitem.SystemPlannerItem, workitem.SystemPlannerItem, link.SystemWorkItemLinkCategorySystem); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	return nil
 }
@@ -266,14 +266,14 @@ func createOrUpdateWorkItemLinkCategory(ctx context.Context, linkCatRepo *link.G
 	case errors.NotFoundError:
 		_, err := linkCatRepo.Create(ctx, &name, &description)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	case nil:
 		log.Printf("Work item link category %v exists, will update/overwrite the description", name)
 		cat.Description = &description
 		linkCat := link.ConvertLinkCategoryFromModel(*cat)
 		_, err = linkCatRepo.Save(ctx, linkCat)
-		return err
+		return errors.WithStack(err)
 	}
 	return nil
 }
@@ -281,7 +281,7 @@ func createOrUpdateWorkItemLinkCategory(ctx context.Context, linkCatRepo *link.G
 func createOrUpdateWorkItemLinkType(ctx context.Context, linkCatRepo *link.GormWorkItemLinkCategoryRepository, linkTypeRepo *link.GormWorkItemLinkTypeRepository, name, description, topology, forwardName, reverseName, sourceTypeName, targetTypeName, linkCatName string) error {
 	cat, err := linkCatRepo.LoadCategoryFromDB(ctx, linkCatName)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	linkType, err := linkTypeRepo.LoadTypeFromDBByNameAndCategory(name, cat.ID)
@@ -300,14 +300,14 @@ func createOrUpdateWorkItemLinkType(ctx context.Context, linkCatRepo *link.GormW
 	case errors.NotFoundError:
 		_, err := linkTypeRepo.Create(ctx, lt.Name, lt.Description, lt.SourceTypeName, lt.TargetTypeName, lt.ForwardName, lt.ReverseName, lt.Topology, lt.LinkCategoryID)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	case nil:
 		log.Printf("Work item link type %v exists, will update/overwrite all fields", name)
 		lt.ID = linkType.ID
 		lt.Version = linkType.Version
 		_, err = linkTypeRepo.Save(ctx, link.ConvertLinkTypeFromModel(lt))
-		return err
+		return errors.WithStack(err)
 	}
 	return nil
 }
@@ -316,8 +316,9 @@ func createOrUpdateWorkItemLinkType(ctx context.Context, linkCatRepo *link.GormW
 func PopulateCommonTypes(ctx context.Context, db *gorm.DB, witr *workitem.GormWorkItemTypeRepository) error {
 
 	if err := createOrUpdateSystemPlannerItemType(ctx, witr, db); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
+<<<<<<< 7f9d0e129a6f2e5e2a6e451536b42c2f31824d6d
 	if err := createOrUpdatePlannerItemExtension(workitem.SystemUserStory, ctx, witr, db); err != nil {
 		return err
 	}
@@ -391,7 +392,7 @@ func createOrUpdateType(typeName string, extendedTypeName *string, fields map[st
 	case errors.NotFoundError:
 		_, err := witr.Create(ctx, extendedTypeName, typeName, fields)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	case nil:
 		log.Printf("Work item type %v exists, will update/overwrite the fields only and parentPath", typeName)
@@ -401,19 +402,19 @@ func createOrUpdateType(typeName string, extendedTypeName *string, fields map[st
 			log.Printf("Work item type %v extends another type %v, will copy fields from the extended type", typeName, *extendedTypeName)
 			extendedWit, err := witr.LoadTypeFromDB(*extendedTypeName)
 			if err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 			path = extendedWit.Path + workitem.GetTypePathSeparator() + path
 
 			//load fields from the extended type
 			err = loadFields(ctx, extendedWit, convertedFields)
 			if err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 		}
 
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 		wit.Fields = convertedFields
 		wit.Path = path

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -11,7 +11,7 @@ func Transactional(db *gorm.DB, todo func(tx *gorm.DB) error) error {
 	}
 	if err := todo(tx); err != nil {
 		tx.Rollback()
-		return err
+		return errors.WithStack(err)
 	}
 	tx.Commit()
 	return tx.Error

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -1,6 +1,9 @@
 package models
 
-import "github.com/jinzhu/gorm"
+import (
+	"github.com/jinzhu/gorm"
+	errs "github.com/pkg/errors"
+)
 
 // Transactional executes the given function in a transaction. If todo returns an error, the transaction is rolled back
 func Transactional(db *gorm.DB, todo func(tx *gorm.DB) error) error {
@@ -11,7 +14,7 @@ func Transactional(db *gorm.DB, todo func(tx *gorm.DB) error) error {
 	}
 	if err := todo(tx); err != nil {
 		tx.Rollback()
-		return errors.WithStack(err)
+		return errs.WithStack(err)
 	}
 	tx.Commit()
 	return tx.Error

--- a/paging.go
+++ b/paging.go
@@ -126,7 +126,7 @@ func parseInts(s *string) ([]int, error) {
 	for index, value := range split {
 		converted, err := strconv.Atoi(value)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		result[index] = converted
 	}
@@ -136,7 +136,7 @@ func parseInts(s *string) ([]int, error) {
 func parseLimit(pageParameter *string) (s *int, l int, e error) {
 	params, err := parseInts(pageParameter)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, errors.WithStack(err)
 	}
 
 	if len(params) > 1 {

--- a/paging.go
+++ b/paging.go
@@ -10,6 +10,7 @@ import (
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/rest"
 	"github.com/goadesign/goa"
+	errs "github.com/pkg/errors"
 )
 
 const (
@@ -126,7 +127,7 @@ func parseInts(s *string) ([]int, error) {
 	for index, value := range split {
 		converted, err := strconv.Atoi(value)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errs.WithStack(err)
 		}
 		result[index] = converted
 	}
@@ -136,7 +137,7 @@ func parseInts(s *string) ([]int, error) {
 func parseLimit(pageParameter *string) (s *int, l int, e error) {
 	params, err := parseInts(pageParameter)
 	if err != nil {
-		return nil, 0, errors.WithStack(err)
+		return nil, 0, errs.WithStack(err)
 	}
 
 	if len(params) > 1 {

--- a/query/simple/simple_parser.go
+++ b/query/simple/simple_parser.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 
 	. "github.com/almighty/almighty-core/criteria"
+	"github.com/pkg/errors"
 )
 
 // Parse parses strings of the form { "attribute1":value1,"attribute2":value2} into an expression of the form "attribute1=value1 and attribute2=value2"

--- a/query/simple/simple_parser.go
+++ b/query/simple/simple_parser.go
@@ -18,7 +18,7 @@ func Parse(exp *string) (Expression, error) {
 	var unmarshalled map[string]interface{}
 	err := json.Unmarshal([]byte(*exp), &unmarshalled)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	var result *Expression
 	if len(unmarshalled) > 0 {

--- a/remoteworkitem/remoteworkitem.go
+++ b/remoteworkitem/remoteworkitem.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/workitem"
+	"github.com/pkg/errors"
 )
 
 // List of supported attributes

--- a/remoteworkitem/remoteworkitem.go
+++ b/remoteworkitem/remoteworkitem.go
@@ -138,7 +138,7 @@ func NewGitHubRemoteWorkItem(item TrackerItem) (AttributeAccessor, error) {
 	var j map[string]interface{}
 	err := json.Unmarshal([]byte(item.Item), &j)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	j = Flatten(j)
 	return GitHubRemoteWorkItem{issue: j}, nil
@@ -159,7 +159,7 @@ func NewJiraRemoteWorkItem(item TrackerItem) (AttributeAccessor, error) {
 	var j map[string]interface{}
 	err := json.Unmarshal([]byte(item.Item), &j)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	j = Flatten(j)
 	return JiraRemoteWorkItem{issue: j}, nil

--- a/remoteworkitem/remoteworkitem_test.go
+++ b/remoteworkitem/remoteworkitem_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/almighty/almighty-core/resource"
 	"github.com/almighty/almighty-core/test"
 	"github.com/almighty/almighty-core/workitem"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/remoteworkitem/remoteworkitem_test.go
+++ b/remoteworkitem/remoteworkitem_test.go
@@ -17,13 +17,13 @@ import (
 func provideRemoteData(dataURL string) ([]byte, error) {
 	response, err := http.Get(dataURL)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	defer response.Body.Close()
 	responseData, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return responseData, nil
 }

--- a/remoteworkitem/scheduler.go
+++ b/remoteworkitem/scheduler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/almighty/almighty-core/models"
 	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
 	"github.com/robfig/cron"
 	uuid "github.com/satori/go.uuid"
 )

--- a/remoteworkitem/scheduler.go
+++ b/remoteworkitem/scheduler.go
@@ -55,11 +55,11 @@ func (s *Scheduler) ScheduleAllQueries() {
 					// Save the remote items in a 'temporary' table.
 					err := upload(tx, tq.TrackerID, i)
 					if err != nil {
-						return err
+						return errors.WithStack(err)
 					}
 					// Convert the remote item into a local work item and persist in the DB.
 					_, err = convert(tx, tq.TrackerID, i, tq.TrackerType)
-					return err
+					return errors.WithStack(err)
 				})
 			}
 		})

--- a/remoteworkitem/tracker_repository.go
+++ b/remoteworkitem/tracker_repository.go
@@ -99,7 +99,7 @@ func (r *GormTrackerRepository) List(ctx context.Context, criteria criteria.Expr
 		db = db.Limit(*limit)
 	}
 	if err := db.Find(&rows).Error; err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	result := make([]*app.Tracker, len(rows))
 

--- a/remoteworkitem/tracker_repository.go
+++ b/remoteworkitem/tracker_repository.go
@@ -10,6 +10,7 @@ import (
 	"github.com/almighty/almighty-core/criteria"
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	govalidator "gopkg.in/asaskevich/govalidator.v4"
 )

--- a/remoteworkitem/trackeritem_repository.go
+++ b/remoteworkitem/trackeritem_repository.go
@@ -9,6 +9,7 @@ import (
 	"github.com/almighty/almighty-core/criteria"
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
 )
 
 // upload imports the items into database

--- a/remoteworkitem/trackeritem_repository.go
+++ b/remoteworkitem/trackeritem_repository.go
@@ -85,5 +85,5 @@ func convert(db *gorm.DB, tID int, item TrackerItemContent, provider string) (*a
 			fmt.Println("Error creating work item : ", err)
 		}
 	}
-	return newWorkItem, err
+	return newWorkItem, errors.WithStack(err)
 }

--- a/remoteworkitem/trackeritem_repository_test.go
+++ b/remoteworkitem/trackeritem_repository_test.go
@@ -49,7 +49,7 @@ func TestConvertNewWorkItem(t *testing.T) {
 		wir := workitem.NewWorkItemRepository(db)
 		wir.Delete(context.Background(), workItem.ID)
 
-		return err
+		return errors.WithStack(err)
 	})
 }
 
@@ -84,7 +84,7 @@ func TestConvertExistingWorkItem(t *testing.T) {
 		assert.Equal(t, "sbose78", workItem.Fields[workitem.SystemCreator])
 		assert.Equal(t, "pranav", workItem.Fields[workitem.SystemAssignees].([]interface{})[0])
 		assert.Equal(t, "closed", workItem.Fields[workitem.SystemState])
-		return err
+		return errors.WithStack(err)
 	})
 
 	t.Log("Updating the existing work item when it's reimported.")
@@ -105,7 +105,7 @@ func TestConvertExistingWorkItem(t *testing.T) {
 		wir := workitem.NewWorkItemRepository(tx)
 		wir.Delete(context.Background(), workItemUpdated.ID)
 
-		return err
+		return errors.WithStack(err)
 	})
 
 }
@@ -147,7 +147,7 @@ func TestConvertGithubIssue(t *testing.T) {
 		assert.Equal(t, "sbose78", workItemGithub.Fields[workitem.SystemAssignees].([]interface{})[0])
 		assert.Equal(t, "open", workItemGithub.Fields[workitem.SystemState])
 
-		return err
+		return errors.WithStack(err)
 	})
 
 }

--- a/remoteworkitem/trackeritem_repository_test.go
+++ b/remoteworkitem/trackeritem_repository_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/almighty/almighty-core/test"
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/remoteworkitem/trackerquery_repository.go
+++ b/remoteworkitem/trackerquery_repository.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 

--- a/remoteworkitem/trackerquery_repository.go
+++ b/remoteworkitem/trackerquery_repository.go
@@ -150,7 +150,7 @@ func (r *GormTrackerQueryRepository) Delete(ctx context.Context, ID string) erro
 func (r *GormTrackerQueryRepository) List(ctx context.Context) ([]*app.TrackerQuery, error) {
 	var rows []TrackerQuery
 	if err := r.db.Find(&rows).Error; err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	result := make([]*app.TrackerQuery, len(rows))
 	for i, tq := range rows {

--- a/search.go
+++ b/search.go
@@ -10,6 +10,7 @@ import (
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/goadesign/goa"
+	errs "github.com/pkg/errors"
 )
 
 // SearchController implements the search resource.
@@ -58,7 +59,8 @@ func (c *SearchController) Show(ctx *app.ShowSearchContext) error {
 		result, c, err := appl.SearchItems().SearchFullText(ctx.Context, ctx.Q, &offset, &limit)
 		count := int(c)
 		if err != nil {
-			switch err := err.(type) {
+			cause := errs.Cause(err)
+			switch cause.(type) {
 			case errors.BadParameterError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error listing work items: %s", err.Error())))
 				return ctx.BadRequest(jerrors)

--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -19,6 +19,7 @@ import (
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/asaskevich/govalidator"
 	"github.com/jinzhu/gorm"
+	errs "github.com/pkg/errors"
 )
 
 const (
@@ -61,7 +62,7 @@ func convertFromModel(wiType workitem.WorkItemType, workItem workitem.WorkItem) 
 		var err error
 		result.Fields[name], err = field.ConvertFromModel(name, workItem.Fields[name])
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errs.WithStack(err)
 		}
 	}
 
@@ -295,7 +296,7 @@ func (r *GormSearchRepository) search(ctx context.Context, sqlSearchQueryParamet
 
 	rows, err := db.Rows()
 	if err != nil {
-		return nil, 0, errors.WithStack(err)
+		return nil, 0, errs.WithStack(err)
 	}
 	defer rows.Close()
 
@@ -343,14 +344,14 @@ func (r *GormSearchRepository) SearchFullText(ctx context.Context, rawSearchStri
 	// ....
 	parsedSearchDict, err := parseSearchString(rawSearchString)
 	if err != nil {
-		return nil, 0, errors.WithStack(err)
+		return nil, 0, errs.WithStack(err)
 	}
 
 	sqlSearchQueryParameter := generateSQLSearchInfo(parsedSearchDict)
 	var rows []workitem.WorkItem
 	rows, count, err := r.search(ctx, sqlSearchQueryParameter, parsedSearchDict.workItemTypes, start, limit)
 	if err != nil {
-		return nil, 0, errors.WithStack(err)
+		return nil, 0, errs.WithStack(err)
 	}
 	result := make([]*app.WorkItem, len(rows))
 

--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -61,7 +61,7 @@ func convertFromModel(wiType workitem.WorkItemType, workItem workitem.WorkItem) 
 		var err error
 		result.Fields[name], err = field.ConvertFromModel(name, workItem.Fields[name])
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 	}
 
@@ -295,7 +295,7 @@ func (r *GormSearchRepository) search(ctx context.Context, sqlSearchQueryParamet
 
 	rows, err := db.Rows()
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, errors.WithStack(err)
 	}
 	defer rows.Close()
 
@@ -343,14 +343,14 @@ func (r *GormSearchRepository) SearchFullText(ctx context.Context, rawSearchStri
 	// ....
 	parsedSearchDict, err := parseSearchString(rawSearchString)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, errors.WithStack(err)
 	}
 
 	sqlSearchQueryParameter := generateSQLSearchInfo(parsedSearchDict)
 	var rows []workitem.WorkItem
 	rows, count, err := r.search(ctx, sqlSearchQueryParameter, parsedSearchDict.workItemTypes, start, limit)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, errors.WithStack(err)
 	}
 	result := make([]*app.WorkItem, len(rows))
 

--- a/search/search_repository_whitebox_test.go
+++ b/search/search_repository_whitebox_test.go
@@ -282,7 +282,7 @@ func (s *searchRepositoryWhiteboxTest) TestSearchByID() {
 			s.T().Log("Found search result for ID Search ", workItemValue.ID)
 			assert.Equal(s.T(), createdWorkItem.ID, workItemValue.ID)
 		}
-		return err
+		return errors.WithStack(err)
 	})
 }
 

--- a/search/search_repository_whitebox_test.go
+++ b/search/search_repository_whitebox_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/jinzhu/gorm"
 	_ "github.com/lib/pq"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/net/context"

--- a/space/space.go
+++ b/space/space.go
@@ -169,7 +169,7 @@ func (r *GormRepository) listSpaceFromDB(ctx context.Context, start *int, limit 
 
 	rows, err := db.Rows()
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, errors.WithStack(err)
 	}
 	defer rows.Close()
 
@@ -208,7 +208,7 @@ func (r *GormRepository) listSpaceFromDB(ctx context.Context, start *int, limit 
 		rows2, err := orgDB.Rows()
 		defer rows2.Close()
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, errors.WithStack(err)
 		}
 		rows2.Next() // count(*) will always return a row
 		rows2.Scan(&count)
@@ -220,7 +220,7 @@ func (r *GormRepository) listSpaceFromDB(ctx context.Context, start *int, limit 
 func (r *GormRepository) List(ctx context.Context, start *int, limit *int) ([]*Space, uint64, error) {
 	result, count, err := r.listSpaceFromDB(ctx, start, limit)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, errors.WithStack(err)
 	}
 
 	return result, count, nil

--- a/space/space.go
+++ b/space/space.go
@@ -7,6 +7,7 @@ import (
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/jinzhu/gorm"
+	errs "github.com/pkg/errors"
 	satoriuuid "github.com/satori/go.uuid"
 	"golang.org/x/net/context"
 )
@@ -169,7 +170,7 @@ func (r *GormRepository) listSpaceFromDB(ctx context.Context, start *int, limit 
 
 	rows, err := db.Rows()
 	if err != nil {
-		return nil, 0, errors.WithStack(err)
+		return nil, 0, errs.WithStack(err)
 	}
 	defer rows.Close()
 
@@ -208,7 +209,7 @@ func (r *GormRepository) listSpaceFromDB(ctx context.Context, start *int, limit 
 		rows2, err := orgDB.Rows()
 		defer rows2.Close()
 		if err != nil {
-			return nil, 0, errors.WithStack(err)
+			return nil, 0, errs.WithStack(err)
 		}
 		rows2.Next() // count(*) will always return a row
 		rows2.Scan(&count)
@@ -220,7 +221,7 @@ func (r *GormRepository) listSpaceFromDB(ctx context.Context, start *int, limit 
 func (r *GormRepository) List(ctx context.Context, start *int, limit *int) ([]*Space, uint64, error) {
 	result, count, err := r.listSpaceFromDB(ctx, start, limit)
 	if err != nil {
-		return nil, 0, errors.WithStack(err)
+		return nil, 0, errs.WithStack(err)
 	}
 
 	return result, count, nil

--- a/space/space_test.go
+++ b/space/space_test.go
@@ -111,7 +111,7 @@ type spaceExpectation func(p *space.Space, err error)
 func expectSpace(f func() (*space.Space, error), e spaceExpectation) (*space.Space, error) {
 	p, err := f()
 	e(p, err)
-	return p, err
+	return p, errors.WithStack(err)
 }
 
 func (test *repoBBTest) requireOk(p *space.Space, err error) {

--- a/space/space_test.go
+++ b/space/space_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/space"
+	errs "github.com/pkg/errors"
 	satoriuuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -111,7 +112,7 @@ type spaceExpectation func(p *space.Space, err error)
 func expectSpace(f func() (*space.Space, error), e spaceExpectation) (*space.Space, error) {
 	p, err := f()
 	e(p, err)
-	return p, errors.WithStack(err)
+	return p, errs.WithStack(err)
 }
 
 func (test *repoBBTest) requireOk(p *space.Space, err error) {

--- a/test/remote_test_data.go
+++ b/test/remote_test_data.go
@@ -22,11 +22,11 @@ func LoadTestData(filename string, provider TestDataProvider) ([]byte, error) {
 	refreshLocalData := func(path string, refresh TestDataProvider) ([]byte, error) {
 		content, err := refresh()
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		err = ioutil.WriteFile(path, content, 0644)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		return content, nil
 	}
@@ -41,7 +41,7 @@ func LoadTestData(filename string, provider TestDataProvider) ([]byte, error) {
 	targetDir := filepath.FromSlash(path.Dir(packagefilename) + "/../test/data/")
 	err := os.MkdirAll(targetDir, 0777)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	targetPath := filepath.FromSlash(targetDir + filename)

--- a/test/remote_test_data.go
+++ b/test/remote_test_data.go
@@ -6,6 +6,8 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+
+	"github.com/pkg/errors"
 )
 
 // TestDataProvider defines the simple funcion for returning data from a remote provider

--- a/token/token.go
+++ b/token/token.go
@@ -2,12 +2,11 @@ package token
 
 import (
 	"crypto/rsa"
-	"errors"
 
 	"github.com/almighty/almighty-core/account"
 	jwt "github.com/dgrijalva/jwt-go"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
-	errs "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"golang.org/x/net/context"
 )
@@ -40,7 +39,7 @@ func (mgm tokenManager) Generate(ident account.Identity) (string, error) {
 
 	tokenStr, err := token.SignedString(mgm.privateKey)
 	if err != nil {
-		return "", errs.WithStack(err)
+		return "", errors.WithStack(err)
 	}
 	return tokenStr, nil
 }
@@ -50,7 +49,7 @@ func (mgm tokenManager) Extract(tokenString string) (*account.Identity, error) {
 		return mgm.publicKey, nil
 	})
 	if err != nil {
-		return nil, errs.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
 
 	if !token.Valid {
@@ -64,7 +63,7 @@ func (mgm tokenManager) Extract(tokenString string) (*account.Identity, error) {
 	// in case of nil UUID, below type casting will fail hence we need above check
 	id, err := uuid.FromString(token.Claims.(jwt.MapClaims)["uuid"].(string))
 	if err != nil {
-		return nil, errs.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
 
 	ident := account.Identity{

--- a/token/token.go
+++ b/token/token.go
@@ -39,7 +39,7 @@ func (mgm tokenManager) Generate(ident account.Identity) (string, error) {
 
 	tokenStr, err := token.SignedString(mgm.privateKey)
 	if err != nil {
-		return "", err
+		return "", errors.WithStack(err)
 	}
 	return tokenStr, nil
 }
@@ -49,7 +49,7 @@ func (mgm tokenManager) Extract(tokenString string) (*account.Identity, error) {
 		return mgm.publicKey, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	if !token.Valid {
@@ -63,7 +63,7 @@ func (mgm tokenManager) Extract(tokenString string) (*account.Identity, error) {
 	// in case of nil UUID, below type casting will fail hence we need above check
 	id, err := uuid.FromString(token.Claims.(jwt.MapClaims)["uuid"].(string))
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	ident := account.Identity{

--- a/token/token.go
+++ b/token/token.go
@@ -7,6 +7,7 @@ import (
 	"github.com/almighty/almighty-core/account"
 	jwt "github.com/dgrijalva/jwt-go"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"golang.org/x/net/context"
 )
@@ -39,7 +40,7 @@ func (mgm tokenManager) Generate(ident account.Identity) (string, error) {
 
 	tokenStr, err := token.SignedString(mgm.privateKey)
 	if err != nil {
-		return "", errors.WithStack(err)
+		return "", errs.WithStack(err)
 	}
 	return tokenStr, nil
 }
@@ -49,7 +50,7 @@ func (mgm tokenManager) Extract(tokenString string) (*account.Identity, error) {
 		return mgm.publicKey, nil
 	})
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errs.WithStack(err)
 	}
 
 	if !token.Valid {
@@ -63,7 +64,7 @@ func (mgm tokenManager) Extract(tokenString string) (*account.Identity, error) {
 	// in case of nil UUID, below type casting will fail hence we need above check
 	id, err := uuid.FromString(token.Claims.(jwt.MapClaims)["uuid"].(string))
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errs.WithStack(err)
 	}
 
 	ident := account.Identity{

--- a/tracker.go
+++ b/tracker.go
@@ -10,6 +10,7 @@ import (
 	query "github.com/almighty/almighty-core/query/simple"
 	"github.com/almighty/almighty-core/remoteworkitem"
 	"github.com/goadesign/goa"
+	errs "github.com/pkg/errors"
 )
 
 // TrackerController implements the tracker resource.
@@ -29,7 +30,8 @@ func (c *TrackerController) Create(ctx *app.CreateTrackerContext) error {
 	result := application.Transactional(c.db, func(appl application.Application) error {
 		t, err := appl.Trackers().Create(ctx.Context, ctx.Payload.URL, ctx.Payload.Type)
 		if err != nil {
-			switch err := err.(type) {
+			cause := errs.Cause(err)
+			switch cause.(type) {
 			case remoteworkitem.BadParameterError, remoteworkitem.ConversionError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(err.Error()))
 				return ctx.BadRequest(jerrors)
@@ -50,7 +52,8 @@ func (c *TrackerController) Delete(ctx *app.DeleteTrackerContext) error {
 	result := application.Transactional(c.db, func(appl application.Application) error {
 		err := appl.Trackers().Delete(ctx.Context, ctx.ID)
 		if err != nil {
-			switch err.(type) {
+			cause := errs.Cause(err)
+			switch cause.(type) {
 			case remoteworkitem.NotFoundError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrNotFound(err.Error()))
 				return ctx.NotFound(jerrors)
@@ -70,7 +73,8 @@ func (c *TrackerController) Show(ctx *app.ShowTrackerContext) error {
 	return application.Transactional(c.db, func(appl application.Application) error {
 		t, err := appl.Trackers().Load(ctx.Context, ctx.ID)
 		if err != nil {
-			switch err.(type) {
+			cause := errs.Cause(err)
+			switch cause.(type) {
 			case remoteworkitem.NotFoundError:
 				log.Printf("not found, id=%s", ctx.ID)
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrNotFound(err.Error()))
@@ -119,7 +123,8 @@ func (c *TrackerController) Update(ctx *app.UpdateTrackerContext) error {
 		t, err := appl.Trackers().Save(ctx.Context, toSave)
 
 		if err != nil {
-			switch err := err.(type) {
+			cause := errs.Cause(err)
+			switch cause.(type) {
 			case remoteworkitem.BadParameterError, remoteworkitem.ConversionError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(err.Error()))
 				return ctx.BadRequest(jerrors)

--- a/trackerquery.go
+++ b/trackerquery.go
@@ -55,7 +55,7 @@ func (c *TrackerqueryController) Show(ctx *app.ShowTrackerqueryContext) error {
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrNotFound(err.Error()))
 				return ctx.NotFound(jerrors)
 			default:
-				return err
+				return errors.WithStack(err)
 			}
 		}
 		return ctx.OK(tq)

--- a/trackerquery.go
+++ b/trackerquery.go
@@ -9,7 +9,7 @@ import (
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/remoteworkitem"
 	"github.com/goadesign/goa"
-	"github.com/pkg/errors"
+	errs "github.com/pkg/errors"
 )
 
 // TrackerqueryController implements the trackerquery resource.
@@ -29,7 +29,8 @@ func (c *TrackerqueryController) Create(ctx *app.CreateTrackerqueryContext) erro
 	result := application.Transactional(c.db, func(appl application.Application) error {
 		tq, err := appl.TrackerQueries().Create(ctx.Context, ctx.Payload.Query, ctx.Payload.Schedule, ctx.Payload.TrackerID)
 		if err != nil {
-			switch err := err.(type) {
+			cause := errs.Cause(err)
+			switch cause.(type) {
 			case remoteworkitem.BadParameterError, remoteworkitem.ConversionError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(err.Error()))
 				return ctx.BadRequest(jerrors)
@@ -50,13 +51,14 @@ func (c *TrackerqueryController) Show(ctx *app.ShowTrackerqueryContext) error {
 	return application.Transactional(c.db, func(appl application.Application) error {
 		tq, err := appl.TrackerQueries().Load(ctx.Context, ctx.ID)
 		if err != nil {
-			switch err.(type) {
+			cause := errs.Cause(err)
+			switch cause.(type) {
 			case remoteworkitem.NotFoundError:
 				log.Printf("not found, id=%s", ctx.ID)
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrNotFound(err.Error()))
 				return ctx.NotFound(jerrors)
 			default:
-				return errors.WithStack(err)
+				return errs.WithStack(err)
 			}
 		}
 		return ctx.OK(tq)
@@ -76,7 +78,8 @@ func (c *TrackerqueryController) Update(ctx *app.UpdateTrackerqueryContext) erro
 		tq, err := appl.TrackerQueries().Save(ctx.Context, toSave)
 
 		if err != nil {
-			switch err := err.(type) {
+			cause := errs.Cause(err)
+			switch cause.(type) {
 			case remoteworkitem.BadParameterError, remoteworkitem.ConversionError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(err.Error()))
 				return ctx.BadRequest(jerrors)
@@ -96,7 +99,8 @@ func (c *TrackerqueryController) Delete(ctx *app.DeleteTrackerqueryContext) erro
 	result := application.Transactional(c.db, func(appl application.Application) error {
 		err := appl.TrackerQueries().Delete(ctx.Context, ctx.ID)
 		if err != nil {
-			switch err.(type) {
+			cause := errs.Cause(err)
+			switch cause.(type) {
 			case remoteworkitem.NotFoundError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrNotFound(err.Error()))
 				return ctx.NotFound(jerrors)

--- a/trackerquery.go
+++ b/trackerquery.go
@@ -9,6 +9,7 @@ import (
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/remoteworkitem"
 	"github.com/goadesign/goa"
+	"github.com/pkg/errors"
 )
 
 // TrackerqueryController implements the trackerquery resource.

--- a/user_test.go
+++ b/user_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -14,6 +13,7 @@ import (
 	"github.com/goadesign/goa"
 	"github.com/goadesign/goa/middleware/security/jwt"
 	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 )
 

--- a/work-item-comments.go
+++ b/work-item-comments.go
@@ -8,6 +8,7 @@ import (
 	"github.com/almighty/almighty-core/login"
 	"github.com/almighty/almighty-core/rest"
 	"github.com/goadesign/goa"
+	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"golang.org/x/net/context"
 )

--- a/work-item-comments.go
+++ b/work-item-comments.go
@@ -123,7 +123,7 @@ func WorkItemIncludeCommentsAndTotal(ctx context.Context, db application.DB, par
 			cs, err := appl.Comments().List(ctx, parentID)
 			if err != nil {
 				count <- 0
-				return err
+				return errors.WithStack(err)
 			}
 			count <- len(cs)
 			return nil

--- a/work-item-comments_test.go
+++ b/work-item-comments_test.go
@@ -19,6 +19,7 @@ import (
 	almtoken "github.com/almighty/almighty-core/token"
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/goadesign/goa"
+	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"

--- a/work-item-comments_test.go
+++ b/work-item-comments_test.go
@@ -197,13 +197,13 @@ func createWorkItem(db *gormapplication.GormDB) (string, error) {
 			},
 			uuid.NewV4().String())
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 		wiid = wi.ID
 		return nil
 	})
 	if err != nil {
-		return "", err
+		return "", errors.WithStack(err)
 	}
 	return wiid, nil
 }

--- a/work-item-link.go
+++ b/work-item-link.go
@@ -10,6 +10,7 @@ import (
 	"github.com/almighty/almighty-core/rest"
 	"github.com/almighty/almighty-core/workitem/link"
 	"github.com/goadesign/goa"
+	errs "github.com/pkg/errors"
 )
 
 // WorkItemLinkController implements the work-item-link resource.
@@ -71,7 +72,7 @@ func getTypesOfLinks(ctx *workItemLinkContext, linksDataArr []*app.WorkItemLinkD
 	for typeID := range typeIDMap {
 		linkType, err := ctx.Application.WorkItemLinkTypes().Load(ctx.Context, typeID)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errs.WithStack(err)
 		}
 		typeDataArr = append(typeDataArr, linkType.Data)
 	}
@@ -92,7 +93,7 @@ func getWorkItemsOfLinks(ctx *workItemLinkContext, linksDataArr []*app.WorkItemL
 	for workItemID := range workItemIDMap {
 		wi, err := ctx.Application.WorkItems().Load(ctx.Context, workItemID)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errs.WithStack(err)
 		}
 		workItemArr = append(workItemArr, ConvertWorkItem(ctx.RequestData, wi))
 	}
@@ -112,7 +113,7 @@ func getCategoriesOfLinkTypes(ctx *workItemLinkContext, linkTypeDataArr []*app.W
 	for catID := range catIDMap {
 		linkType, err := ctx.Application.WorkItemLinkCategories().Load(ctx.Context, catID)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errs.WithStack(err)
 		}
 		catDataArr = append(catDataArr, linkType.Data)
 	}
@@ -125,42 +126,42 @@ func enrichLinkSingle(ctx *workItemLinkContext, link *app.WorkItemLinkSingle) er
 	// include link type
 	linkType, err := ctx.Application.WorkItemLinkTypes().Load(ctx.Context, link.Data.Relationships.LinkType.Data.ID)
 	if err != nil {
-		return errors.WithStack(err)
+		return errs.WithStack(err)
 	}
 	link.Included = append(link.Included, linkType.Data)
 
 	// include link category
 	linkCat, err := ctx.Application.WorkItemLinkCategories().Load(ctx.Context, linkType.Data.Relationships.LinkCategory.Data.ID)
 	if err != nil {
-		return errors.WithStack(err)
+		return errs.WithStack(err)
 	}
 	link.Included = append(link.Included, linkCat.Data)
 
 	// TODO(kwk): include source work item type (once #559 is merged)
 	// sourceWit, err := appl.WorkItemTypes().Load(ctx, linkType.Data.Relationships.SourceType.Data.ID)
 	// if err != nil {
-	// 	return errors.WithStack(err)
+	// 	return errs.WithStack(err)
 	// }
 	// link.Included = append(link.Included, sourceWit.Data)
 
 	// TODO(kwk): include target work item type (once #559 is merged)
 	// targetWit, err := appl.WorkItemTypes().Load(ctx, linkType.Data.Relationships.TargetType.Data.ID)
 	// if err != nil {
-	// 	return errors.WithStack(err)
+	// 	return errs.WithStack(err)
 	// }
 	// link.Included = append(link.Included, targetWit.Data)
 
 	// TODO(kwk): include source work item
 	sourceWi, err := ctx.Application.WorkItems().Load(ctx.Context, link.Data.Relationships.Source.Data.ID)
 	if err != nil {
-		return errors.WithStack(err)
+		return errs.WithStack(err)
 	}
 	link.Included = append(link.Included, ConvertWorkItem(ctx.RequestData, sourceWi))
 
 	// TODO(kwk): include target work item
 	targetWi, err := ctx.Application.WorkItems().Load(ctx.Context, link.Data.Relationships.Target.Data.ID)
 	if err != nil {
-		return errors.WithStack(err)
+		return errs.WithStack(err)
 	}
 	link.Included = append(link.Included, ConvertWorkItem(ctx.RequestData, targetWi))
 
@@ -179,7 +180,7 @@ func enrichLinkList(ctx *workItemLinkContext, linkArr *app.WorkItemLinkList) err
 	// include link types
 	typeDataArr, err := getTypesOfLinks(ctx, linkArr.Data)
 	if err != nil {
-		return errors.WithStack(err)
+		return errs.WithStack(err)
 	}
 	// Convert slice of objects to slice of interface (see https://golang.org/doc/faq#convert_slice_of_interface)
 	interfaceArr := make([]interface{}, len(typeDataArr))
@@ -191,7 +192,7 @@ func enrichLinkList(ctx *workItemLinkContext, linkArr *app.WorkItemLinkList) err
 	// include link categories
 	catDataArr, err := getCategoriesOfLinkTypes(ctx, typeDataArr)
 	if err != nil {
-		return errors.WithStack(err)
+		return errs.WithStack(err)
 	}
 	// Convert slice of objects to slice of interface (see https://golang.org/doc/faq#convert_slice_of_interface)
 	interfaceArr = make([]interface{}, len(catDataArr))
@@ -203,7 +204,7 @@ func enrichLinkList(ctx *workItemLinkContext, linkArr *app.WorkItemLinkList) err
 	// TODO(kwk): Include WIs from source and target
 	workItemDataArr, err := getWorkItemsOfLinks(ctx, linkArr.Data)
 	if err != nil {
-		return errors.WithStack(err)
+		return errs.WithStack(err)
 	}
 	// Convert slice of objects to slice of interface (see https://golang.org/doc/faq#convert_slice_of_interface)
 	interfaceArr = make([]interface{}, len(workItemDataArr))

--- a/work-item-link.go
+++ b/work-item-link.go
@@ -244,7 +244,8 @@ func createWorkItemLink(ctx *workItemLinkContext, funcs createWorkItemLinkFuncs,
 	}
 	link, err := ctx.Application.WorkItemLinks().Create(ctx.Context, model.SourceID, model.TargetID, model.LinkTypeID)
 	if err != nil {
-		switch err.(type) {
+		cause := errs.Cause(err)
+		switch cause.(type) {
 		case errors.NotFoundError:
 			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(err.Error()))
 			return funcs.BadRequest(jerrors)

--- a/work-item-link.go
+++ b/work-item-link.go
@@ -71,7 +71,7 @@ func getTypesOfLinks(ctx *workItemLinkContext, linksDataArr []*app.WorkItemLinkD
 	for typeID := range typeIDMap {
 		linkType, err := ctx.Application.WorkItemLinkTypes().Load(ctx.Context, typeID)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		typeDataArr = append(typeDataArr, linkType.Data)
 	}
@@ -92,7 +92,7 @@ func getWorkItemsOfLinks(ctx *workItemLinkContext, linksDataArr []*app.WorkItemL
 	for workItemID := range workItemIDMap {
 		wi, err := ctx.Application.WorkItems().Load(ctx.Context, workItemID)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		workItemArr = append(workItemArr, ConvertWorkItem(ctx.RequestData, wi))
 	}
@@ -112,7 +112,7 @@ func getCategoriesOfLinkTypes(ctx *workItemLinkContext, linkTypeDataArr []*app.W
 	for catID := range catIDMap {
 		linkType, err := ctx.Application.WorkItemLinkCategories().Load(ctx.Context, catID)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		catDataArr = append(catDataArr, linkType.Data)
 	}
@@ -125,42 +125,42 @@ func enrichLinkSingle(ctx *workItemLinkContext, link *app.WorkItemLinkSingle) er
 	// include link type
 	linkType, err := ctx.Application.WorkItemLinkTypes().Load(ctx.Context, link.Data.Relationships.LinkType.Data.ID)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	link.Included = append(link.Included, linkType.Data)
 
 	// include link category
 	linkCat, err := ctx.Application.WorkItemLinkCategories().Load(ctx.Context, linkType.Data.Relationships.LinkCategory.Data.ID)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	link.Included = append(link.Included, linkCat.Data)
 
 	// TODO(kwk): include source work item type (once #559 is merged)
 	// sourceWit, err := appl.WorkItemTypes().Load(ctx, linkType.Data.Relationships.SourceType.Data.ID)
 	// if err != nil {
-	// 	return err
+	// 	return errors.WithStack(err)
 	// }
 	// link.Included = append(link.Included, sourceWit.Data)
 
 	// TODO(kwk): include target work item type (once #559 is merged)
 	// targetWit, err := appl.WorkItemTypes().Load(ctx, linkType.Data.Relationships.TargetType.Data.ID)
 	// if err != nil {
-	// 	return err
+	// 	return errors.WithStack(err)
 	// }
 	// link.Included = append(link.Included, targetWit.Data)
 
 	// TODO(kwk): include source work item
 	sourceWi, err := ctx.Application.WorkItems().Load(ctx.Context, link.Data.Relationships.Source.Data.ID)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	link.Included = append(link.Included, ConvertWorkItem(ctx.RequestData, sourceWi))
 
 	// TODO(kwk): include target work item
 	targetWi, err := ctx.Application.WorkItems().Load(ctx.Context, link.Data.Relationships.Target.Data.ID)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	link.Included = append(link.Included, ConvertWorkItem(ctx.RequestData, targetWi))
 
@@ -179,7 +179,7 @@ func enrichLinkList(ctx *workItemLinkContext, linkArr *app.WorkItemLinkList) err
 	// include link types
 	typeDataArr, err := getTypesOfLinks(ctx, linkArr.Data)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	// Convert slice of objects to slice of interface (see https://golang.org/doc/faq#convert_slice_of_interface)
 	interfaceArr := make([]interface{}, len(typeDataArr))
@@ -191,7 +191,7 @@ func enrichLinkList(ctx *workItemLinkContext, linkArr *app.WorkItemLinkList) err
 	// include link categories
 	catDataArr, err := getCategoriesOfLinkTypes(ctx, typeDataArr)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	// Convert slice of objects to slice of interface (see https://golang.org/doc/faq#convert_slice_of_interface)
 	interfaceArr = make([]interface{}, len(catDataArr))
@@ -203,7 +203,7 @@ func enrichLinkList(ctx *workItemLinkContext, linkArr *app.WorkItemLinkList) err
 	// TODO(kwk): Include WIs from source and target
 	workItemDataArr, err := getWorkItemsOfLinks(ctx, linkArr.Data)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	// Convert slice of objects to slice of interface (see https://golang.org/doc/faq#convert_slice_of_interface)
 	interfaceArr = make([]interface{}, len(workItemDataArr))

--- a/workitem.go
+++ b/workitem.go
@@ -17,6 +17,7 @@ import (
 	"github.com/almighty/almighty-core/rest"
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/goadesign/goa"
+	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -62,7 +63,8 @@ func (c *WorkitemController) List(ctx *app.ListWorkitemContext) error {
 		result, tc, err := tx.WorkItems().List(ctx.Context, exp, &offset, &limit)
 		count := int(tc)
 		if err != nil {
-			switch err := err.(type) {
+			cause := errs.Cause(err)
+			switch cause.(type) {
 			case errors.BadParameterError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error listing work items: %s", err.Error())))
 				return ctx.BadRequest(jerrors)
@@ -107,7 +109,8 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 		}
 		wi, err = appl.WorkItems().Save(ctx, *wi)
 		if err != nil {
-			switch err := err.(type) {
+			cause := errs.Cause(err)
+			switch cause.(type) {
 			case errors.BadParameterError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
 				return ctx.BadRequest(jerrors)
@@ -165,7 +168,8 @@ func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
 
 		wi, err := appl.WorkItems().Create(ctx, *wit, wi.Fields, currentUser)
 		if err != nil {
-			switch err := err.(type) {
+			cause := errs.Cause(err)
+			switch cause.(type) {
 			case errors.BadParameterError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
 				return ctx.BadRequest(jerrors)
@@ -199,7 +203,8 @@ func (c *WorkitemController) Show(ctx *app.ShowWorkitemContext) error {
 
 		wi, err := appl.WorkItems().Load(ctx, ctx.ID)
 		if err != nil {
-			switch err := err.(type) {
+			cause := errs.Cause(err)
+			switch cause.(type) {
 			case errors.NotFoundError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrNotFound(err.Error()))
 				return ctx.NotFound(jerrors)
@@ -230,7 +235,8 @@ func (c *WorkitemController) Delete(ctx *app.DeleteWorkitemContext) error {
 
 		err := appl.WorkItems().Delete(ctx, ctx.ID)
 		if err != nil {
-			switch err := err.(type) {
+			cause := errs.Cause(err)
+			switch cause.(type) {
 			case errors.NotFoundError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrNotFound(err.Error()))
 				return ctx.NotFound(jerrors)

--- a/workitem/field_definition.go
+++ b/workitem/field_definition.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"github.com/almighty/almighty-core/convert"
+	"github.com/pkg/errors"
 )
 
 // constants for describing possible field types

--- a/workitem/field_definition.go
+++ b/workitem/field_definition.go
@@ -113,7 +113,7 @@ func (f *FieldDefinition) UnmarshalJSON(bytes []byte) error {
 
 	err := json.Unmarshal(bytes, &temp)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	rawType := map[string]interface{}{}
 	json.Unmarshal(*temp.Type, &rawType)
@@ -121,28 +121,28 @@ func (f *FieldDefinition) UnmarshalJSON(bytes []byte) error {
 	kind, err := convertAnyToKind(rawType["Kind"])
 
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	switch *kind {
 	case KindList:
 		theType := ListType{}
 		err = json.Unmarshal(*temp.Type, &theType)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 		*f = FieldDefinition{Type: theType, Required: temp.Required}
 	case KindEnum:
 		theType := EnumType{}
 		err = json.Unmarshal(*temp.Type, &theType)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 		*f = FieldDefinition{Type: theType, Required: temp.Required}
 	default:
 		theType := SimpleType{}
 		err = json.Unmarshal(*temp.Type, &theType)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 		*f = FieldDefinition{Type: theType, Required: temp.Required}
 	}

--- a/workitem/json_storage.go
+++ b/workitem/json_storage.go
@@ -3,10 +3,10 @@ package workitem
 import (
 	"database/sql/driver"
 	"encoding/json"
-	"errors"
 	"reflect"
 
 	"github.com/almighty/almighty-core/convert"
+	"github.com/pkg/errors"
 )
 
 type Fields map[string]interface{}

--- a/workitem/link/link-repository.go
+++ b/workitem/link/link-repository.go
@@ -11,6 +11,7 @@ import (
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/jinzhu/gorm"
+	errs "github.com/pkg/errors"
 	satoriuuid "github.com/satori/go.uuid"
 )
 
@@ -56,26 +57,26 @@ type GormWorkItemLinkRepository struct {
 func (r *GormWorkItemLinkRepository) ValidateCorrectSourceAndTargetType(sourceID, targetID uint64, linkTypeID satoriuuid.UUID) error {
 	linkType, err := r.workItemLinkTypeRepo.LoadTypeFromDBByID(linkTypeID)
 	if err != nil {
-		return errors.WithStack(err)
+		return errs.WithStack(err)
 	}
 	// Fetch the source work item
 	source, err := r.workItemRepo.LoadFromDB(strconv.FormatUint(sourceID, 10))
 	if err != nil {
-		return errors.WithStack(err)
+		return errs.WithStack(err)
 	}
 	// Fetch the target work item
 	target, err := r.workItemRepo.LoadFromDB(strconv.FormatUint(targetID, 10))
 	if err != nil {
-		return errors.WithStack(err)
+		return errs.WithStack(err)
 	}
 	// Fetch the concrete work item types of the target and the source.
 	sourceWorkItemType, err := r.workItemTypeRepo.LoadTypeFromDB(source.Type)
 	if err != nil {
-		return errors.WithStack(err)
+		return errs.WithStack(err)
 	}
 	targetWorkItemType, err := r.workItemTypeRepo.LoadTypeFromDB(target.Type)
 	if err != nil {
-		return errors.WithStack(err)
+		return errs.WithStack(err)
 	}
 	// Check type paths
 	if !sourceWorkItemType.IsTypeOrSubtypeOf(linkType.SourceTypeName) {
@@ -96,10 +97,10 @@ func (r *GormWorkItemLinkRepository) Create(ctx context.Context, sourceID, targe
 		LinkTypeID: linkTypeID,
 	}
 	if err := link.CheckValidForCreation(); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errs.WithStack(err)
 	}
 	if err := r.ValidateCorrectSourceAndTargetType(sourceID, targetID, linkTypeID); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errs.WithStack(err)
 	}
 	db := r.db.Create(link)
 	if db.Error != nil {
@@ -142,7 +143,7 @@ type fetchLinksFunc func() ([]WorkItemLink, error)
 func (r *GormWorkItemLinkRepository) list(ctx context.Context, fetchFunc fetchLinksFunc) (*app.WorkItemLinkList, error) {
 	rows, err := fetchFunc()
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errs.WithStack(err)
 	}
 	res := app.WorkItemLinkList{}
 	res.Data = make([]*app.WorkItemLinkData, len(rows))
@@ -165,7 +166,7 @@ func (r *GormWorkItemLinkRepository) ListByWorkItemID(ctx context.Context, wiIDS
 		var rows []WorkItemLink
 		wi, err := r.workItemRepo.LoadFromDB(wiIDStr)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errs.WithStack(err)
 		}
 		// Now fetch all links for that work item
 		db := r.db.Model(&WorkItemLink{}).Where("? IN (source_id, target_id)", wi.ID).Find(&rows)
@@ -235,11 +236,11 @@ func (r *GormWorkItemLinkRepository) Save(ctx context.Context, lt app.WorkItemLi
 		return nil, errors.NewVersionConflictError("version conflict")
 	}
 	if err := ConvertLinkToModel(lt, &res); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errs.WithStack(err)
 	}
 	res.Version = res.Version + 1
 	if err := r.ValidateCorrectSourceAndTargetType(res.SourceID, res.TargetID, res.LinkTypeID); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errs.WithStack(err)
 	}
 	db = r.db.Save(&res)
 	if db.Error != nil {

--- a/workitem/link/type-repository.go
+++ b/workitem/link/type-repository.go
@@ -45,7 +45,7 @@ func (r *GormWorkItemLinkTypeRepository) Create(ctx context.Context, name string
 		LinkCategoryID: linkCategoryID,
 	}
 	if err := linkType.CheckValidForCreation(); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	// Check link category exists
@@ -186,7 +186,7 @@ func (r *GormWorkItemLinkTypeRepository) Save(ctx context.Context, lt app.WorkIt
 		return nil, errors.NewVersionConflictError("version conflict")
 	}
 	if err := ConvertLinkTypeToModel(lt, &res); err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	res.Version = res.Version + 1
 	db = db.Save(&res)

--- a/workitem/link/type-repository.go
+++ b/workitem/link/type-repository.go
@@ -9,6 +9,7 @@ import (
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/errors"
 	"github.com/jinzhu/gorm"
+	errs "github.com/pkg/errors"
 	satoriuuid "github.com/satori/go.uuid"
 )
 
@@ -45,7 +46,7 @@ func (r *GormWorkItemLinkTypeRepository) Create(ctx context.Context, name string
 		LinkCategoryID: linkCategoryID,
 	}
 	if err := linkType.CheckValidForCreation(); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errs.WithStack(err)
 	}
 
 	// Check link category exists
@@ -186,7 +187,7 @@ func (r *GormWorkItemLinkTypeRepository) Save(ctx context.Context, lt app.WorkIt
 		return nil, errors.NewVersionConflictError("version conflict")
 	}
 	if err := ConvertLinkTypeToModel(lt, &res); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errs.WithStack(err)
 	}
 	res.Version = res.Version + 1
 	db = db.Save(&res)

--- a/workitem/link/type.go
+++ b/workitem/link/type.go
@@ -5,6 +5,7 @@ import (
 	convert "github.com/almighty/almighty-core/convert"
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"
+	errs "github.com/pkg/errors"
 	satoriuuid "github.com/satori/go.uuid"
 )
 
@@ -124,7 +125,7 @@ func (t *WorkItemLinkType) CheckValidForCreation() error {
 		return errors.NewBadParameterError("reverse_name", t.ReverseName)
 	}
 	if err := CheckValidTopology(t.Topology); err != nil {
-		return errors.WithStack(err)
+		return errs.WithStack(err)
 	}
 	if t.LinkCategoryID == satoriuuid.Nil {
 		return errors.NewBadParameterError("link_category_id", t.LinkCategoryID)
@@ -237,7 +238,7 @@ func ConvertLinkTypeToModel(in app.WorkItemLinkTypeSingle, out *WorkItemLinkType
 
 		if attrs.Topology != nil {
 			if err := CheckValidTopology(*attrs.Topology); err != nil {
-				return errors.WithStack(err)
+				return errs.WithStack(err)
 			}
 			out.Topology = *attrs.Topology
 		}

--- a/workitem/link/type.go
+++ b/workitem/link/type.go
@@ -124,7 +124,7 @@ func (t *WorkItemLinkType) CheckValidForCreation() error {
 		return errors.NewBadParameterError("reverse_name", t.ReverseName)
 	}
 	if err := CheckValidTopology(t.Topology); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	if t.LinkCategoryID == satoriuuid.Nil {
 		return errors.NewBadParameterError("link_category_id", t.LinkCategoryID)
@@ -237,7 +237,7 @@ func ConvertLinkTypeToModel(in app.WorkItemLinkTypeSingle, out *WorkItemLinkType
 
 		if attrs.Topology != nil {
 			if err := CheckValidTopology(*attrs.Topology); err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 			out.Topology = *attrs.Topology
 		}

--- a/workitem/simple_type.go
+++ b/workitem/simple_type.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/almighty/almighty-core/convert"
 	"github.com/asaskevich/govalidator"
+	"github.com/pkg/errors"
 )
 
 // SimpleType is an unstructured FieldType

--- a/workitem/simple_type.go
+++ b/workitem/simple_type.go
@@ -73,7 +73,7 @@ func (fieldType SimpleType) ConvertToModel(value interface{}) (interface{}, erro
 			return nil, fmt.Errorf("value %v should be %s, but is %s", value, "string", valueType.Name())
 		}
 		idValue, err := strconv.Atoi(value.(string))
-		return idValue, err
+		return idValue, errors.WithStack(err)
 	case KindList:
 		if (valueType.Kind() != reflect.Array) && (valueType.Kind() != reflect.Slice) {
 			return nil, fmt.Errorf("value %v should be %s, but is %s,", value, "array/slice", valueType.Kind())

--- a/workitem/undoable_wi_repo.go
+++ b/workitem/undoable_wi_repo.go
@@ -56,7 +56,7 @@ func (r *UndoableWorkItemRepository) Save(ctx context.Context, wi app.WorkItem) 
 			return db.Error
 		})
 	}
-	return res, err
+	return res, errors.WithStack(err)
 }
 
 // Delete implements application.WorkItemRepository
@@ -82,14 +82,14 @@ func (r *UndoableWorkItemRepository) Delete(ctx context.Context, ID string) erro
 			return db.Error
 		})
 	}
-	return err
+	return errors.WithStack(err)
 }
 
 // Create implements application.WorkItemRepository
 func (r *UndoableWorkItemRepository) Create(ctx context.Context, typeID string, fields map[string]interface{}, creator string) (*app.WorkItem, error) {
 	result, err := r.wrapped.Create(ctx, typeID, fields, creator)
 	if err != nil {
-		return result, err
+		return result, errors.WithStack(err)
 	}
 	id, err := strconv.ParseUint(result.ID, 10, 64)
 	if err != nil {
@@ -104,7 +104,7 @@ func (r *UndoableWorkItemRepository) Create(ctx context.Context, typeID string, 
 		return db.Error
 	})
 
-	return result, err
+	return result, errors.WithStack(err)
 }
 
 // List implements application.WorkItemRepository

--- a/workitem/undoable_wi_repo.go
+++ b/workitem/undoable_wi_repo.go
@@ -13,6 +13,7 @@ import (
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/jinzhu/gorm"
+	errs "github.com/pkg/errors"
 )
 
 var _ WorkItemRepository = &UndoableWorkItemRepository{}
@@ -56,7 +57,7 @@ func (r *UndoableWorkItemRepository) Save(ctx context.Context, wi app.WorkItem) 
 			return db.Error
 		})
 	}
-	return res, errors.WithStack(err)
+	return res, errs.WithStack(err)
 }
 
 // Delete implements application.WorkItemRepository
@@ -82,14 +83,14 @@ func (r *UndoableWorkItemRepository) Delete(ctx context.Context, ID string) erro
 			return db.Error
 		})
 	}
-	return errors.WithStack(err)
+	return errs.WithStack(err)
 }
 
 // Create implements application.WorkItemRepository
 func (r *UndoableWorkItemRepository) Create(ctx context.Context, typeID string, fields map[string]interface{}, creator string) (*app.WorkItem, error) {
 	result, err := r.wrapped.Create(ctx, typeID, fields, creator)
 	if err != nil {
-		return result, errors.WithStack(err)
+		return result, errs.WithStack(err)
 	}
 	id, err := strconv.ParseUint(result.ID, 10, 64)
 	if err != nil {
@@ -104,7 +105,7 @@ func (r *UndoableWorkItemRepository) Create(ctx context.Context, typeID string, 
 		return db.Error
 	})
 
-	return result, errors.WithStack(err)
+	return result, errs.WithStack(err)
 }
 
 // List implements application.WorkItemRepository

--- a/workitem/undoable_wi_type_repo.go
+++ b/workitem/undoable_wi_type_repo.go
@@ -6,6 +6,7 @@ import (
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
 )
 
 var _ WorkItemTypeRepository = &UndoableWorkItemTypeRepository{}

--- a/workitem/undoable_wi_type_repo.go
+++ b/workitem/undoable_wi_type_repo.go
@@ -41,5 +41,5 @@ func (r *UndoableWorkItemTypeRepository) Create(ctx context.Context, extendedTyp
 			return db.Error
 		})
 	}
-	return res, err
+	return res, errors.WithStack(err)
 }

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -52,7 +52,7 @@ func (r *GormWorkItemRepository) LoadFromDB(ID string) (*WorkItem, error) {
 func (r *GormWorkItemRepository) Load(ctx context.Context, ID string) (*app.WorkItem, error) {
 	res, err := r.LoadFromDB(ID)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	wiType, err := r.wir.LoadTypeFromDB(res.Type)
 	if err != nil {
@@ -209,7 +209,7 @@ func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, criteria c
 
 	rows, err := db.Rows()
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, errors.WithStack(err)
 	}
 	defer rows.Close()
 
@@ -249,7 +249,7 @@ func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, criteria c
 		rows2, err := orgDB.Rows()
 		defer rows2.Close()
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, errors.WithStack(err)
 		}
 		rows2.Next() // count(*) will always return a row
 		rows2.Scan(&count)
@@ -261,7 +261,7 @@ func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, criteria c
 func (r *GormWorkItemRepository) List(ctx context.Context, criteria criteria.Expression, start *int, limit *int) ([]*app.WorkItem, uint64, error) {
 	result, count, err := r.listItemsFromDB(ctx, criteria, start, limit)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, errors.WithStack(err)
 	}
 
 	res := make([]*app.WorkItem, len(result))

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -10,6 +10,7 @@ import (
 	"github.com/almighty/almighty-core/criteria"
 	"github.com/almighty/almighty-core/errors"
 	"github.com/jinzhu/gorm"
+	errs "github.com/pkg/errors"
 )
 
 // WorkItemRepository encapsulates storage & retrieval of work items
@@ -52,7 +53,7 @@ func (r *GormWorkItemRepository) LoadFromDB(ID string) (*WorkItem, error) {
 func (r *GormWorkItemRepository) Load(ctx context.Context, ID string) (*app.WorkItem, error) {
 	res, err := r.LoadFromDB(ID)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errs.WithStack(err)
 	}
 	wiType, err := r.wir.LoadTypeFromDB(res.Type)
 	if err != nil {
@@ -209,7 +210,7 @@ func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, criteria c
 
 	rows, err := db.Rows()
 	if err != nil {
-		return nil, 0, errors.WithStack(err)
+		return nil, 0, errs.WithStack(err)
 	}
 	defer rows.Close()
 
@@ -249,7 +250,7 @@ func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, criteria c
 		rows2, err := orgDB.Rows()
 		defer rows2.Close()
 		if err != nil {
-			return nil, 0, errors.WithStack(err)
+			return nil, 0, errs.WithStack(err)
 		}
 		rows2.Next() // count(*) will always return a row
 		rows2.Scan(&count)
@@ -261,7 +262,7 @@ func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, criteria c
 func (r *GormWorkItemRepository) List(ctx context.Context, criteria criteria.Expression, start *int, limit *int) ([]*app.WorkItem, uint64, error) {
 	result, count, err := r.listItemsFromDB(ctx, criteria, start, limit)
 	if err != nil {
-		return nil, 0, errors.WithStack(err)
+		return nil, 0, errs.WithStack(err)
 	}
 
 	res := make([]*app.WorkItem, len(result))

--- a/workitem/workitem_repository_blackbox_test.go
+++ b/workitem/workitem_repository_blackbox_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/workitem"
+	errs "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -41,7 +42,7 @@ func (s *workItemRepoBlackBoxTest) TestFailDeleteZeroID() {
 	}
 
 	err = s.repo.Delete(context.Background(), "0")
-	require.IsType(s.T(), errors.NotFoundError{}, err)
+	require.IsType(s.T(), errors.NotFoundError{}, errs.Cause(err))
 }
 
 func (s *workItemRepoBlackBoxTest) TestFailSaveZeroID() {
@@ -55,13 +56,11 @@ func (s *workItemRepoBlackBoxTest) TestFailSaveZeroID() {
 			workitem.SystemState: workitem.SystemStateNew,
 		}, "xx")
 
-	if err != nil {
-		s.T().Error("Could not create workitem", err)
-	}
+	require.Nil(s.T(), err, "Could not create workitem")
 	wi.ID = "0"
 
 	_, err = s.repo.Save(context.Background(), *wi)
-	require.IsType(s.T(), errors.NotFoundError{}, err)
+	require.IsType(s.T(), errors.NotFoundError{}, errs.Cause(err))
 }
 
 func (s *workItemRepoBlackBoxTest) TestFaiLoadZeroID() {
@@ -75,12 +74,10 @@ func (s *workItemRepoBlackBoxTest) TestFaiLoadZeroID() {
 			workitem.SystemState: workitem.SystemStateNew,
 		}, "xx")
 
-	if err != nil {
-		s.T().Error("Could not create workitem", err)
-	}
+	require.Nil(s.T(), err, "Could not create workitem")
 
 	_, err = s.repo.Load(context.Background(), "0")
-	require.IsType(s.T(), errors.NotFoundError{}, err)
+	require.IsType(s.T(), errors.NotFoundError{}, errs.Cause(err))
 }
 
 func (s *workItemRepoBlackBoxTest) TestSaveAssignees() {
@@ -94,9 +91,7 @@ func (s *workItemRepoBlackBoxTest) TestSaveAssignees() {
 			workitem.SystemAssignees: []string{"A", "B"},
 		}, "xx")
 
-	if err != nil {
-		s.T().Error("Could not create workitem", err)
-	}
+	require.Nil(s.T(), err, "Could not create workitem")
 
 	wi, err = s.repo.Load(context.Background(), wi.ID)
 

--- a/workitem/workitemtype.go
+++ b/workitem/workitemtype.go
@@ -116,7 +116,7 @@ func (wit WorkItemType) ConvertFromModel(workItem WorkItem) (*app.WorkItem, erro
 		}
 		result.Fields[name], err = field.ConvertFromModel(name, workItem.Fields[name])
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 	}
 

--- a/workitem/workitemtype.go
+++ b/workitem/workitemtype.go
@@ -7,6 +7,7 @@ import (
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/convert"
 	"github.com/almighty/almighty-core/gormsupport"
+	"github.com/pkg/errors"
 )
 
 // String constants for the local work item types.

--- a/workitem/workitemtype_repository.go
+++ b/workitem/workitemtype_repository.go
@@ -10,6 +10,7 @@ import (
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/errors"
 	"github.com/jinzhu/gorm"
+	errs "github.com/pkg/errors"
 )
 
 // WorkItemTypeRepository encapsulates storage & retrieval of work item types
@@ -39,7 +40,7 @@ type GormWorkItemTypeRepository struct {
 func (r *GormWorkItemTypeRepository) Load(ctx context.Context, name string) (*app.WorkItemType, error) {
 	res, err := r.LoadTypeFromDB(name)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errs.WithStack(err)
 	}
 
 	result := convertTypeFromModels(res)
@@ -94,7 +95,7 @@ func (r *GormWorkItemTypeRepository) Create(ctx context.Context, extendedTypeNam
 		existing, exists := allFields[field]
 		ct, err := convertFieldTypeToModels(*definition.Type)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errs.WithStack(err)
 		}
 		converted := FieldDefinition{
 			Required: definition.Required,
@@ -137,7 +138,7 @@ func (r *GormWorkItemTypeRepository) List(ctx context.Context, start *int, limit
 		db = db.Limit(*limit)
 	}
 	if err := db.Find(&rows).Error; err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errs.WithStack(err)
 	}
 	result := make([]*app.WorkItemType, len(rows))
 
@@ -208,13 +209,13 @@ func convertStringToKind(k string) (*Kind, error) {
 func convertFieldTypeToModels(t app.FieldType) (FieldType, error) {
 	kind, err := convertStringToKind(t.Kind)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errs.WithStack(err)
 	}
 	switch *kind {
 	case KindList:
 		componentType, err := convertAnyToKind(*t.ComponentType)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errs.WithStack(err)
 		}
 		if !componentType.isSimpleType() {
 			return nil, fmt.Errorf("Component type is not list type: %s", componentType)
@@ -223,7 +224,7 @@ func convertFieldTypeToModels(t app.FieldType) (FieldType, error) {
 	case KindEnum:
 		bt, err := convertAnyToKind(*t.BaseType)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errs.WithStack(err)
 		}
 		if !bt.isSimpleType() {
 			return nil, fmt.Errorf("baseType type is not list type: %s", bt)
@@ -235,7 +236,7 @@ func convertFieldTypeToModels(t app.FieldType) (FieldType, error) {
 			return ft.ConvertToModel(element)
 		}, baseType, values)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errs.WithStack(err)
 		}
 		return EnumType{SimpleType{*kind}, baseType, converted}, nil
 	default:
@@ -249,7 +250,7 @@ func TEMPConvertFieldTypesToModel(fields map[string]app.FieldDefinition) (map[st
 	for field, definition := range fields {
 		ct, err := convertFieldTypeToModels(*definition.Type)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errs.WithStack(err)
 		}
 		converted := FieldDefinition{
 			Required: definition.Required,

--- a/workitem/workitemtype_repository.go
+++ b/workitem/workitemtype_repository.go
@@ -39,7 +39,7 @@ type GormWorkItemTypeRepository struct {
 func (r *GormWorkItemTypeRepository) Load(ctx context.Context, name string) (*app.WorkItemType, error) {
 	res, err := r.LoadTypeFromDB(name)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	result := convertTypeFromModels(res)
@@ -94,7 +94,7 @@ func (r *GormWorkItemTypeRepository) Create(ctx context.Context, extendedTypeNam
 		existing, exists := allFields[field]
 		ct, err := convertFieldTypeToModels(*definition.Type)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		converted := FieldDefinition{
 			Required: definition.Required,
@@ -137,7 +137,7 @@ func (r *GormWorkItemTypeRepository) List(ctx context.Context, start *int, limit
 		db = db.Limit(*limit)
 	}
 	if err := db.Find(&rows).Error; err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	result := make([]*app.WorkItemType, len(rows))
 
@@ -208,13 +208,13 @@ func convertStringToKind(k string) (*Kind, error) {
 func convertFieldTypeToModels(t app.FieldType) (FieldType, error) {
 	kind, err := convertStringToKind(t.Kind)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	switch *kind {
 	case KindList:
 		componentType, err := convertAnyToKind(*t.ComponentType)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		if !componentType.isSimpleType() {
 			return nil, fmt.Errorf("Component type is not list type: %s", componentType)
@@ -223,7 +223,7 @@ func convertFieldTypeToModels(t app.FieldType) (FieldType, error) {
 	case KindEnum:
 		bt, err := convertAnyToKind(*t.BaseType)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		if !bt.isSimpleType() {
 			return nil, fmt.Errorf("baseType type is not list type: %s", bt)
@@ -235,7 +235,7 @@ func convertFieldTypeToModels(t app.FieldType) (FieldType, error) {
 			return ft.ConvertToModel(element)
 		}, baseType, values)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		return EnumType{SimpleType{*kind}, baseType, converted}, nil
 	default:
@@ -249,7 +249,7 @@ func TEMPConvertFieldTypesToModel(fields map[string]app.FieldDefinition) (map[st
 	for field, definition := range fields {
 		ct, err := convertFieldTypeToModels(*definition.Type)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		converted := FieldDefinition{
 			Required: definition.Required,

--- a/workitem/workitemtype_repository_blackbox_test.go
+++ b/workitem/workitemtype_repository_blackbox_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/workitem"
+	errs "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -51,7 +52,7 @@ func (s *workItemTypeRepoBlackBoxTest) TestCreateLoadWIT() {
 	assert.NotNil(s.T(), wit)
 
 	wit3, err := s.repo.Create(context.Background(), nil, "foo_bar", map[string]app.FieldDefinition{})
-	assert.IsType(s.T(), errors.BadParameterError{}, err)
+	assert.IsType(s.T(), errors.BadParameterError{}, errs.Cause(err))
 	assert.Nil(s.T(), wit3)
 
 	wit2, err := s.repo.Load(context.Background(), "foo_bar")
@@ -81,7 +82,7 @@ func (s *workItemTypeRepoBlackBoxTest) TestCreateLoadWITWithList() {
 	assert.NotNil(s.T(), wit)
 
 	wit3, err := s.repo.Create(context.Background(), nil, "foo_bar", map[string]app.FieldDefinition{})
-	assert.IsType(s.T(), errors.BadParameterError{}, err)
+	assert.IsType(s.T(), errors.BadParameterError{}, errs.Cause(err))
 	assert.Nil(s.T(), wit3)
 
 	wit2, err := s.repo.Load(context.Background(), "foo_bar")


### PR DESCRIPTION
1. Add stack to all error reporting methods that could be found using this command:

```sh
find . -name "*.go" -exec sed -i -e 's/return\(.*\) err$/return\1 errors.WithStack(err)/g' {} \;
```

This basically replaces:

   - `return err` with `return errors.WithStack(err)`,
   - `return nil, err` with `return nil, errors.WithStack(err)`,
   - and so forth.

2. Added `github.com/pkg/errors` to glide and imported it in Go as `errs` (most of the time) in order to avoid confusion.
3. Use `github.com/pkg/errors.New()` instead of standard `errors.New()` wherever possible
4. Use `errors.Errorf()` instead of `fmt.Errorf()` wherever possible
5. Use `errors.Cause(err)` in tests that check for a particular error type to get the `github.com/almighty/almighty-core/errors` errors
* Error type switch based on
    ``` go
    cause := errors.Cause(err)
    switch cause.(type) {
    // ...
    }
    ```

## TODO

Decide on a strategy to enrich return values like these in order to provide good stack traces for errors that bubble up:

```go
return errors.NewInternalError("blabla")
return errors.NewNotFoundError("work item ID", wiIDStr)
```

Do we want to wrap those calls like so?

```go
return errs.WithStack(errors.NewInternalError("blabla"))
return errs.WithStack(errors.NewNotFoundError("work item ID", wiIDStr))
```

Or do we want to reduce the verbosity and have `errors.NewInternalError` and the other error constructors do that for us? IMHO I would like to change the constructors anyway so that we can pass along any existing `error` to them.

See #641
