### PR TITLE
Update URL format in search API "/list/" and "/board/"

### DIFF
--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -22,15 +22,10 @@ import (
 	errs "github.com/pkg/errors"
 )
 
+// KnownURL registration key constants
 const (
-/*
-	- The SQL queries do a case-insensitive search.
-	- English words are normalized during search which means words like qualifying === qualify
-	- To disable the above normalization change "to_tsquery('english',$1)" to "to_tsquery($1)"
-	- Create GIN indexes : https://www.postgresql.org/docs/9.5/static/textsearch-tables.html#TEXTSEARCH-TABLES-INDEX
-	- To perform "LIKE" query we are appending ":*" to the search token
-
-*/
+	HostRegistrationKeyForListWI   = "work-item-list-details"
+	HostRegistrationKeyForBoardtWI = "work-item-board-details"
 )
 
 // GormSearchRepository provides a Gorm based repository
@@ -78,7 +73,7 @@ type searchKeyword struct {
 
 // KnownURL has a regex string format URL and compiled regex for the same
 type KnownURL struct {
-	urlRegex          string         // regex for URL
+	URLRegex          string         // regex for URL, Exposed to make the code testable
 	compiledRegex     *regexp.Regexp // valid output of regexp.MustCompile()
 	groupNamesInRegex []string       // Valid output of SubexpNames called on compliedRegex
 }
@@ -89,7 +84,7 @@ KnownURLs is set of KnownURLs will be used while searching on a URL
 URLs in this slice will be considered while searching to match search string and decouple it into multiple searchable parts
 e.g> Following example defines work-item-detail-page URL on client side, with its compiled version
 knownURLs["work-item-details"] = KnownURL{
-urlRegex:      `^(?P<protocol>http[s]?)://(?P<domain>demo.almighty.io)(?P<path>/work-item/list/detail/)(?P<id>\d*)`,
+URLRegex:      `^(?P<protocol>http[s]?)://(?P<domain>demo.almighty.io)(?P<path>/work-item/list/detail/)(?P<id>\d*)`,
 compiledRegex: regexp.MustCompile(`^(?P<protocol>http[s]?)://(?P<domain>demo.almighty.io)(?P<path>/work-item/list/detail/)(?P<id>\d*)`),
 groupNamesInRegex: []string{"protocol", "domain", "path", "id"}
 }
@@ -105,10 +100,15 @@ func RegisterAsKnownURL(name, urlRegex string) {
 	knownURLLock.Lock()
 	defer knownURLLock.Unlock()
 	knownURLs[name] = KnownURL{
-		urlRegex:          urlRegex,
+		URLRegex:          urlRegex,
 		compiledRegex:     regexp.MustCompile(urlRegex),
 		groupNamesInRegex: groupNames,
 	}
+}
+
+// GetAllRegisteredURLs returns all known URLs
+func GetAllRegisteredURLs() map[string]KnownURL {
+	return knownURLs
 }
 
 /*
@@ -374,8 +374,6 @@ func (r *GormSearchRepository) SearchFullText(ctx context.Context, rawSearchStri
 func init() {
 	// While registering URLs do not include protocol becasue it will be removed before scanning starts
 	// Please do not include trailing slashes becasue it will be removed before scanning starts
-	RegisterAsKnownURL("work-item-details", `(?P<domain>demo.almighty.io)(?P<path>/work-item/list/detail/)(?P<id>\d*)`)
-	RegisterAsKnownURL("localhost-work-item-details", `(?P<domain>localhost)(?P<port>:\d+){0,1}(?P<path>/work-item/list/detail/)(?P<id>\d*)`)
-	RegisterAsKnownURL("work-item-board-details", `(?P<domain>demo.almighty.io)(?P<path>/work-item/board/detail/)(?P<id>\d*)`)
-	RegisterAsKnownURL("localhost-work-item-board-details", `(?P<domain>localhost)(?P<port>:\d+){0,1}(?P<path>/work-item/board/detail/)(?P<id>\d*)`)
+	RegisterAsKnownURL("test-work-item-list-details", `(?P<domain>demo.almighty.io)(?P<path>/work-item/list/detail/)(?P<id>\d*)`)
+	RegisterAsKnownURL("test-work-item-board-details", `(?P<domain>demo.almighty.io)(?P<path>/work-item/board/detail/)(?P<id>\d*)`)
 }

--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -89,8 +89,8 @@ KnownURLs is set of KnownURLs will be used while searching on a URL
 URLs in this slice will be considered while searching to match search string and decouple it into multiple searchable parts
 e.g> Following example defines work-item-detail-page URL on client side, with its compiled version
 knownURLs["work-item-details"] = KnownURL{
-urlRegex:      `^(?P<protocol>http[s]?)://(?P<domain>demo.almighty.io)(?P<path>/work-item-list/detail/)(?P<id>\d*)`,
-compiledRegex: regexp.MustCompile(`^(?P<protocol>http[s]?)://(?P<domain>demo.almighty.io)(?P<path>/work-item-list/detail/)(?P<id>\d*)`),
+urlRegex:      `^(?P<protocol>http[s]?)://(?P<domain>demo.almighty.io)(?P<path>/work-item/list/detail/)(?P<id>\d*)`,
+compiledRegex: regexp.MustCompile(`^(?P<protocol>http[s]?)://(?P<domain>demo.almighty.io)(?P<path>/work-item/list/detail/)(?P<id>\d*)`),
 groupNamesInRegex: []string{"protocol", "domain", "path", "id"}
 }
 above url will be decoupled into two parts "ID:* | domain+path+id:*" while performing search query
@@ -178,7 +178,7 @@ func getSearchQueryFromURLPattern(patternName, stringToMatch string) string {
 		}
 	}
 	// first value from FindStringSubmatch is always full input itself, hence ignored
-	// Join rest of the tokens to make query like "demo.almighty.io/work-item-list/detail/100"
+	// Join rest of the tokens to make query like "demo.almighty.io/work-item/list/detail/100"
 	if len(match) > 1 {
 		searchQueryString := strings.Join(match[1:], "")
 		searchQueryString = strings.Replace(searchQueryString, ":", "\\:", -1)
@@ -374,6 +374,8 @@ func (r *GormSearchRepository) SearchFullText(ctx context.Context, rawSearchStri
 func init() {
 	// While registering URLs do not include protocol becasue it will be removed before scanning starts
 	// Please do not include trailing slashes becasue it will be removed before scanning starts
-	RegisterAsKnownURL("work-item-details", `(?P<domain>demo.almighty.io)(?P<path>/work-item-list/detail/)(?P<id>\d*)`)
-	RegisterAsKnownURL("localhost-work-item-details", `(?P<domain>localhost)(?P<port>:\d+){0,1}(?P<path>/work-item-list/detail/)(?P<id>\d*)`)
+	RegisterAsKnownURL("work-item-details", `(?P<domain>demo.almighty.io)(?P<path>/work-item/list/detail/)(?P<id>\d*)`)
+	RegisterAsKnownURL("localhost-work-item-details", `(?P<domain>localhost)(?P<port>:\d+){0,1}(?P<path>/work-item/list/detail/)(?P<id>\d*)`)
+	RegisterAsKnownURL("work-item-board-details", `(?P<domain>demo.almighty.io)(?P<path>/work-item/board/detail/)(?P<id>\d*)`)
+	RegisterAsKnownURL("localhost-work-item-board-details", `(?P<domain>localhost)(?P<port>:\d+){0,1}(?P<path>/work-item/board/detail/)(?P<id>\d*)`)
 }

--- a/search/search_repository_whitebox_test.go
+++ b/search/search_repository_whitebox_test.go
@@ -413,7 +413,7 @@ func TestRegisterAsKnownURL(t *testing.T) {
 	groupNames := compiledRegex.SubexpNames()
 	var expected = make(map[string]KnownURL)
 	expected[routeName] = KnownURL{
-		urlRegex:          urlRegex,
+		URLRegex:          urlRegex,
 		compiledRegex:     regexp.MustCompile(urlRegex),
 		groupNamesInRegex: groupNames,
 	}

--- a/search/search_repository_whitebox_test.go
+++ b/search/search_repository_whitebox_test.go
@@ -151,7 +151,7 @@ func (s *searchRepositoryWhiteboxTest) TestSearchByText() {
 			workItem := testData.wi
 			searchString := testData.searchString
 			minimumResults := testData.minimumResults
-			workItemURLInSearchString := "http://demo.almighty.io/work-item-list/detail/"
+			workItemURLInSearchString := "http://demo.almighty.io/work-item/list/detail/"
 
 			createdWorkItem, err := wir.Create(context.Background(), workitem.SystemBug, workItem.Fields, account.TestIdentity.ID.String())
 			if err != nil {
@@ -325,32 +325,56 @@ func TestParseSearchString(t *testing.T) {
 	assert.True(t, assert.ObjectsAreEqualValues(expectedSearchRes, op))
 }
 
+type searchTestData struct {
+	query    string
+	expected searchKeyword
+}
+
 func TestParseSearchStringURL(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
-	input := "http://demo.almighty.io/work-item-list/detail/100"
-	op, _ := parseSearchString(input)
+	inputSet := []searchTestData{searchTestData{
+		query: "http://demo.almighty.io/work-item/list/detail/100",
+		expected: searchKeyword{
+			id:    nil,
+			words: []string{"(100:* | demo.almighty.io/work-item/list/detail/100:*)"},
+		},
+	}, searchTestData{
+		query: "http://demo.almighty.io/work-item/board/detail/100",
+		expected: searchKeyword{
+			id:    nil,
+			words: []string{"(100:* | demo.almighty.io/work-item/board/detail/100:*)"},
+		},
+	}}
 
-	expectedSearchRes := searchKeyword{
-		id:    nil,
-		words: []string{"(100:* | demo.almighty.io/work-item-list/detail/100:*)"},
+	for _, input := range inputSet {
+		op, _ := parseSearchString(input.query)
+		assert.True(t, assert.ObjectsAreEqualValues(input.expected, op))
 	}
-
-	assert.True(t, assert.ObjectsAreEqualValues(expectedSearchRes, op))
 }
 
 func TestParseSearchStringURLWithouID(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
-	input := "http://demo.almighty.io/work-item-list/detail/"
-	op, _ := parseSearchString(input)
+	inputSet := []searchTestData{searchTestData{
+		query: "http://demo.almighty.io/work-item/list/detail/",
+		expected: searchKeyword{
+			id:    nil,
+			words: []string{"demo.almighty.io/work-item/list/detail:*"},
+		},
+	}, searchTestData{
+		query: "http://demo.almighty.io/work-item/board/detail/",
+		expected: searchKeyword{
+			id:    nil,
+			words: []string{"demo.almighty.io/work-item/board/detail:*"},
+		},
+	}}
 
-	expectedSearchRes := searchKeyword{
-		id:    nil,
-		words: []string{"demo.almighty.io/work-item-list/detail:*"},
+	for _, input := range inputSet {
+		op, _ := parseSearchString(input.query)
+		assert.True(t, assert.ObjectsAreEqualValues(input.expected, op))
 	}
 
-	assert.True(t, assert.ObjectsAreEqualValues(expectedSearchRes, op))
 }
 
 func TestParseSearchStringDifferentURL(t *testing.T) {
@@ -370,11 +394,11 @@ func TestParseSearchStringCombination(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	// do combination of ID, full text and URLs
 	// check if it works as expected.
-	input := "http://general.url.io http://demo.almighty.io/work-item-list/detail/100 id:300 golang book and           id:900 \t \n unwanted"
+	input := "http://general.url.io http://demo.almighty.io/work-item/list/detail/100 id:300 golang book and           id:900 \t \n unwanted"
 	op, _ := parseSearchString(input)
 	expectedSearchRes := searchKeyword{
 		id:    []string{"300:*A", "900:*A"},
-		words: []string{"general.url.io:*", "(100:* | demo.almighty.io/work-item-list/detail/100:*)", "golang:*", "book:*", "and:*", "unwanted:*"},
+		words: []string{"general.url.io:*", "(100:* | demo.almighty.io/work-item/list/detail/100:*)", "golang:*", "book:*", "and:*", "unwanted:*"},
 	}
 	assert.True(t, assert.ObjectsAreEqualValues(expectedSearchRes, op))
 }

--- a/search_blackbox_test.go
+++ b/search_blackbox_test.go
@@ -1,19 +1,29 @@
 package main_test
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
+
+	"fmt"
 
 	. "github.com/almighty/almighty-core"
 	"github.com/almighty/almighty-core/account"
+	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/resource"
+	"github.com/almighty/almighty-core/search"
 	testsupport "github.com/almighty/almighty-core/test"
 	almtoken "github.com/almighty/almighty-core/token"
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/goadesign/goa"
+	"github.com/goadesign/goa/goatest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 
@@ -199,4 +209,104 @@ func TestUnwantedCharactersRelatedToSearchLogic(t *testing.T) {
 	q := `http://url:some-random-other-domain:8080/different-path/`
 	_, sr := test.ShowSearchOK(t, nil, nil, controller, nil, nil, q)
 	assert.Equal(t, 0, len(sr.Data))
+}
+
+func getWICreatePayload() *app.CreateWorkitemPayload {
+	c := app.CreateWorkitemPayload{
+		Data: &app.WorkItem2{
+			Type:       APIStringTypeWorkItem,
+			Attributes: map[string]interface{}{},
+			Relationships: &app.WorkItemRelationships{
+				BaseType: &app.RelationBaseType{
+					Data: &app.BaseTypeData{
+						Type: APIStringTypeWorkItemType,
+						ID:   workitem.SystemUserStory,
+					},
+				},
+			},
+		},
+	}
+	c.Data.Attributes[workitem.SystemTitle] = "Title"
+	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
+	return &c
+}
+
+// searchByURL copies much of the codebase from search_testing.go->ShowSearchOK
+// and customises the values to add custom Host in the call.
+func searchByURL(t *testing.T, customHost, queryString string) *app.SearchWorkItemList {
+	service := getServiceAsUser()
+	var resp interface{}
+	var respSetter goatest.ResponseSetterFunc = func(r interface{}) { resp = r }
+	newEncoder := func(io.Writer) goa.Encoder { return respSetter }
+	service.Encoder = goa.NewHTTPEncoder()
+	service.Encoder.Register(newEncoder, "*/*")
+	rw := httptest.NewRecorder()
+	query := url.Values{}
+	u := &url.URL{
+		Path:     fmt.Sprintf("/api/search"),
+		RawQuery: query.Encode(),
+		Host:     customHost,
+	}
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		panic("invalid test " + err.Error()) // bug
+	}
+	prms := url.Values{}
+	prms["q"] = []string{queryString} // any value will do
+	ctx := service.Context
+	goaCtx := goa.NewContext(goa.WithAction(ctx, "SearchTest"), rw, req, prms)
+	showCtx, err := app.NewShowSearchContext(goaCtx, service)
+	if err != nil {
+		panic("invalid test data " + err.Error()) // bug
+	}
+	ctrl := NewSearchController(service, gormapplication.NewGormDB(DB))
+	// Perform action
+	err = ctrl.Show(showCtx)
+
+	// Validate response
+	if err != nil {
+		t.Fatalf("controller returned %s", err)
+	}
+	if rw.Code != 200 {
+		t.Fatalf("invalid response status code: got %+v, expected 200", rw.Code)
+	}
+	mt, ok := resp.(*app.SearchWorkItemList)
+	if !ok {
+		t.Fatalf("invalid response media: got %+v, expected instance of app.SearchWorkItemList", resp)
+	}
+	return mt
+}
+
+// verifySearchByKnownURLs performs actual tests on search result and knwonURL map
+func verifySearchByKnownURLs(t *testing.T, wi *app.WorkItem2Single, host, searchQuery string) {
+	result := searchByURL(t, host, searchQuery)
+	assert.NotEmpty(t, result.Data)
+	assert.Equal(t, *wi.Data.ID, *result.Data[0].ID)
+
+	known := search.GetAllRegisteredURLs()
+	require.NotNil(t, known)
+	assert.NotEmpty(t, known)
+	assert.Contains(t, known[search.HostRegistrationKeyForListWI].URLRegex, host)
+	assert.Contains(t, known[search.HostRegistrationKeyForBoardtWI].URLRegex, host)
+}
+
+// TestAutoRegisterHostURL checks if client's host is neatly registered as a KnwonURL or not
+// Uses helper functions verifySearchByKnownURLs, searchByURL, getWICreatePayload
+func TestAutoRegisterHostURL(t *testing.T) {
+	resource.Require(t, resource.Database)
+	defer gormsupport.DeleteCreatedEntities(DB)()
+	service := getServiceAsUser()
+	wiCtrl := NewWorkitemController(service, gormapplication.NewGormDB(DB))
+	// create a WI, search by `list view URL` of newly created item
+	newWI := getWICreatePayload()
+	_, wi := test.CreateWorkitemCreated(t, service.Context, service, wiCtrl, newWI)
+	require.NotNil(t, wi)
+	customHost := "own.domain.one"
+	queryString := fmt.Sprintf("http://%s/work-item/list/detail/%s", customHost, *wi.Data.ID)
+	verifySearchByKnownURLs(t, wi, customHost, queryString)
+
+	// Search by `board view URL` of newly created item
+	customHost2 := "own.domain.two"
+	queryString2 := fmt.Sprintf("http://%s/work-item/board/detail/%s", customHost2, *wi.Data.ID)
+	verifySearchByKnownURLs(t, wi, customHost2, queryString2)
 }


### PR DESCRIPTION
fixes https://github.com/fabric8io/fabric8-planner/issues/749
Support work item URLs in search API
* `/work-item/list/detail/100`
* `/work-item/board/detail/100`
