### PR TITLE
Fix #550 - Disallow changing a work item's type

### DIFF
--- a/workitem.go
+++ b/workitem.go
@@ -100,11 +100,16 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrNotFound(fmt.Sprintf("Error updating work item: %s", err.Error())))
 			return ctx.NotFound(jerrors)
 		}
+		// Type changes of WI are not allowed which is why we overwrite it the
+		// type with the old one after the WI has been converted.
+		oldType := wi.Type
 		err = ConvertJSONAPIToWorkItem(appl, *ctx.Payload.Data, wi)
 		if err != nil {
 			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
 			return ctx.BadRequest(jerrors)
 		}
+		wi.Type = oldType
+
 		wi, err = appl.WorkItems().Save(ctx, *wi)
 		if err != nil {
 			switch err := err.(type) {

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -104,6 +104,10 @@ func (r *GormWorkItemRepository) Save(ctx context.Context, wi app.WorkItem) (*ap
 	if res.Version != wi.Version {
 		return nil, errors.NewVersionConflictError("version conflict")
 	}
+	// Changing the type of a work item is prohibited.
+	if res.Type != wi.Type {
+		return nil, errors.NewBadParameterError("type", wi.Type).Expected(res.Type)
+	}
 
 	wiType, err := r.wir.LoadTypeFromDB(wi.Type)
 	if err != nil {

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -104,10 +104,6 @@ func (r *GormWorkItemRepository) Save(ctx context.Context, wi app.WorkItem) (*ap
 	if res.Version != wi.Version {
 		return nil, errors.NewVersionConflictError("version conflict")
 	}
-	// Changing the type of a work item is prohibited.
-	if res.Type != wi.Type {
-		return nil, errors.NewBadParameterError("type", wi.Type).Expected(res.Type)
-	}
 
 	wiType, err := r.wir.LoadTypeFromDB(wi.Type)
 	if err != nil {
@@ -115,7 +111,6 @@ func (r *GormWorkItemRepository) Save(ctx context.Context, wi app.WorkItem) (*ap
 	}
 
 	res.Version = res.Version + 1
-	res.Type = wi.Type
 	res.Fields = Fields{}
 
 	for fieldName, fieldDef := range wiType.Fields {

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -111,6 +111,7 @@ func (r *GormWorkItemRepository) Save(ctx context.Context, wi app.WorkItem) (*ap
 	}
 
 	res.Version = res.Version + 1
+	res.Type = wi.Type
 	res.Fields = Fields{}
 
 	for fieldName, fieldDef := range wiType.Fields {

--- a/workitem/workitem_repository_blackbox_test.go
+++ b/workitem/workitem_repository_blackbox_test.go
@@ -127,7 +127,7 @@ func (s *workItemRepoBlackBoxTest) TestTypeChangeIsNotProhibitedOnDBLayer() {
 
 	// Create at least 1 item to avoid RowsAffectedCheck
 	wi, err := s.repo.Create(
-		context.Background(), "system.bug",
+		context.Background(), "bug",
 		map[string]interface{}{
 			workitem.SystemTitle: "Title",
 			workitem.SystemState: workitem.SystemStateNew,
@@ -135,9 +135,9 @@ func (s *workItemRepoBlackBoxTest) TestTypeChangeIsNotProhibitedOnDBLayer() {
 
 	require.Nil(s.T(), err)
 
-	wi.Type = "system.feature"
+	wi.Type = "feature"
 
 	newWi, err := s.repo.Save(context.Background(), *wi)
 	require.Nil(s.T(), err)
-	require.Equal(s.T(), "system.feature", newWi.Type)
+	require.Equal(s.T(), "feature", newWi.Type)
 }

--- a/workitem/workitem_repository_blackbox_test.go
+++ b/workitem/workitem_repository_blackbox_test.go
@@ -129,7 +129,7 @@ func (s *workItemRepoBlackBoxTest) TestSaveForUnchangedCreatedDate() {
 func (s *workItemRepoBlackBoxTest) TestTypeChangeIsProhibited() {
 	defer gormsupport.DeleteCreatedEntities(s.DB)()
 
-	// Create at least 1 item to avoid RowsEffectedCheck
+	// Create at least 1 item to avoid RowsAffectedCheck
 	wi, err := s.repo.Create(
 		context.Background(), "system.bug",
 		map[string]interface{}{
@@ -141,6 +141,7 @@ func (s *workItemRepoBlackBoxTest) TestTypeChangeIsProhibited() {
 
 	wi.Type = "system.feature"
 
-	_, err = s.repo.Save(context.Background(), *wi)
-	require.IsType(s.T(), errors.BadParameterError{}, err)
+	newWi, err := s.repo.Save(context.Background(), *wi)
+	require.Nil(s.T(), err)
+	require.Equal(s.T(), "system.bug", newWi.Type, "Type change must be silently ignored")
 }

--- a/workitem/workitem_repository_blackbox_test.go
+++ b/workitem/workitem_repository_blackbox_test.go
@@ -124,9 +124,10 @@ func (s *workItemRepoBlackBoxTest) TestSaveForUnchangedCreatedDate() {
 	assert.Equal(s.T(), wi.Fields[workitem.SystemCreatedAt], wiNew.Fields[workitem.SystemCreatedAt])
 }
 
-// TestTypeChangeIsProhibited tests that you cannot change the type of a work
-// item (see https://github.com/fabric8io/fabric8-planner/issues/635).
-func (s *workItemRepoBlackBoxTest) TestTypeChangeIsProhibited() {
+// TestTypeChangeIsNotProhibitedOnDBLayer tests that you can change the type of
+// a work item. NOTE: This functionality only works on the DB layer and is not
+// exposed to REST.
+func (s *workItemRepoBlackBoxTest) TestTypeChangeIsNotProhibitedOnDBLayer() {
 	defer gormsupport.DeleteCreatedEntities(s.DB)()
 
 	// Create at least 1 item to avoid RowsAffectedCheck
@@ -143,5 +144,5 @@ func (s *workItemRepoBlackBoxTest) TestTypeChangeIsProhibited() {
 
 	newWi, err := s.repo.Save(context.Background(), *wi)
 	require.Nil(s.T(), err)
-	require.Equal(s.T(), "system.bug", newWi.Type, "Type change must be silently ignored")
+	require.Equal(s.T(), "system.feature", newWi.Type)
 }

--- a/workitem_blackbox_test.go
+++ b/workitem_blackbox_test.go
@@ -652,13 +652,12 @@ func (s *WorkItem2Suite) TestWI2UpdateSetBaseType() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				ID:   workitem.SystemExperience,
-				Type: APIStringTypeWorkItemType,
+				Type: APIStringTypeWorkItemType, // Not allowed to change the WIT of a WI
 			},
 		},
 	}
 
-	_, updated := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.ID, &u)
-	assert.Equal(s.T(), u.Data.Relationships.BaseType.Data.ID, updated.Data.Relationships.BaseType.Data.ID)
+	_, _ = test.UpdateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.ID, &u)
 }
 
 func (s *WorkItem2Suite) TestWI2UpdateOnlyDescription() {

--- a/workitem_blackbox_test.go
+++ b/workitem_blackbox_test.go
@@ -657,7 +657,10 @@ func (s *WorkItem2Suite) TestWI2UpdateSetBaseType() {
 		},
 	}
 
-	_, _ = test.UpdateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.ID, &u)
+	_, newWi := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.ID, &u)
+
+	// Ensure the type wasn't updated
+	require.Equal(s.T(), workitem.SystemBug, newWi.Data.Relationships.BaseType.Data.ID)
 }
 
 func (s *WorkItem2Suite) TestWI2UpdateOnlyDescription() {


### PR DESCRIPTION
Previously you could create invalid links by changing the a work item's type if a work item of such a type was already used in some link. This change prevents links between two work items from becoming invalid by disallowing you to change a work item's type.

Fix #550

See https://github.com/fabric8io/fabric8-planner/issues/635 as well as https://github.com/fabric8io/fabric8-planner/commit/4af7d3ebf39161165c1bb6f3cc5e3c82dfe209e6 which removes the ability to change the WIT of a WI from the UI.