### PR TITLE
List WI - filter by Iterations

### DIFF
--- a/design/workitems.go
+++ b/design/workitems.go
@@ -96,7 +96,7 @@ var _ = a.Resource("workitem", func() {
 			a.Param("page[offset]", d.String, "Paging start position")
 			a.Param("page[limit]", d.Integer, "Paging size")
 			a.Param("filter[assignee]", d.String, "Work Items assigned to the given user")
-			a.Param("filter[iteration]", d.String, "IterationID to filter Work items")
+			a.Param("filter[iteration]", d.String, "IterationID to filter work items")
 		})
 		a.Response(d.OK, func() {
 			a.Media(workItemList)

--- a/design/workitems.go
+++ b/design/workitems.go
@@ -96,6 +96,7 @@ var _ = a.Resource("workitem", func() {
 			a.Param("page[offset]", d.String, "Paging start position")
 			a.Param("page[limit]", d.Integer, "Paging size")
 			a.Param("filter[assignee]", d.String, "Work Items assigned to the given user")
+			a.Param("filter[iteration]", d.String, "IterationID to filter Work items")
 		})
 		a.Response(d.OK, func() {
 			a.Media(workItemList)

--- a/iteration.go
+++ b/iteration.go
@@ -163,6 +163,7 @@ func ConvertIteration(request *goa.RequestData, itr *iteration.Iteration, additi
 
 	selfURL := rest.AbsoluteURL(request, app.IterationHref(itr.ID))
 	spaceSelfURL := rest.AbsoluteURL(request, "/api/spaces/"+spaceID)
+	workitemsRelatedURL := rest.AbsoluteURL(request, "/api/workitems?filter[iteration]="+itr.ID.String())
 
 	i := &app.Iteration{
 		Type: iterationType,
@@ -182,6 +183,11 @@ func ConvertIteration(request *goa.RequestData, itr *iteration.Iteration, additi
 				},
 				Links: &app.GenericLinks{
 					Self: &spaceSelfURL,
+				},
+			},
+			Workitems: &app.RelationGeneric{
+				Links: &app.GenericLinks{
+					Related: &workitemsRelatedURL,
 				},
 			},
 		},

--- a/space-iterations_test.go
+++ b/space-iterations_test.go
@@ -7,6 +7,8 @@ import (
 
 	"golang.org/x/net/context"
 
+	"fmt"
+
 	. "github.com/almighty/almighty-core"
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
@@ -142,6 +144,10 @@ func (rest *TestSpaceIterationREST) TestListIterationsBySpace() {
 	svc, ctrl := rest.UnSecuredController()
 	_, cs := test.ListSpaceIterationsOK(t, svc.Context, svc, ctrl, spaceID.String())
 	assert.Len(t, cs.Data, 3)
+	for _, iterationItem := range cs.Data {
+		subString := fmt.Sprintf("?filter[iteration]=%s", iterationItem.ID.String())
+		assert.Contains(t, *iterationItem.Relationships.Workitems.Links.Related, subString)
+	}
 }
 
 func (rest *TestSpaceIterationREST) TestCreateIterationMissingSpace() {

--- a/workitem.go
+++ b/workitem.go
@@ -58,6 +58,11 @@ func (c *WorkitemController) List(ctx *app.ListWorkitemContext) error {
 		exp = criteria.And(exp, criteria.Equals(criteria.Field("system.assignees"), criteria.Literal([]string{*assignee})))
 		additionalQuery = append(additionalQuery, "filter[assignee]="+*assignee)
 	}
+	if ctx.FilterIteration != nil {
+		iteration := ctx.FilterIteration
+		exp = criteria.And(exp, criteria.Equals(criteria.Field(workitem.SystemIteration), criteria.Literal(string(*iteration))))
+		additionalQuery = append(additionalQuery, "filter[iteration]="+*iteration)
+	}
 	offset, limit := computePagingLimts(ctx.PageOffset, ctx.PageLimit)
 
 	return application.Transactional(c.db, func(tx application.Application) error {

--- a/workitem_blackbox_test.go
+++ b/workitem_blackbox_test.go
@@ -1040,8 +1040,8 @@ func (s *WorkItem2Suite) TestWI2ListByIterationFilter() {
 	c.Data.Relationships = &app.WorkItemRelationships{
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
-				Type: "workitemtypes",
-				ID:   "bug",
+				Type: APIStringTypeWorkItemType,
+				ID:   workitem.SystemBug,
 			},
 		},
 		Iteration: &app.RelationGeneric{
@@ -1059,7 +1059,7 @@ func (s *WorkItem2Suite) TestWI2ListByIterationFilter() {
 	assert.Equal(s.T(), iterationID, *wi.Data.Relationships.Iteration.Data.ID)
 
 	_, list := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, nil, nil, &iterationID, nil, nil)
-	assert.Len(s.T(), list.Data, 1)
+	require.Len(s.T(), list.Data, 1)
 	assert.Equal(s.T(), iterationID, *list.Data[0].Relationships.Iteration.Data.ID)
 	assert.True(s.T(), strings.Contains(*list.Links.First, "filter[iteration]"))
 }

--- a/workitem_blackbox_test.go
+++ b/workitem_blackbox_test.go
@@ -142,7 +142,7 @@ func TestListByFields(t *testing.T) {
 	filter := "{\"system.title\":\"run integration test\"}"
 	offset := "0"
 	limit := 1
-	_, result := test.ListWorkitemOK(t, nil, nil, controller, &filter, nil, &limit, &offset)
+	_, result := test.ListWorkitemOK(t, nil, nil, controller, &filter, nil, nil, &limit, &offset)
 
 	if result == nil {
 		t.Errorf("nil result")
@@ -153,7 +153,7 @@ func TestListByFields(t *testing.T) {
 	}
 
 	filter = fmt.Sprintf("{\"system.creator\":\"%s\"}", account.TestIdentity.ID.String())
-	_, result = test.ListWorkitemOK(t, nil, nil, controller, &filter, nil, &limit, &offset)
+	_, result = test.ListWorkitemOK(t, nil, nil, controller, &filter, nil, nil, &limit, &offset)
 
 	if result == nil {
 		t.Errorf("nil result")
@@ -309,7 +309,7 @@ func createPagingTest(t *testing.T, controller *WorkitemController, repo *testsu
 		count := computeCount(totalCount, int(start), int(limit))
 		repo.ListReturns(makeWorkItems(count), uint64(totalCount), nil)
 		offset := strconv.Itoa(start)
-		_, response := test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, &limit, &offset)
+		_, response := test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, nil, &limit, &offset)
 		assertLink(t, "first", first, response.Links.First)
 		assertLink(t, "last", last, response.Links.Last)
 		assertLink(t, "prev", prev, response.Links.Prev)
@@ -388,28 +388,28 @@ func TestPagingErrors(t *testing.T) {
 
 	var offset string = "-1"
 	var limit int = 2
-	_, result := test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, &limit, &offset)
+	_, result := test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, nil, &limit, &offset)
 	if !strings.Contains(*result.Links.First, "page[offset]=0") {
 		assert.Fail(t, "Offset is negative", "Expected offset to be %d, but was %s", 0, *result.Links.First)
 	}
 
 	offset = "0"
 	limit = 0
-	_, result = test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, &limit, &offset)
+	_, result = test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, nil, &limit, &offset)
 	if !strings.Contains(*result.Links.First, "page[limit]=20") {
 		assert.Fail(t, "Limit is 0", "Expected limit to be default size %d, but was %s", 20, *result.Links.First)
 	}
 
 	offset = "0"
 	limit = -1
-	_, result = test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, &limit, &offset)
+	_, result = test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, nil, &limit, &offset)
 	if !strings.Contains(*result.Links.First, "page[limit]=20") {
 		assert.Fail(t, "Limit is negative", "Expected limit to be default size %d, but was %s", 20, *result.Links.First)
 	}
 
 	offset = "-3"
 	limit = -1
-	_, result = test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, &limit, &offset)
+	_, result = test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, nil, &limit, &offset)
 	if !strings.Contains(*result.Links.First, "page[limit]=20") {
 		assert.Fail(t, "Limit is negative", "Expected limit to be default size %d, but was %s", 20, *result.Links.First)
 	}
@@ -419,7 +419,7 @@ func TestPagingErrors(t *testing.T) {
 
 	offset = "ALPHA"
 	limit = 40
-	_, result = test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, &limit, &offset)
+	_, result = test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, nil, &limit, &offset)
 	if !strings.Contains(*result.Links.First, "page[limit]=40") {
 		assert.Fail(t, "Limit is within range", "Expected limit to be size %d, but was %s", 40, *result.Links.First)
 	}
@@ -440,7 +440,7 @@ func TestPagingLinksHasAbsoluteURL(t *testing.T) {
 	repo := db.WorkItems().(*testsupport.WorkItemRepository)
 	repo.ListReturns(makeWorkItems(10), uint64(100), nil)
 
-	_, result := test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, &limit, &offset)
+	_, result := test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, nil, &limit, &offset)
 	if !strings.HasPrefix(*result.Links.First, "http://") {
 		assert.Fail(t, "Not Absolute URL", "Expected link %s to contain absolute URL but was %s", "First", *result.Links.First)
 	}
@@ -466,18 +466,18 @@ func TestPagingDefaultAndMaxSize(t *testing.T) {
 	repo := db.WorkItems().(*testsupport.WorkItemRepository)
 	repo.ListReturns(makeWorkItems(10), uint64(100), nil)
 
-	_, result := test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, nil, &offset)
+	_, result := test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, nil, nil, &offset)
 	if !strings.Contains(*result.Links.First, "page[limit]=20") {
 		assert.Fail(t, "Limit is nil", "Expected limit to be default size %d, got %v", 20, *result.Links.First)
 	}
 	limit = 1000
-	_, result = test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, &limit, &offset)
+	_, result = test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, nil, &limit, &offset)
 	if !strings.Contains(*result.Links.First, "page[limit]=100") {
 		assert.Fail(t, "Limit is more than max", "Expected limit to be %d, got %v", 100, *result.Links.First)
 	}
 
 	limit = 50
-	_, result = test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, &limit, &offset)
+	_, result = test.ListWorkitemOK(t, context.Background(), nil, controller, nil, nil, nil, &limit, &offset)
 	if !strings.Contains(*result.Links.First, "page[limit]=50") {
 		assert.Fail(t, "Limit is within range", "Expected limit to be %d, got %v", 50, *result.Links.First)
 	}
@@ -540,6 +540,19 @@ func createOneRandomUserIdentity(ctx context.Context, db *gorm.DB) *account.Iden
 		return nil
 	}
 	return &identity
+}
+
+func createOneRandomIteration(ctx context.Context, db *gorm.DB) *iteration.Iteration {
+	iterationRepo := iteration.NewIterationRepository(db)
+	itr := iteration.Iteration{
+		Name: "Sprint 101",
+	}
+	err := iterationRepo.Create(ctx, &itr)
+	if err != nil {
+		fmt.Println("Failed to create iteration.")
+		return nil
+	}
+	return &itr
 }
 
 // ========== WorkItem2Suite struct that implements SetupSuite, TearDownSuite, SetupTest, TearDownTest ==========
@@ -900,11 +913,45 @@ func (s *WorkItem2Suite) TestWI2ListByAssigneeFilter() {
 	assert.Equal(s.T(), newUser.ID.String(), *wi.Data.Relationships.Assignees.Data[0].ID)
 
 	newUserID := newUser.ID.String()
-	_, list := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, nil, &newUserID, nil, nil)
+	_, list := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, nil, &newUserID, nil, nil, nil)
 
 	assert.Len(s.T(), list.Data, 1)
 	assert.Equal(s.T(), newUser.ID.String(), *list.Data[0].Relationships.Assignees.Data[0].ID)
 	assert.True(s.T(), strings.Contains(*list.Links.First, "filter[assignee]"))
+}
+
+func (s *WorkItem2Suite) TestWI2ListByIterationFilter() {
+	tempIteration := createOneRandomIteration(s.svc.Context, s.db)
+	require.NotNil(s.T(), tempIteration)
+	iterationID := tempIteration.ID.String()
+	c := minimumRequiredCreatePayload()
+	c.Data.Attributes[workitem.SystemTitle] = "Title"
+	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
+	c.Data.Relationships = &app.WorkItemRelationships{
+		BaseType: &app.RelationBaseType{
+			Data: &app.BaseTypeData{
+				Type: "workitemtypes",
+				ID:   "bug",
+			},
+		},
+		Iteration: &app.RelationGeneric{
+			Data: &app.GenericData{
+				ID: &iterationID,
+			},
+		},
+	}
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	require.NotNil(s.T(), wi.Data)
+	require.NotNil(s.T(), wi.Data.ID)
+	require.NotNil(s.T(), wi.Data.Type)
+	require.NotNil(s.T(), wi.Data.Attributes)
+	require.NotNil(s.T(), wi.Data.Relationships.Iteration)
+	assert.Equal(s.T(), iterationID, *wi.Data.Relationships.Iteration.Data.ID)
+
+	_, list := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, nil, nil, &iterationID, nil, nil)
+	assert.Len(s.T(), list.Data, 1)
+	assert.Equal(s.T(), iterationID, *list.Data[0].Relationships.Iteration.Data.ID)
+	assert.True(s.T(), strings.Contains(*list.Links.First, "filter[iteration]"))
 }
 
 func (s *WorkItem2Suite) TestWI2FailCreateInvalidAssignees() {


### PR DESCRIPTION
Fixes https://github.com/fabric8io/fabric8-planner/issues/704 and https://github.com/fabric8io/fabric8-planner/issues/703

* List workitems API updated to have filter by iteration
* Updated tests to consume above changes
* Added WorkItemsByIteration URL in related links of list iterations
* Added test case to verify list of work items filter by iteration

