### PR TITLE
API to update iterations (title, desc, startDate, endDate)

### DIFF
--- a/design/iterations.go
+++ b/design/iterations.go
@@ -25,7 +25,7 @@ var iterationAttributes = a.Type("IterationAttributes", func() {
 		a.Example("Sprint #24")
 	})
 	a.Attribute("description", d.String, "Description of the iteration ", func() {
-		a.Example("this is the description of iteration")
+		a.Example("Sprint #42 focusing on UI and build process improvements")
 	})
 	a.Attribute("startAt", d.DateTime, "When the iteration starts", func() {
 		a.Example("2016-11-29T23:18:14Z")
@@ -93,7 +93,7 @@ var _ = a.Resource("iteration", func() {
 		a.Routing(
 			a.PATCH("/:id"),
 		)
-		a.Description("update the iteration with the given id.")
+		a.Description("update the iteration for the given id.")
 		a.Params(func() {
 			a.Param("id", d.String, "id")
 		})

--- a/design/iterations.go
+++ b/design/iterations.go
@@ -30,7 +30,7 @@ var iterationAttributes = a.Type("IterationAttributes", func() {
 	a.Attribute("startAt", d.DateTime, "When the iteration starts", func() {
 		a.Example("2016-11-29T23:18:14Z")
 	})
-	a.Attribute("endAt", d.DateTime, "When the iteration starts", func() {
+	a.Attribute("endAt", d.DateTime, "When the iteration ends", func() {
 		a.Example("2016-11-29T23:18:14Z")
 	})
 })

--- a/design/iterations.go
+++ b/design/iterations.go
@@ -24,9 +24,6 @@ var iterationAttributes = a.Type("IterationAttributes", func() {
 	a.Attribute("name", d.String, "The iteration name", func() {
 		a.Example("Sprint #24")
 	})
-	a.Attribute("version", d.Integer, "Version for optimistic concurrency control (optional during creating)", func() {
-		a.Example(42)
-	})
 	a.Attribute("description", d.String, "Description of the iteration ", func() {
 		a.Example("this is the description of iteration")
 	})

--- a/design/iterations.go
+++ b/design/iterations.go
@@ -24,6 +24,9 @@ var iterationAttributes = a.Type("IterationAttributes", func() {
 	a.Attribute("name", d.String, "The iteration name", func() {
 		a.Example("Sprint #24")
 	})
+	a.Attribute("version", d.Integer, "Version for optimistic concurrency control (optional during creating)", func() {
+		a.Example(42)
+	})
 	a.Attribute("description", d.String, "Description of the iteration ", func() {
 		a.Example("this is the description of iteration")
 	})
@@ -86,6 +89,24 @@ var _ = a.Resource("iteration", func() {
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+	})
+	a.Action("update", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.PATCH("/:id"),
+		)
+		a.Description("update the iteration with the given id.")
+		a.Params(func() {
+			a.Param("id", d.String, "id")
+		})
+		a.Payload(iterationSingle)
+		a.Response(d.OK, func() {
+			a.Media(iterationSingle)
+		})
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 	})
 })

--- a/design/iterations.go
+++ b/design/iterations.go
@@ -24,6 +24,9 @@ var iterationAttributes = a.Type("IterationAttributes", func() {
 	a.Attribute("name", d.String, "The iteration name", func() {
 		a.Example("Sprint #24")
 	})
+	a.Attribute("description", d.String, "Description of the iteration ", func() {
+		a.Example("this is the description of iteration")
+	})
 	a.Attribute("startAt", d.DateTime, "When the iteration starts", func() {
 		a.Example("2016-11-29T23:18:14Z")
 	})

--- a/design/iterations.go
+++ b/design/iterations.go
@@ -57,11 +57,11 @@ var _ = a.Resource("iteration", func() {
 	a.BasePath("/iterations")
 	a.Action("show", func() {
 		a.Routing(
-			a.GET("/:id"),
+			a.GET("/:iterationID"),
 		)
 		a.Description("Retrieve iteration with given id.")
 		a.Params(func() {
-			a.Param("id", d.String, "id")
+			a.Param("iterationID", d.String, "Iteration Identifier")
 		})
 		a.Response(d.OK, func() {
 			a.Media(iterationSingle)
@@ -73,10 +73,10 @@ var _ = a.Resource("iteration", func() {
 	a.Action("create-child", func() {
 		a.Security("jwt")
 		a.Routing(
-			a.POST("/:id"),
+			a.POST("/:iterationID"),
 		)
 		a.Params(func() {
-			a.Param("id", d.String, "id")
+			a.Param("iterationID", d.String, "Iteration Identifier")
 		})
 		a.Description("create child iteration.")
 		a.Payload(iterationSingle)
@@ -91,11 +91,11 @@ var _ = a.Resource("iteration", func() {
 	a.Action("update", func() {
 		a.Security("jwt")
 		a.Routing(
-			a.PATCH("/:id"),
+			a.PATCH("/:iterationID"),
 		)
 		a.Description("update the iteration for the given id.")
 		a.Params(func() {
-			a.Param("id", d.String, "id")
+			a.Param("iterationID", d.String, "Iteration Identifier")
 		})
 		a.Payload(iterationSingle)
 		a.Response(d.OK, func() {

--- a/iteration.go
+++ b/iteration.go
@@ -90,6 +90,54 @@ func (c *IterationController) Show(ctx *app.ShowIterationContext) error {
 	})
 }
 
+// Update runs the update action.
+func (c *IterationController) Update(ctx *app.UpdateIterationContext) error {
+	_, err := login.ContextIdentity(ctx)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(err.Error()))
+	}
+	id, err := uuid.FromString(ctx.ID)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
+	}
+
+	err = validateUpdateIteration(ctx)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, err)
+	}
+
+	return application.Transactional(c.db, func(appl application.Application) error {
+		itr, err := appl.Iterations().Load(ctx.Context, id)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, err)
+		}
+		itr.Version = *ctx.Payload.Data.Attributes.Version
+		if ctx.Payload.Data.Attributes.Name != nil {
+			itr.Name = *ctx.Payload.Data.Attributes.Name
+		}
+		if ctx.Payload.Data.Attributes.StartAt != nil {
+			itr.StartAt = ctx.Payload.Data.Attributes.StartAt
+		}
+		if ctx.Payload.Data.Attributes.EndAt != nil {
+			itr.EndAt = ctx.Payload.Data.Attributes.EndAt
+		}
+		if ctx.Payload.Data.Attributes.Description != nil {
+			itr.Description = *ctx.Payload.Data.Attributes.Description
+		}
+
+		itr, err = appl.Iterations().Save(ctx.Context, *itr)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, err)
+		}
+
+		response := app.IterationSingle{
+			Data: ConvertIteration(ctx.RequestData, itr),
+		}
+
+		return ctx.OK(&response)
+	})
+}
+
 // IterationConvertFunc is a open ended function to add additional links/data/relations to a Iteration during
 // convertion from internal to API
 type IterationConvertFunc func(*goa.RequestData, *iteration.Iteration, *app.Iteration)
@@ -104,23 +152,24 @@ func ConvertIterations(request *goa.RequestData, Iterations []*iteration.Iterati
 }
 
 // ConvertIteration converts between internal and external REST representation
-func ConvertIteration(request *goa.RequestData, iteration *iteration.Iteration, additional ...IterationConvertFunc) *app.Iteration {
-	iterationType := "iterations"
+func ConvertIteration(request *goa.RequestData, itr *iteration.Iteration, additional ...IterationConvertFunc) *app.Iteration {
+	iterationType := iteration.APIStringTypeIteration
 	spaceType := "spaces"
 
-	spaceID := iteration.SpaceID.String()
+	spaceID := itr.SpaceID.String()
 
-	selfURL := AbsoluteURL(request, app.IterationHref(iteration.ID))
+	selfURL := AbsoluteURL(request, app.IterationHref(itr.ID))
 	spaceSelfURL := AbsoluteURL(request, "/api/spaces/"+spaceID)
 
 	i := &app.Iteration{
 		Type: iterationType,
-		ID:   &iteration.ID,
+		ID:   &itr.ID,
 		Attributes: &app.IterationAttributes{
-			Name:        &iteration.Name,
-			StartAt:     iteration.StartAt,
-			EndAt:       iteration.EndAt,
-			Description: &iteration.Description,
+			Name:        &itr.Name,
+			StartAt:     itr.StartAt,
+			EndAt:       itr.EndAt,
+			Description: &itr.Description,
+			Version:     &itr.Version,
 		},
 		Relationships: &app.IterationRelations{
 			Space: &app.RelationGeneric{
@@ -137,9 +186,9 @@ func ConvertIteration(request *goa.RequestData, iteration *iteration.Iteration, 
 			Self: &selfURL,
 		},
 	}
-	if iteration.ParentID != uuid.Nil {
-		parentSelfURL := AbsoluteURL(request, app.IterationHref(iteration.ParentID))
-		parentID := iteration.ParentID.String()
+	if itr.ParentID != uuid.Nil {
+		parentSelfURL := AbsoluteURL(request, app.IterationHref(itr.ParentID))
+		parentID := itr.ParentID.String()
 		i.Relationships.Parent = &app.RelationGeneric{
 			Data: &app.GenericData{
 				Type: &iterationType,
@@ -151,7 +200,7 @@ func ConvertIteration(request *goa.RequestData, iteration *iteration.Iteration, 
 		}
 	}
 	for _, add := range additional {
-		add(request, iteration, i)
+		add(request, itr, i)
 	}
 	return i
 }
@@ -172,4 +221,17 @@ func createIterationLinks(request *goa.RequestData, id interface{}) *app.Generic
 	return &app.GenericLinks{
 		Self: &selfURL,
 	}
+}
+
+func validateUpdateIteration(ctx *app.UpdateIterationContext) error {
+	if ctx.Payload.Data == nil {
+		return errors.NewBadParameterError("data", nil).Expected("not nil")
+	}
+	if ctx.Payload.Data.Attributes == nil {
+		return errors.NewBadParameterError("data.attributes", nil).Expected("not nil")
+	}
+	if ctx.Payload.Data.Attributes.Version == nil {
+		return errors.NewBadParameterError("data.attributes.version", nil).Expected("not nil")
+	}
+	return nil
 }

--- a/iteration.go
+++ b/iteration.go
@@ -30,7 +30,7 @@ func (c *IterationController) CreateChild(ctx *app.CreateChildIterationContext) 
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(err.Error()))
 	}
-	parentID, err := uuid.FromString(ctx.ID)
+	parentID, err := uuid.FromString(ctx.IterationID)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
 	}
@@ -70,7 +70,7 @@ func (c *IterationController) CreateChild(ctx *app.CreateChildIterationContext) 
 
 // Show runs the show action.
 func (c *IterationController) Show(ctx *app.ShowIterationContext) error {
-	id, err := uuid.FromString(ctx.ID)
+	id, err := uuid.FromString(ctx.IterationID)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
 	}
@@ -96,7 +96,7 @@ func (c *IterationController) Update(ctx *app.UpdateIterationContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(err.Error()))
 	}
-	id, err := uuid.FromString(ctx.ID)
+	id, err := uuid.FromString(ctx.IterationID)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
 	}

--- a/iteration.go
+++ b/iteration.go
@@ -117,9 +117,10 @@ func ConvertIteration(request *goa.RequestData, iteration *iteration.Iteration, 
 		Type: iterationType,
 		ID:   &iteration.ID,
 		Attributes: &app.IterationAttributes{
-			Name:    &iteration.Name,
-			StartAt: iteration.StartAt,
-			EndAt:   iteration.EndAt,
+			Name:        &iteration.Name,
+			StartAt:     iteration.StartAt,
+			EndAt:       iteration.EndAt,
+			Description: &iteration.Description,
 		},
 		Relationships: &app.IterationRelations{
 			Space: &app.RelationGeneric{

--- a/iteration/iteration.go
+++ b/iteration/iteration.go
@@ -1,6 +1,7 @@
 package iteration
 
 import (
+	"log"
 	"time"
 
 	"github.com/almighty/almighty-core/errors"
@@ -9,6 +10,11 @@ import (
 	"github.com/jinzhu/gorm"
 	uuid "github.com/satori/go.uuid"
 	"golang.org/x/net/context"
+)
+
+// Defines "type" string to be used while validating jsonapi spec based payload
+const (
+	APIStringTypeIteration = "iterations"
 )
 
 // Iteration describes a single iteration
@@ -21,6 +27,7 @@ type Iteration struct {
 	EndAt       *time.Time
 	Name        string
 	Description string
+	Version     int
 }
 
 // TableName overrides the table name settings in Gorm to force a specific table name
@@ -34,6 +41,7 @@ type Repository interface {
 	Create(ctx context.Context, u *Iteration) error
 	List(ctx context.Context, spaceID uuid.UUID) ([]*Iteration, error)
 	Load(ctx context.Context, id uuid.UUID) (*Iteration, error)
+	Save(ctx context.Context, i Iteration) (*Iteration, error)
 }
 
 // NewIterationRepository creates a new storage type.
@@ -86,4 +94,29 @@ func (m *GormIterationRepository) Load(ctx context.Context, id uuid.UUID) (*Iter
 		return nil, errors.NewInternalError(tx.Error.Error())
 	}
 	return &obj, nil
+}
+
+// Save updates the given iteration in the db. Version must be the same as the one in the stored version
+// returns NotFoundError, VersionConflictError or InternalError
+func (m *GormIterationRepository) Save(ctx context.Context, i Iteration) (*Iteration, error) {
+	itr := Iteration{}
+	tx := m.db.Where("id=?", i.ID).First(&itr)
+	oldVersion := i.Version
+	i.Version++
+	if tx.RecordNotFound() {
+		// treating this as a not found error: the fact that we're using number internal is implementation detail
+		return nil, errors.NewNotFoundError("iteration", i.ID.String())
+	}
+	if err := tx.Error; err != nil {
+		return nil, errors.NewInternalError(err.Error())
+	}
+	tx = tx.Where("Version = ?", oldVersion).Save(&i)
+	if err := tx.Error; err != nil {
+		return nil, errors.NewInternalError(err.Error())
+	}
+	if tx.RowsAffected == 0 {
+		return nil, errors.NewVersionConflictError("version conflict")
+	}
+	log.Printf("updated iteration to %v\n", i)
+	return &i, nil
 }

--- a/iteration/iteration.go
+++ b/iteration/iteration.go
@@ -1,7 +1,6 @@
 package iteration
 
 import (
-	"log"
 	"time"
 
 	"github.com/almighty/almighty-core/errors"
@@ -111,6 +110,5 @@ func (m *GormIterationRepository) Save(ctx context.Context, i Iteration) (*Itera
 	if err := tx.Error; err != nil {
 		return nil, errors.NewInternalError(err.Error())
 	}
-	log.Printf("updated iteration to %v\n", i)
 	return &i, nil
 }

--- a/iteration/iteration.go
+++ b/iteration/iteration.go
@@ -14,12 +14,13 @@ import (
 // Iteration describes a single iteration
 type Iteration struct {
 	gormsupport.Lifecycle
-	ID       uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"` // This is the ID PK field
-	SpaceID  uuid.UUID `sql:"type:uuid"`
-	ParentID uuid.UUID `sql:"type:uuid"` // TODO: This should be * to support nil ?
-	StartAt  *time.Time
-	EndAt    *time.Time
-	Name     string
+	ID          uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"` // This is the ID PK field
+	SpaceID     uuid.UUID `sql:"type:uuid"`
+	ParentID    uuid.UUID `sql:"type:uuid"` // TODO: This should be * to support nil ?
+	StartAt     *time.Time
+	EndAt       *time.Time
+	Name        string
+	Description string
 }
 
 // TableName overrides the table name settings in Gorm to force a specific table name

--- a/iteration/iteration_test.go
+++ b/iteration/iteration_test.go
@@ -155,21 +155,20 @@ func (test *TestIterationRepository) TestUpdateIteration() {
 	updatedName := "Sprint 25"
 	i2 := iteration.Iteration{
 		ID:          i.ID,
-		Version:     i.Version,
-		Description: desc,
+		Description: &desc,
 		Name:        updatedName,
 	}
+
 	// update iteration with new values of Name and Desc
 	updatedIteration, err := repo.Save(context.Background(), i2)
 	assert.Nil(t, err)
 	assert.Equal(t, updatedIteration.Name, updatedName)
-	assert.Equal(t, updatedIteration.Description, desc)
+	assert.Equal(t, *updatedIteration.Description, desc)
 
 	changedStart := start.Add(time.Hour)
 	changedEnd := start.Add(time.Hour * 2)
 	i3 := iteration.Iteration{
 		ID:      i.ID,
-		Version: updatedIteration.Version,
 		StartAt: &changedStart,
 		EndAt:   &changedEnd,
 	}

--- a/iteration/iteration_test.go
+++ b/iteration/iteration_test.go
@@ -152,28 +152,21 @@ func (test *TestIterationRepository) TestUpdateIteration() {
 	}
 
 	desc := "Updated item"
+	i.Description = &desc
 	updatedName := "Sprint 25"
-	i2 := iteration.Iteration{
-		ID:          i.ID,
-		Description: &desc,
-		Name:        updatedName,
-	}
-
+	i.Name = updatedName
 	// update iteration with new values of Name and Desc
-	updatedIteration, err := repo.Save(context.Background(), i2)
+	updatedIteration, err := repo.Save(context.Background(), i)
 	assert.Nil(t, err)
 	assert.Equal(t, updatedIteration.Name, updatedName)
 	assert.Equal(t, *updatedIteration.Description, desc)
 
 	changedStart := start.Add(time.Hour)
+	i.StartAt = &changedStart
 	changedEnd := start.Add(time.Hour * 2)
-	i3 := iteration.Iteration{
-		ID:      i.ID,
-		StartAt: &changedStart,
-		EndAt:   &changedEnd,
-	}
+	i.EndAt = &changedEnd
 	// update iteration with new values of StartAt, EndAt
-	updatedIteration, err = repo.Save(context.Background(), i3)
+	updatedIteration, err = repo.Save(context.Background(), i)
 	assert.Nil(t, err)
 	assert.Equal(t, changedStart, *updatedIteration.StartAt)
 	assert.Equal(t, changedEnd, *updatedIteration.EndAt)

--- a/iteration/iteration_test.go
+++ b/iteration/iteration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/almighty/almighty-core/resource"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -147,9 +148,7 @@ func (test *TestIterationRepository) TestUpdateIteration() {
 	}
 	// creates an iteration
 	repo.Create(context.Background(), &i)
-	if i.ID == uuid.Nil {
-		t.Errorf("Comment was not created, ID nil")
-	}
+	require.NotEqual(t, uuid.Nil, i.ID, "Iteration was not created, ID nil")
 
 	desc := "Updated item"
 	i.Description = &desc
@@ -157,7 +156,7 @@ func (test *TestIterationRepository) TestUpdateIteration() {
 	i.Name = updatedName
 	// update iteration with new values of Name and Desc
 	updatedIteration, err := repo.Save(context.Background(), i)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, updatedIteration.Name, updatedName)
 	assert.Equal(t, *updatedIteration.Description, desc)
 
@@ -167,7 +166,7 @@ func (test *TestIterationRepository) TestUpdateIteration() {
 	i.EndAt = &changedEnd
 	// update iteration with new values of StartAt, EndAt
 	updatedIteration, err = repo.Save(context.Background(), i)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, changedStart, *updatedIteration.StartAt)
 	assert.Equal(t, changedEnd, *updatedIteration.EndAt)
 }

--- a/iteration_test.go
+++ b/iteration_test.go
@@ -159,8 +159,7 @@ func (rest *TestIterationREST) TestFailUpdateIterationNotFound() {
 		},
 	}
 	svc, ctrl := rest.SecuredController()
-	_, err := test.UpdateIterationNotFound(t, svc.Context, svc, ctrl, itr.ID.String(), &payload)
-	assert.NotEmpty(t, err.Errors)
+	test.UpdateIterationNotFound(t, svc.Context, svc, ctrl, itr.ID.String(), &payload)
 }
 
 func (rest *TestIterationREST) TestFailUpdateIterationUnauthorized() {

--- a/iteration_test.go
+++ b/iteration_test.go
@@ -134,7 +134,6 @@ func (rest *TestIterationREST) TestSuccessUpdateIteration() {
 		Data: &app.Iteration{
 			Attributes: &app.IterationAttributes{
 				Name:        &newName,
-				Version:     &itr.Version,
 				Description: &newDesc,
 			},
 			ID:   &itr.ID,
@@ -144,38 +143,7 @@ func (rest *TestIterationREST) TestSuccessUpdateIteration() {
 	svc, ctrl := rest.SecuredController()
 	_, updated := test.UpdateIterationOK(t, svc.Context, svc, ctrl, itr.ID.String(), &payload)
 	assert.Equal(t, newName, *updated.Data.Attributes.Name)
-	assert.Equal(t, itr.Version+1, *updated.Data.Attributes.Version)
 	assert.Equal(t, newDesc, *updated.Data.Attributes.Description)
-}
-
-func (rest *TestIterationREST) TestFailUpdateIterationBadRequest() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-	itr := createSpaceAndIteration(t, rest.db)
-	payload := app.UpdateIterationPayload{
-		Data: &app.Iteration{
-			Attributes: &app.IterationAttributes{},
-			ID:         &itr.ID,
-			Type:       iteration.APIStringTypeIteration,
-		},
-	}
-	svc, ctrl := rest.SecuredController()
-	// no attributes set in payload => version not specified
-	test.UpdateIterationBadRequest(t, svc.Context, svc, ctrl, itr.ID.String(), &payload)
-
-	invalidVersion := itr.Version + 1
-	payload = app.UpdateIterationPayload{
-		Data: &app.Iteration{
-			Attributes: &app.IterationAttributes{
-				Version: &invalidVersion,
-			},
-			ID:   &itr.ID,
-			Type: iteration.APIStringTypeIteration,
-		},
-	}
-	// invalid version set in payload
-	test.UpdateIterationBadRequest(t, svc.Context, svc, ctrl, itr.ID.String(), &payload)
-
 }
 
 func (rest *TestIterationREST) TestFailUpdateIterationNotFound() {
@@ -185,11 +153,9 @@ func (rest *TestIterationREST) TestFailUpdateIterationNotFound() {
 	itr.ID = uuid.NewV4()
 	payload := app.UpdateIterationPayload{
 		Data: &app.Iteration{
-			Attributes: &app.IterationAttributes{
-				Version: &itr.Version,
-			},
-			ID:   &itr.ID,
-			Type: iteration.APIStringTypeIteration,
+			Attributes: &app.IterationAttributes{},
+			ID:         &itr.ID,
+			Type:       iteration.APIStringTypeIteration,
 		},
 	}
 	svc, ctrl := rest.SecuredController()
@@ -203,11 +169,9 @@ func (rest *TestIterationREST) TestFailUpdateIterationUnauthorized() {
 	itr := createSpaceAndIteration(t, rest.db)
 	payload := app.UpdateIterationPayload{
 		Data: &app.Iteration{
-			Attributes: &app.IterationAttributes{
-				Version: &itr.Version,
-			},
-			ID:   &itr.ID,
-			Type: iteration.APIStringTypeIteration,
+			Attributes: &app.IterationAttributes{},
+			ID:         &itr.ID,
+			Type:       iteration.APIStringTypeIteration,
 		},
 	}
 	svc, ctrl := rest.UnSecuredController()

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -127,6 +127,9 @@ func getMigrations() migrations {
 	// Version 16
 	m = append(m, steps{executeSQLFile("016-drop-wi-links-trigger.sql")})
 
+	// Version 17
+	m = append(m, steps{executeSQLFile("017-alter-iterations.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/017-alter-iterations.sql
+++ b/migration/sql-files/017-alter-iterations.sql
@@ -1,3 +1,1 @@
--- Add two columns to `iteration` relation
 ALTER TABLE iterations ADD description TEXT;
-ALTER TABLE iterations ADD version INTEGER DEFAULT 0 NOT NULL;

--- a/migration/sql-files/017-alter-iterations.sql
+++ b/migration/sql-files/017-alter-iterations.sql
@@ -1,0 +1,1 @@
+ALTER table iterations ADD description text;

--- a/migration/sql-files/017-alter-iterations.sql
+++ b/migration/sql-files/017-alter-iterations.sql
@@ -1,1 +1,3 @@
-ALTER table iterations ADD description text;
+-- Add two columns to `iteration` relation
+ALTER TABLE iterations ADD description TEXT;
+ALTER TABLE iterations ADD version INTEGER DEFAULT 0 NOT NULL;

--- a/space-iterations.go
+++ b/space-iterations.go
@@ -54,7 +54,9 @@ func (c *SpaceIterationsController) Create(ctx *app.CreateSpaceIterationsContext
 			StartAt: reqIter.Attributes.StartAt,
 			EndAt:   reqIter.Attributes.EndAt,
 		}
-
+		if reqIter.Attributes.Description != nil {
+			newItr.Description = *reqIter.Attributes.Description
+		}
 		err = appl.Iterations().Create(ctx, &newItr)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)

--- a/space-iterations.go
+++ b/space-iterations.go
@@ -55,7 +55,7 @@ func (c *SpaceIterationsController) Create(ctx *app.CreateSpaceIterationsContext
 			EndAt:   reqIter.Attributes.EndAt,
 		}
 		if reqIter.Attributes.Description != nil {
-			newItr.Description = *reqIter.Attributes.Description
+			newItr.Description = reqIter.Attributes.Description
 		}
 		err = appl.Iterations().Create(ctx, &newItr)
 		if err != nil {

--- a/space-iterations_test.go
+++ b/space-iterations_test.go
@@ -175,7 +175,7 @@ func createSpaceIteration(name string, desc *string) *app.CreateSpaceIterationsP
 
 	return &app.CreateSpaceIterationsPayload{
 		Data: &app.Iteration{
-			Type: "iterations",
+			Type: iteration.APIStringTypeIteration,
 			Attributes: &app.IterationAttributes{
 				Name:        &name,
 				StartAt:     &start,

--- a/space-iterations_test.go
+++ b/space-iterations_test.go
@@ -99,11 +99,12 @@ func (rest *TestSpaceIterationREST) TestSuccessCreateIterationWithOptionalValues
 	assert.Equal(t, *c.Data.Attributes.Name, iterationName)
 	assert.Equal(t, *c.Data.Attributes.Description, iterationDesc)
 
+	// create another Iteration with nil description
 	iterationName2 := "Sprint #23"
 	ci = createSpaceIteration(iterationName2, nil)
 	_, c = test.CreateSpaceIterationsCreated(t, svc.Context, svc, ctrl, p.ID.String(), ci)
 	assert.Equal(t, *c.Data.Attributes.Name, iterationName2)
-	assert.Empty(t, *c.Data.Attributes.Description)
+	assert.Nil(t, c.Data.Attributes.Description)
 }
 
 func (rest *TestSpaceIterationREST) TestListIterationsBySpace() {

--- a/workitem_blackbox_test.go
+++ b/workitem_blackbox_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/gormsupport"
+	"github.com/almighty/almighty-core/iteration"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/migration"
 	"github.com/almighty/almighty-core/models"
@@ -1040,9 +1041,9 @@ func (s *WorkItem2Suite) TestWI2FailMissingDelete() {
 func (s *WorkItem2Suite) TestWI2CreateWithIteration() {
 	t := s.T()
 
-	iteration := createSpaceAndIteration(t, gormapplication.NewGormDB(s.db))
-	iterationID := iteration.ID.String()
-	itType := "iterations"
+	iterationInstance := createSpaceAndIteration(t, gormapplication.NewGormDB(s.db))
+	iterationID := iterationInstance.ID.String()
+	itType := iteration.APIStringTypeIteration
 
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
@@ -1069,9 +1070,9 @@ func (s *WorkItem2Suite) TestWI2CreateWithIteration() {
 func (s *WorkItem2Suite) TestWI2UpdateWithIteration() {
 	t := s.T()
 
-	iteration := createSpaceAndIteration(t, gormapplication.NewGormDB(s.db))
-	iterationID := iteration.ID.String()
-	itType := "iterations"
+	iterationInstance := createSpaceAndIteration(t, gormapplication.NewGormDB(s.db))
+	iterationID := iterationInstance.ID.String()
+	itType := iteration.APIStringTypeIteration
 
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
@@ -1110,9 +1111,9 @@ func (s *WorkItem2Suite) TestWI2UpdateRemoveIteration() {
 
 	t.Skip("iteration.data can't be sent as nil from client libs since it's optionall and is removed during json encoding")
 
-	iteration := createSpaceAndIteration(t, gormapplication.NewGormDB(s.db))
-	iterationID := iteration.ID.String()
-	itType := "iterations"
+	iterationInstance := createSpaceAndIteration(t, gormapplication.NewGormDB(s.db))
+	iterationID := iterationInstance.ID.String()
+	itType := iteration.APIStringTypeIteration
 
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
@@ -1152,7 +1153,7 @@ func (s *WorkItem2Suite) TestWI2UpdateRemoveIteration() {
 func (s *WorkItem2Suite) TestWI2CreateUnknownIteration() {
 	t := s.T()
 
-	itType := "iterations"
+	itType := iteration.APIStringTypeIteration
 	iterationID := uuid.NewV4().String()
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"


### PR DESCRIPTION
Fixes : https://github.com/fabric8io/fabric8-planner/issues/701

Added description field to iteration table optional input
added PATCH api to update existing iteration provided with iteration-ID
added tests to cross check API against NotFound, Unauthorized and OK200 cases
Added whitebox tests for update iteration repository method
In many cases `iteration` package was shadowed by the `iteration` parameter in function. It made sense to keep package name as iteration and change the parameter name
Created string constant for jsonapi based `type` value