### PR TITLE
Add ability to run tests without coverage for faster CI feedback on PR

### DIFF
--- a/.make/docker.mk
+++ b/.make/docker.mk
@@ -97,7 +97,7 @@ endif
 
 # The targets in the following list all depend on a running database container.
 # Make sure you run "make integration-test-env-prepare" before you run any of these targets.
-DB_DEPENDENT_DOCKER_TARGETS = docker-test-migration docker-test-integration docker-coverage-all
+DB_DEPENDENT_DOCKER_TARGETS = docker-test-migration docker-test-integration docker-test-integration-no-coverage docker-coverage-all
 
 $(DB_DEPENDENT_DOCKER_TARGETS):
 	$(eval makecommand:=$(subst docker-,,$@))

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -138,15 +138,15 @@ test-integration-no-coverage: prebuild-check migrate-database $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
 	ALMIGHTY_RESOURCE_DATABASE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test -v github.com/almighty/almighty-core \
-		github.com/almighty/almighty-core/account
-# github.com/almighty/almighty-core/comment
-# github.com/almighty/almighty-core/configuration
-# github.com/almighty/almighty-core/convert
-# github.com/almighty/almighty-core/criteria
-# github.com/almighty/almighty-core/errors
-# github.com/almighty/almighty-core/gormsupport
-# github.com/almighty/almighty-core/iteration
-# github.com/almighty/almighty-core/jsonapi
+		github.com/almighty/almighty-core/account \
+		github.com/almighty/almighty-core/comment \
+		github.com/almighty/almighty-core/configuration \
+		github.com/almighty/almighty-core/convert \
+		github.com/almighty/almighty-core/criteria \
+		github.com/almighty/almighty-core/errors \
+		github.com/almighty/almighty-core/gormsupport \
+		github.com/almighty/almighty-core/iteration \
+		github.com/almighty/almighty-core/jsonapi
 # github.com/almighty/almighty-core/login
 # github.com/almighty/almighty-core/migration
 # github.com/almighty/almighty-core/models

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -137,30 +137,7 @@ test-integration: prebuild-check clean-coverage-integration migrate-database $(C
 test-integration-no-coverage: prebuild-check migrate-database $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	ALMIGHTY_RESOURCE_DATABASE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test -v \
-		github.com/almighty/almighty-core \
-		github.com/almighty/almighty-core/account \
-		github.com/almighty/almighty-core/comment \
-		github.com/almighty/almighty-core/configuration \
-		github.com/almighty/almighty-core/convert \
-		github.com/almighty/almighty-core/criteria \
-		github.com/almighty/almighty-core/errors \
-		github.com/almighty/almighty-core/gormsupport \
-		github.com/almighty/almighty-core/iteration \
-		github.com/almighty/almighty-core/jsonapi \
-		github.com/almighty/almighty-core/login \
-		github.com/almighty/almighty-core/migration \
-		github.com/almighty/almighty-core/models \
-		github.com/almighty/almighty-core/query/simple \
-		github.com/almighty/almighty-core/remoteworkitem \
-		github.com/almighty/almighty-core/resource \
-		github.com/almighty/almighty-core/search \
-		github.com/almighty/almighty-core/space \
-		github.com/almighty/almighty-core/token \
-		github.com/almighty/almighty-core/tool/alm-cli \
-		github.com/almighty/almighty-core/workitem \
-		github.com/almighty/almighty-core/workitem/link
-#ALMIGHTY_RESOURCE_DATABASE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test -v $(TEST_PACKAGES)
+	ALMIGHTY_RESOURCE_DATABASE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test -v $(TEST_PACKAGES)
 
 .PHONY: test-migration
 ## Runs the migration tests and should be executed before running the integration tests

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -137,7 +137,8 @@ test-integration: prebuild-check clean-coverage-integration migrate-database $(C
 test-integration-no-coverage: prebuild-check migrate-database $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	ALMIGHTY_RESOURCE_DATABASE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test -v github.com/almighty/almighty-core \
+	ALMIGHTY_RESOURCE_DATABASE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test -v \
+		github.com/almighty/almighty-core \
 		github.com/almighty/almighty-core/account \
 		github.com/almighty/almighty-core/comment \
 		github.com/almighty/almighty-core/configuration \

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -137,10 +137,8 @@ test-integration: prebuild-check clean-coverage-integration migrate-database $(C
 test-integration-no-coverage: prebuild-check migrate-database $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	ALMIGHTY_RESOURCE_DATABASE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test -v github.com/almighty/almighty-core
-
-# Add one by one until it breaks on CI
-# github.com/almighty/almighty-core/account
+	ALMIGHTY_RESOURCE_DATABASE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test -v github.com/almighty/almighty-core \
+		github.com/almighty/almighty-core/account
 # github.com/almighty/almighty-core/comment
 # github.com/almighty/almighty-core/configuration
 # github.com/almighty/almighty-core/convert

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -119,10 +119,25 @@ test-all: prebuild-check test-unit test-integration
 ## Runs the unit tests and produces coverage files for each package.
 test-unit: prebuild-check clean-coverage-unit $(COV_PATH_UNIT)
 
+.PHONY: test-unit-no-coverage
+## Runs the unit tests and WITHOUT producing coverage files for each package.
+test-unit-no-coverage: prebuild-check $(SOURCES)
+	$(call log-info,"Running test: $@")
+	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
+	ALMIGHTY_RESOURCE_UNIT_TEST=1 go test -v $(TEST_PACKAGES)
+
 .PHONY: test-integration
 ## Runs the integration tests and produces coverage files for each package.
 ## Make sure you ran "make integration-test-env-prepare" before you run this target.
 test-integration: prebuild-check clean-coverage-integration migrate-database $(COV_PATH_INTEGRATION)
+
+.PHONY: test-integration-no-coverage
+## Runs the integration tests WITHOUT producing coverage files for each package.
+## Make sure you ran "make integration-test-env-prepare" before you run this target.
+test-integration-no-coverage: prebuild-check migrate-database
+	$(call log-info,"Running test: $@")
+	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
+	ALMIGHTY_RESOURCE_DATABASE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test -v $(TEST_PACKAGES)
 
 .PHONY: test-migration
 ## Runs the migration tests and should be executed before running the integration tests
@@ -324,7 +339,8 @@ gocov-integration-annotate: prebuild-check $(GOCOV_BIN) $(COV_PATH_INTEGRATION)
 #  2. package name "github.com/almighty/almighty-core/model"
 #  3. File in which to combine the output
 #  4. Path to file in which to store names of packages that failed testing
-#  5. Environment variable (in the form VAR=VALUE) to be specified for running the test
+#  5. Environment variable (in the form VAR=VALUE) to be specified for running
+#     the test. For multiple environment variables, pass "VAR1=VAL1 VAR2=VAL2".
 define test-package
 $(eval TEST_NAME := $(1))
 $(eval PACKAGE_NAME := $(2))

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -156,10 +156,10 @@ test-integration-no-coverage: prebuild-check migrate-database $(SOURCES)
 		github.com/almighty/almighty-core/resource \
 		github.com/almighty/almighty-core/search \
 		github.com/almighty/almighty-core/space \
-		github.com/almighty/almighty-core/token
-# github.com/almighty/almighty-core/tool/alm-cli
-# github.com/almighty/almighty-core/workitem
-# github.com/almighty/almighty-core/workitem/link
+		github.com/almighty/almighty-core/token \
+		github.com/almighty/almighty-core/tool/alm-cli \
+		github.com/almighty/almighty-core/workitem \
+		github.com/almighty/almighty-core/workitem/link
 #ALMIGHTY_RESOURCE_DATABASE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test -v $(TEST_PACKAGES)
 
 .PHONY: test-migration

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -152,11 +152,11 @@ test-integration-no-coverage: prebuild-check migrate-database $(SOURCES)
 		github.com/almighty/almighty-core/migration \
 		github.com/almighty/almighty-core/models \
 		github.com/almighty/almighty-core/query/simple \
-		github.com/almighty/almighty-core/remoteworkitem
-# github.com/almighty/almighty-core/resource
-# github.com/almighty/almighty-core/search
-# github.com/almighty/almighty-core/space
-# github.com/almighty/almighty-core/token
+		github.com/almighty/almighty-core/remoteworkitem \
+		github.com/almighty/almighty-core/resource \
+		github.com/almighty/almighty-core/search \
+		github.com/almighty/almighty-core/space \
+		github.com/almighty/almighty-core/token
 # github.com/almighty/almighty-core/tool/alm-cli
 # github.com/almighty/almighty-core/workitem
 # github.com/almighty/almighty-core/workitem/link

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -150,8 +150,8 @@ test-integration-no-coverage: prebuild-check migrate-database $(SOURCES)
 		github.com/almighty/almighty-core/login \
 		github.com/almighty/almighty-core/migration \
 		github.com/almighty/almighty-core/models \
-		github.com/almighty/almighty-core/query/simple
-# github.com/almighty/almighty-core/remoteworkitem
+		github.com/almighty/almighty-core/query/simple \
+		github.com/almighty/almighty-core/remoteworkitem
 # github.com/almighty/almighty-core/resource
 # github.com/almighty/almighty-core/search
 # github.com/almighty/almighty-core/space

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -137,7 +137,7 @@ test-integration: prebuild-check clean-coverage-integration migrate-database $(C
 test-integration-no-coverage: prebuild-check migrate-database $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	ALMIGHTY_RESOURCE_DATABASE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test -v $(TEST_PACKAGES) github.com/almighty/almighty-core
+	ALMIGHTY_RESOURCE_DATABASE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test -v github.com/almighty/almighty-core
 
 # Add one by one until it breaks on CI
 # github.com/almighty/almighty-core/account

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -134,10 +134,34 @@ test-integration: prebuild-check clean-coverage-integration migrate-database $(C
 .PHONY: test-integration-no-coverage
 ## Runs the integration tests WITHOUT producing coverage files for each package.
 ## Make sure you ran "make integration-test-env-prepare" before you run this target.
-test-integration-no-coverage: prebuild-check migrate-database
+test-integration-no-coverage: prebuild-check migrate-database $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	ALMIGHTY_RESOURCE_DATABASE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test -v $(TEST_PACKAGES)
+	ALMIGHTY_RESOURCE_DATABASE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test -v $(TEST_PACKAGES) github.com/almighty/almighty-core
+
+# Add one by one until it breaks on CI
+# github.com/almighty/almighty-core/account
+# github.com/almighty/almighty-core/comment
+# github.com/almighty/almighty-core/configuration
+# github.com/almighty/almighty-core/convert
+# github.com/almighty/almighty-core/criteria
+# github.com/almighty/almighty-core/errors
+# github.com/almighty/almighty-core/gormsupport
+# github.com/almighty/almighty-core/iteration
+# github.com/almighty/almighty-core/jsonapi
+# github.com/almighty/almighty-core/login
+# github.com/almighty/almighty-core/migration
+# github.com/almighty/almighty-core/models
+# github.com/almighty/almighty-core/query/simple
+# github.com/almighty/almighty-core/remoteworkitem
+# github.com/almighty/almighty-core/resource
+# github.com/almighty/almighty-core/search
+# github.com/almighty/almighty-core/space
+# github.com/almighty/almighty-core/token
+# github.com/almighty/almighty-core/tool/alm-cli
+# github.com/almighty/almighty-core/workitem
+# github.com/almighty/almighty-core/workitem/link
+#ALMIGHTY_RESOURCE_DATABASE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test -v $(TEST_PACKAGES)
 
 .PHONY: test-migration
 ## Runs the migration tests and should be executed before running the integration tests

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -146,11 +146,11 @@ test-integration-no-coverage: prebuild-check migrate-database $(SOURCES)
 		github.com/almighty/almighty-core/errors \
 		github.com/almighty/almighty-core/gormsupport \
 		github.com/almighty/almighty-core/iteration \
-		github.com/almighty/almighty-core/jsonapi
-# github.com/almighty/almighty-core/login
-# github.com/almighty/almighty-core/migration
-# github.com/almighty/almighty-core/models
-# github.com/almighty/almighty-core/query/simple
+		github.com/almighty/almighty-core/jsonapi \
+		github.com/almighty/almighty-core/login \
+		github.com/almighty/almighty-core/migration \
+		github.com/almighty/almighty-core/models \
+		github.com/almighty/almighty-core/query/simple
 # github.com/almighty/almighty-core/remoteworkitem
 # github.com/almighty/almighty-core/resource
 # github.com/almighty/almighty-core/search

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -1,56 +1,9 @@
 #!/bin/bash
 
-# Output command before executing
-set -x
+. cico_setup.sh
 
-# Exit on error
-set -e
+cico_setup;
 
-# Source environment variables of the jenkins slave
-# that might interest this worker.
-if [ -e "jenkins-env" ]; then
-  cat jenkins-env \
-    | grep -E "(JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
-    | sed 's/^/export /g' \
-    > ~/.jenkins-env
-  source ~/.jenkins-env
-fi
+run_tests_with_coverage;
 
-# We need to disable selinux for now, XXX
-/usr/sbin/setenforce 0
-
-# Get all the deps in
-yum -y install docker make git curl 
-sed -i '/OPTIONS=.*/c\OPTIONS="--selinux-enabled --log-driver=journald --insecure-registry registry.ci.centos.org:5000"' /etc/sysconfig/docker
-service docker start
-
-# Let's test
-make docker-start
-make docker-deps
-make docker-generate
-make docker-build
-make docker-test-unit
-make integration-test-env-prepare
-function cleanup {
-  EXIT_CODE=$?
-  make integration-test-env-tear-down
-  echo "CICO: Exiting with $EXIT_CODE"
-}
-trap cleanup EXIT
-make docker-test-migration
-make docker-test-integration
-echo 'CICO: app tests OK'
-
-# Output coverage
-make docker-coverage-all
-
-# Upload coverage to codecov.io
-cp tmp/coverage.mode* coverage.txt
-bash <(curl -s https://codecov.io/bash) -X search -f coverage.txt -t ad12dad7-ebdc-47bc-a016-8c05fa7356bc #-X fix
-
-# Let's deploy
-make docker-image-deploy
-docker tag almighty-core-deploy registry.ci.centos.org:5000/almighty/almighty-core:latest 
-docker push registry.ci.centos.org:5000/almighty/almighty-core:latest
-echo 'CICO: Image pushed, ready to update deployed app'
-
+deploy;

--- a/cico_run_coverage.sh
+++ b/cico_run_coverage.sh
@@ -1,52 +1,7 @@
 #!/bin/bash
 
-# Output command before executing
-set -x
+. cico_setup.sh
 
-# Exit on error
-set -e
+cico_setup;
 
-# Source environment variables of the jenkins slave
-# that might interest this worker.
-if [ -e "jenkins-env" ]; then
-  cat jenkins-env \
-    | grep -E "(JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
-    | sed 's/^/export /g' \
-    > ~/.jenkins-env
-  source ~/.jenkins-env
-fi
-
-# We need to disable selinux for now, XXX
-/usr/sbin/setenforce 0
-
-# Get all the deps in
-yum -y install \
-  docker \
-  make \
-  git \
-  curl
-service docker start
-
-# Let's test
-make docker-start
-make docker-deps
-make docker-generate
-make docker-build
-make docker-test-unit
-
-make integration-test-env-prepare
-
-function cleanup {
-  make integration-test-env-tear-down
-}
-trap cleanup EXIT
-
-make docker-test-migration
-make docker-test-integration
-
-# Output coverage
-make docker-coverage-all
-
-# Upload coverage to codecov.io
-cp tmp/coverage.mode* coverage.txt
-bash <(curl -s https://codecov.io/bash) -X search -f coverage.txt -t ad12dad7-ebdc-47bc-a016-8c05fa7356bc #-X fix
+run_tests_with_coverage;

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -32,7 +32,7 @@ make docker-start
 make docker-deps
 make docker-generate
 make docker-build
-make docker-test-unit
+make docker-test-unit-no-coverage
 
 make integration-test-env-prepare
 
@@ -42,11 +42,4 @@ function cleanup {
 trap cleanup EXIT
 
 make docker-test-migration
-make docker-test-integration
-
-# Output coverage
-make docker-coverage-all
-
-# Upload coverage to codecov.io
-cp tmp/coverage.mode* coverage.txt
-bash <(curl -s https://codecov.io/bash) -X search -f coverage.txt -t ad12dad7-ebdc-47bc-a016-8c05fa7356bc #-X fix
+make docker-test-integration-no-coverage

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -1,45 +1,7 @@
 #!/bin/bash
 
-# Output command before executing
-set -x
+. cico_setup.sh
 
-# Exit on error
-set -e
+cico_setup;
 
-# Source environment variables of the jenkins slave
-# that might interest this worker.
-if [ -e "jenkins-env" ]; then
-  cat jenkins-env \
-    | grep -E "(JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
-    | sed 's/^/export /g' \
-    > ~/.jenkins-env
-  source ~/.jenkins-env
-fi
-
-# We need to disable selinux for now, XXX
-/usr/sbin/setenforce 0
-
-# Get all the deps in
-yum -y install \
-  docker \
-  make \
-  git \
-  curl
-service docker start
-
-# Let's test
-make docker-start
-make docker-deps
-make docker-generate
-make docker-build
-make docker-test-unit-no-coverage
-
-make integration-test-env-prepare
-
-function cleanup {
-  make integration-test-env-tear-down
-}
-trap cleanup EXIT
-
-make docker-test-migration
-make docker-test-integration-no-coverage
+run_tests_without_coverage;

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Output command before executing
+set -x
+
+# Exit on error
+set -e
+
+# Source environment variables of the jenkins slave
+# that might interest this worker.
+function load_jenkins_vars() {
+  if [ -e "jenkins-env" ]; then
+    cat jenkins-env \
+      | grep -E "(JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
+      | sed 's/^/export /g' \
+      > ~/.jenkins-env
+    source ~/.jenkins-env
+  fi
+}
+
+function install_deps() {
+  # We need to disable selinux for now, XXX
+  /usr/sbin/setenforce 0
+
+  # Get all the deps in
+  yum -y install \
+    docker \
+    make \
+    git \
+    curl
+
+  sed -i '/OPTIONS=.*/c\OPTIONS="--selinux-enabled --log-driver=journald --insecure-registry registry.ci.centos.org:5000"' /etc/sysconfig/docker
+  service docker start
+  echo 'CICO: Dependencies installed'
+}
+
+function cleanup_env {
+  EXIT_CODE=$?
+  echo "CICO: Cleanup environment: Tear down test environment"
+  make integration-test-env-tear-down
+  echo "CICO: Exiting with $EXIT_CODE"
+}
+
+function prepare() {
+  # Let's test
+  make docker-start
+  make docker-deps
+  make docker-generate
+  make docker-build
+  echo 'CICO: Preparation complete'
+}
+
+function run_tests_without_coverage() {
+  make docker-test-unit-no-coverage
+  make integration-test-env-prepare
+  trap cleanup_env EXIT
+  make docker-test-migration
+  make docker-test-integration-no-coverage
+  echo "CICO: ran tests without coverage"
+}
+
+function run_tests_with_coverage() {
+  # Run the unit tests that generate coverage information
+  make docker-test-unit
+  
+  make integration-test-env-prepare
+  trap cleanup_env EXIT
+
+  # Run the integration tests that generate coverage information
+  make docker-test-migration
+  make docker-test-integration
+
+  # Output coverage
+  make docker-coverage-all
+
+  # Upload coverage to codecov.io
+  cp tmp/coverage.mode* coverage.txt
+  bash <(curl -s https://codecov.io/bash) -X search -f coverage.txt -t ad12dad7-ebdc-47bc-a016-8c05fa7356bc #-X fix
+
+  echo "CICO: ran tests and uploaded coverage"
+}
+
+function deploy() {
+  # Let's deploy
+  make docker-image-deploy
+  docker tag almighty-core-deploy registry.ci.centos.org:5000/almighty/almighty-core:latest 
+  docker push registry.ci.centos.org:5000/almighty/almighty-core:latest
+  echo 'CICO: Image pushed, ready to update deployed app'
+}
+
+function cico_setup() {
+  load_jenkins_vars;
+  install_deps;
+  prepare;
+}

--- a/remoteworkitem/github_test.go
+++ b/remoteworkitem/github_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/almighty/almighty-core/resource"
 	"github.com/dnaeon/go-vcr/recorder"
 	"github.com/google/go-github/github"
+	"github.com/stretchr/testify/require"
 )
 
 type fakeGithubIssueFetcher struct{}
@@ -67,9 +68,7 @@ func TestGithubFetchWithRateLimit(t *testing.T) {
 func TestGithubFetchWithRecording(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	r, err := recorder.New("../test/data/github_fetch_test")
-	if err != nil {
-		t.Error(err)
-	}
+	require.Nil(t, err)
 	defer r.Stop()
 
 	h := &http.Client{

--- a/remoteworkitem/remoteworkitem_test.go
+++ b/remoteworkitem/remoteworkitem_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/almighty/almighty-core/test"
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func provideRemoteData(dataURL string) ([]byte, error) {
@@ -38,13 +39,10 @@ func TestWorkItemMapping(t *testing.T) {
 
 	remoteWorkItemImpl := RemoteWorkItemImplRegistry[ProviderGithub]
 	gh, err := remoteWorkItemImpl(remoteTrackerItem)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
+
 	workItem, err := Map(gh, workItemMap)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 
 	assert.NotNil(t, workItem.Fields[workitem.SystemTitle], fmt.Sprintf("%s not mapped", workitem.SystemTitle))
 }
@@ -73,23 +71,17 @@ func TestGitHubIssueMapping(t *testing.T) {
 		content, err := test.LoadTestData(j.inputFile, func() ([]byte, error) {
 			return provideRemoteData(j.inputURL)
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.Nil(t, err)
 
 		workItemMap := WorkItemKeyMaps[ProviderGithub]
 		remoteTrackerkItem := TrackerItem{Item: string(content[:]), RemoteItemID: "xyz", TrackerID: uint64(0)}
 
 		remoteWorkItemImpl := RemoteWorkItemImplRegistry[ProviderGithub]
 		gh, err := remoteWorkItemImpl(remoteTrackerkItem)
+		require.Nil(t, err)
 
-		if err != nil {
-			t.Fatal(err)
-		}
 		workItem, err := Map(gh, workItemMap)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.Nil(t, err)
 
 		for _, localWorkItemKey := range workItemMap {
 			t.Log("Mapping ", localWorkItemKey)
@@ -123,22 +115,16 @@ func TestJiraIssueMapping(t *testing.T) {
 		content, err := test.LoadTestData(j.inputFile, func() ([]byte, error) {
 			return provideRemoteData(j.inputURL)
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.Nil(t, err)
 
 		workItemMap := WorkItemKeyMaps[ProviderJira]
 		remoteTrackerItem := TrackerItem{Item: string(content[:]), RemoteItemID: "xyz", TrackerID: uint64(0)}
 		remoteWorkItemImpl := RemoteWorkItemImplRegistry[ProviderJira]
 		ji, err := remoteWorkItemImpl(remoteTrackerItem)
+		require.Nil(t, err)
 
-		if err != nil {
-			t.Fatal(err)
-		}
 		workItem, err := Map(ji, workItemMap)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.Nil(t, err)
 
 		for _, localWorkItemKey := range workItemMap {
 			t.Log("Mapping ", localWorkItemKey)
@@ -176,15 +162,11 @@ func TestFlattenGithubResponseMap(t *testing.T) {
 		testString, err := test.LoadTestData(j.inputFile, func() ([]byte, error) {
 			return provideRemoteData(j.inputURL)
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.Nil(t, err)
+
 		var nestedMap map[string]interface{}
 		err = json.Unmarshal(testString, &nestedMap)
-
-		if err != nil {
-			t.Error("Incorrect dataset ", testString)
-		}
+		require.Nil(t, err, "Incorrect dataset %s", testString)
 
 		OneLevelMap := Flatten(nestedMap)
 
@@ -224,15 +206,11 @@ func TestFlattenGithubResponseMapWithoutAssignee(t *testing.T) {
 		testString, err := test.LoadTestData(j.inputFile, func() ([]byte, error) {
 			return provideRemoteData(j.inputURL)
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.Nil(t, err)
+
 		var nestedMap map[string]interface{}
 		err = json.Unmarshal(testString, &nestedMap)
-
-		if err != nil {
-			t.Error("Incorrect dataset ", testString)
-		}
+		require.Nil(t, err, "Incorrect dataset %s", testString)
 
 		OneLevelMap := Flatten(nestedMap)
 
@@ -272,15 +250,11 @@ func TestFlattenJiraResponseMap(t *testing.T) {
 		testString, err := test.LoadTestData(j.inputFile, func() ([]byte, error) {
 			return provideRemoteData(j.inputURL)
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.Nil(t, err)
+
 		var nestedMap map[string]interface{}
 		err = json.Unmarshal(testString, &nestedMap)
-
-		if err != nil {
-			t.Error("Incorrect dataset ", testString)
-		}
+		require.Nil(t, err, "Incorrect dataset %s", testString)
 
 		OneLevelMap := Flatten(nestedMap)
 		jiraKeyMap := WorkItemKeyMaps[ProviderJira]
@@ -316,15 +290,11 @@ func TestFlattenJiraResponseMapWithoutAssignee(t *testing.T) {
 		testString, err := test.LoadTestData(j.inputFile, func() ([]byte, error) {
 			return provideRemoteData(j.inputURL)
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.Nil(t, err)
+
 		var nestedMap map[string]interface{}
 		err = json.Unmarshal(testString, &nestedMap)
-
-		if err != nil {
-			t.Error("Incorrect dataset ", testString)
-		}
+		require.Nil(t, err, "Incorrect dataset %s", testString)
 
 		OneLevelMap := Flatten(nestedMap)
 		jiraKeyMap := WorkItemKeyMaps[ProviderJira]
@@ -345,8 +315,8 @@ func TestNewGitHubRemoteWorkItem(t *testing.T) {
 	jsonContent := `{"admins":[{"name":"aslak"}],"name":"shoubhik", "assignee":{"fixes": 2, "complete" : true,"foo":[ 1,2,3,4],"1":"sbose","2":"pranav","participants":{"4":"sbose56","5":"sbose78"}},"name":"shoubhik"}`
 	remoteTrackerItem := TrackerItem{Item: jsonContent, RemoteItemID: "xyz", TrackerID: uint64(0)}
 
-	githubRemoteWorkItem, ok := NewGitHubRemoteWorkItem(remoteTrackerItem)
-	assert.Nil(t, ok)
+	githubRemoteWorkItem, err := NewGitHubRemoteWorkItem(remoteTrackerItem)
+	require.Nil(t, err)
 	assert.Equal(t, githubRemoteWorkItem.Get("admins.0.name"), "aslak")
 	assert.Equal(t, githubRemoteWorkItem.Get("name"), "shoubhik")
 	assert.Equal(t, githubRemoteWorkItem.Get("assignee.complete"), true)
@@ -360,8 +330,8 @@ func TestNewJiraRemoteWorkItem(t *testing.T) {
 	jsonContent := `{"admins":[{"name":"aslak"}],"name":"shoubhik", "assignee":{"fixes": 2, "complete" : true,"foo":[ 1,2,3,4],"1":"sbose","2":"pranav","participants":{"4":"sbose56","5":"sbose78"}},"name":"shoubhik"}`
 	remoteTrackerItem := TrackerItem{Item: jsonContent, RemoteItemID: "xyz", TrackerID: uint64(0)}
 
-	jiraRemoteWorkItem, ok := NewJiraRemoteWorkItem(remoteTrackerItem)
-	assert.Nil(t, ok)
+	jiraRemoteWorkItem, err := NewJiraRemoteWorkItem(remoteTrackerItem)
+	require.Nil(t, err)
 	assert.Equal(t, jiraRemoteWorkItem.Get("admins.0.name"), "aslak")
 	assert.Equal(t, jiraRemoteWorkItem.Get("name"), "shoubhik")
 	assert.Equal(t, jiraRemoteWorkItem.Get("assignee.complete"), true)
@@ -372,9 +342,9 @@ func TestRemoteWorkItemImplRegistry(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 
 	_, ok := RemoteWorkItemImplRegistry[ProviderGithub]
-	assert.Equal(t, ok, true)
+	assert.True(t, ok)
 
 	_, ok = RemoteWorkItemImplRegistry[ProviderJira]
-	assert.Equal(t, ok, true)
+	assert.True(t, ok)
 
 }

--- a/remoteworkitem/scheduler_test.go
+++ b/remoteworkitem/scheduler_test.go
@@ -6,9 +6,13 @@ import (
 	"testing"
 
 	"github.com/almighty/almighty-core/configuration"
+	"github.com/almighty/almighty-core/migration"
+	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/resource"
+	"github.com/almighty/almighty-core/workitem"
 	"github.com/jinzhu/gorm"
 	_ "github.com/lib/pq"
+	"golang.org/x/net/context"
 )
 
 var db *gorm.DB
@@ -26,6 +30,13 @@ func TestMain(m *testing.M) {
 			panic("Failed to connect database: " + err.Error())
 		}
 		defer db.Close()
+
+		// Make sure the database is populated with the correct types (e.g. system.bug etc.)
+		if err := models.Transactional(db, func(tx *gorm.DB) error {
+			return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))
+		}); err != nil {
+			panic(err.Error())
+		}
 	}
 	os.Exit(m.Run())
 }

--- a/remoteworkitem/scheduler_test.go
+++ b/remoteworkitem/scheduler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/jinzhu/gorm"
 	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 
@@ -55,17 +56,13 @@ func TestLookupProvider(t *testing.T) {
 	resource.Require(t, resource.Database)
 	ts1 := trackerSchedule{TrackerType: ProviderGithub}
 	tp1 := lookupProvider(ts1)
-	if tp1 == nil {
-		t.Error("nil provider")
-	}
+	require.NotNil(t, tp1)
+
 	ts2 := trackerSchedule{TrackerType: ProviderJira}
 	tp2 := lookupProvider(ts2)
-	if tp2 == nil {
-		t.Error("nil provider")
-	}
+	require.NotNil(t, tp2)
+
 	ts3 := trackerSchedule{TrackerType: "unknown"}
 	tp3 := lookupProvider(ts3)
-	if tp3 != nil {
-		t.Error("non-nil provider")
-	}
+	require.Nil(t, tp3)
 }

--- a/remoteworkitem/trackeritem_repository.go
+++ b/remoteworkitem/trackeritem_repository.go
@@ -59,6 +59,9 @@ func convert(db *gorm.DB, tID int, item TrackerItemContent, provider string) (*a
 
 	// Querying the database
 	existingWorkItems, _, err := wir.List(context.Background(), sqlExpression, nil, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	if len(existingWorkItems) != 0 {
 		fmt.Println("Workitem exists, will be updated")

--- a/remoteworkitem/trackeritem_repository_test.go
+++ b/remoteworkitem/trackeritem_repository_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConvertNewWorkItem(t *testing.T) {
@@ -18,11 +19,13 @@ func TestConvertNewWorkItem(t *testing.T) {
 
 	// Setting up the dependent tracker query and tracker data in the Database
 	tr := Tracker{URL: "https://api.github.com/", Type: ProviderGithub}
-	db.Create(&tr)
+	db = db.Create(&tr)
+	require.Nil(t, db.Error)
 	defer db.Delete(&tr)
 
 	tq := TrackerQuery{Query: "some random query", Schedule: "0 0 0 * * *", TrackerID: tr.ID}
-	db.Create(&tq)
+	db = db.Create(&tq)
+	require.Nil(t, db.Error)
 	defer db.Delete(&tq)
 
 	t.Log("Created Tracker Query and Tracker")
@@ -55,11 +58,13 @@ func TestConvertExistingWorkItem(t *testing.T) {
 
 	// Setting up the dependent tracker query and tracker data in the Database
 	tr := Tracker{URL: "https://api.github.com/", Type: ProviderGithub}
-	db.Create(&tr)
+	db = db.Create(&tr)
+	require.Nil(t, db.Error)
 	defer db.Delete(&tr)
 
 	tq := TrackerQuery{Query: "some random query", Schedule: "0 0 0 * * *", TrackerID: tr.ID}
-	db.Create(&tq)
+	db = db.Create(&tq)
+	require.Nil(t, db.Error)
 	defer db.Delete(&tq)
 
 	t.Log("Created Tracker Query and Tracker")
@@ -113,7 +118,8 @@ func TestConvertGithubIssue(t *testing.T) {
 	t.Log("Scenario 3 : Mapping and persisting a Github issue")
 
 	tr := Tracker{URL: "https://api.github.com/", Type: ProviderGithub}
-	db.Create(&tr)
+	db = db.Create(&tr)
+	require.Nil(t, db.Error)
 	defer db.Delete(&tr)
 
 	tq := TrackerQuery{Query: "some random query", Schedule: "0 0 0 * * *", TrackerID: tr.ID}

--- a/search/search_repository_blackbox_test.go
+++ b/search/search_repository_blackbox_test.go
@@ -1,6 +1,7 @@
 package search_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/almighty/almighty-core/account"
@@ -27,10 +28,12 @@ func (s *searchRepositoryBlackboxTest) SetupSuite() {
 	s.DBTestSuite.SetupSuite()
 
 	// Make sure the database is populated with the correct types (e.g. system.bug etc.)
-	if err := models.Transactional(s.DB, func(tx *gorm.DB) error {
-		return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))
-	}); err != nil {
-		panic(err.Error())
+	if _, c := os.LookupEnv(resource.Database); c != false {
+		if err := models.Transactional(s.DB, func(tx *gorm.DB) error {
+			return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))
+		}); err != nil {
+			panic(err.Error())
+		}
 	}
 }
 

--- a/search/search_repository_blackbox_test.go
+++ b/search/search_repository_blackbox_test.go
@@ -6,9 +6,12 @@ import (
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/gormsupport"
+	"github.com/almighty/almighty-core/migration"
+	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/almighty/almighty-core/search"
 	"github.com/almighty/almighty-core/workitem"
+	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -17,6 +20,18 @@ import (
 
 type searchRepositoryBlackboxTest struct {
 	gormsupport.DBTestSuite
+}
+
+// SetupSuite overrides the DBTestSuite's function but calls it before doing anything else
+func (s *searchRepositoryBlackboxTest) SetupSuite() {
+	s.DBTestSuite.SetupSuite()
+
+	// Make sure the database is populated with the correct types (e.g. system.bug etc.)
+	if err := models.Transactional(s.DB, func(tx *gorm.DB) error {
+		return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))
+	}); err != nil {
+		panic(err.Error())
+	}
 }
 
 func TestRunSearchRepositoryWhiteboxTest(t *testing.T) {

--- a/search/search_repository_whitebox_test.go
+++ b/search/search_repository_whitebox_test.go
@@ -254,7 +254,7 @@ func (s *searchRepositoryWhiteboxTest) TestSearchByID() {
 
 		createdWorkItem, err := wir.Create(context.Background(), workitem.SystemBug, workItem.Fields, account.TestIdentity.ID.String())
 		if err != nil {
-			s.T().Fatal("Couldnt create test data")
+			s.T().Fatalf("Couldn't create test data: %+v", err)
 		}
 		defer wir.Delete(context.Background(), createdWorkItem.ID)
 
@@ -264,7 +264,7 @@ func (s *searchRepositoryWhiteboxTest) TestSearchByID() {
 		workItem.Fields[workitem.SystemTitle] = "Search test sbose " + createdWorkItem.ID
 		_, err = wir.Create(context.Background(), workitem.SystemBug, workItem.Fields, account.TestIdentity.ID.String())
 		if err != nil {
-			s.T().Fatal("Couldnt create test data")
+			s.T().Fatalf("Couldn't create test data: %+v", err)
 		}
 
 		sr := NewGormSearchRepository(tx)


### PR DESCRIPTION
I've introduced two new make targets:

1. `test-unit-no-coverage`
2. `test-integration-no-coverage`

These targets execute much faster than the test-unit and test-integration because they don't generate coverage information.

The cico_*.sh scripts have undergone some unification in order to avoid duplicating the code in three files, which potentially can cause a maintenance issue. Alongside to this step, I've introduced a new file called **cico_run_coverage.sh** with does what previously was done by the **cico_run_tests.sh**. The **cico_run_tests.sh** now runs the **test-XXX-no-coverage** Makefile targets.

I've had to ensure that common types like `system.bug` were available when running the tests for `github.com/almighty/almighty-core/remoteworkitem` and `github.com/almighty/almighty-core/search`. Due to a cyclic import problem I wasn't able to do that directly in `github.com/almighty/almighty-core/gormsupport/db_test_suite.go` but had to override the `SetupSuite` function instead.

Also, I've added some checks that I found were missing or simplified some tests by using `require` or `assert` instead of `if` control flows.

# TODO

Need to create another almighty PR build job to calculate the coverage separately from running the tests without coverage. The only required job for the PR to pass the CI is the one that runs the tests without coverage.

1. Run the tests in the PR (excute **cico_run_tests.sh**)
2. Produce and upload the coverage (excute **cico_run_coverage.sh**)

See https://github.com/almighty/almighty-jobs/pull/49
