### PR TITLE
Use postgres' ltree datatype for WIT's path field

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -274,7 +274,7 @@ http.address: 0.0.0.0:8080
 # Enable development related features, e.g. token generation endpoint
 developer.mode.enabled: false
 
-# Whether you want to create the common work item types such as system.bug, system.feature, ...
+# Whether you want to create the common work item types such as system_bug, system_feature, ...
 populate.commontypes: true
 
 # -----------------------------
@@ -410,17 +410,17 @@ $ ./bin/alm-cli show workitem --id 1 -H localhost:8080 --pp
 
 System defined Work Item Types are
 
- * system.userstory
- * system.valueproposition
- * system.fundamental
- * system.experience
- * system.feature
- * system.bug
+ * system_userstory
+ * system_valueproposition
+ * system_fundamental
+ * system_experience
+ * system_feature
+ * system_bug
 
 Use any one of above to create Work Item based on that type.
-Following example creates a Work Item of type `system.userstory`
+Following example creates a Work Item of type `system_userstory`
 ----
-$ ./bin/alm-cli create workitem --key "<GENERATED TOKEN>" --payload '{"type": "system.userstory", "fields": { "system.title": "A catchy Title", "system.owner": "tmaeder", "system.state": "open" }}' -H localhost:8080
+$ ./bin/alm-cli create workitem --key "<GENERATED TOKEN>" --payload '{"type": "system_userstory", "fields": { "system.title": "A catchy Title", "system.owner": "tmaeder", "system.state": "open" }}' -H localhost:8080
 ----
 
 In response you should get ID of created item, using that you can retrieve the work item.

--- a/README.adoc
+++ b/README.adoc
@@ -274,7 +274,7 @@ http.address: 0.0.0.0:8080
 # Enable development related features, e.g. token generation endpoint
 developer.mode.enabled: false
 
-# Whether you want to create the common work item types such as system_bug, system_feature, ...
+# Whether you want to create the common work item types such as bug, feature, ...
 populate.commontypes: true
 
 # -----------------------------
@@ -410,17 +410,17 @@ $ ./bin/alm-cli show workitem --id 1 -H localhost:8080 --pp
 
 System defined Work Item Types are
 
- * system_userstory
- * system_valueproposition
- * system_fundamental
- * system_experience
- * system_feature
- * system_bug
+ * userstory
+ * valueproposition
+ * fundamental
+ * experience
+ * feature
+ * bug
 
 Use any one of above to create Work Item based on that type.
-Following example creates a Work Item of type `system_userstory`
+Following example creates a Work Item of type `userstory`
 ----
-$ ./bin/alm-cli create workitem --key "<GENERATED TOKEN>" --payload '{"type": "system_userstory", "fields": { "system.title": "A catchy Title", "system.owner": "tmaeder", "system.state": "open" }}' -H localhost:8080
+$ ./bin/alm-cli create workitem --key "<GENERATED TOKEN>" --payload '{"type": "userstory", "fields": { "system.title": "A catchy Title", "system.owner": "tmaeder", "system.state": "open" }}' -H localhost:8080
 ----
 
 In response you should get ID of created item, using that you can retrieve the work item.

--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,7 @@ http.address: 0.0.0.0:8080
 # Enable development related features, e.g. token generation endpoint
 developer.mode.enabled: false
 
-# Whether you want to create the common work item types such as system_bug, system_feature, ...
+# Whether you want to create the common work item types such as bug, feature, ...
 populate.commontypes: true
 
 # ----------------------------

--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,7 @@ http.address: 0.0.0.0:8080
 # Enable development related features, e.g. token generation endpoint
 developer.mode.enabled: false
 
-# Whether you want to create the common work item types such as system.bug, system.feature, ...
+# Whether you want to create the common work item types such as system_bug, system_feature, ...
 populate.commontypes: true
 
 # ----------------------------

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -170,7 +170,7 @@ func GetPostgresConfigString() string {
 }
 
 // GetPopulateCommonTypes returns true if the (as set via default, config file, or environment variable)
-// the common work item types such as system_bug or system_feature shall be created.
+// the common work item types such as bug or feature shall be created.
 func GetPopulateCommonTypes() bool {
 	return viper.GetBool(varPopulateCommonTypes)
 }

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -170,7 +170,7 @@ func GetPostgresConfigString() string {
 }
 
 // GetPopulateCommonTypes returns true if the (as set via default, config file, or environment variable)
-// the common work item types such as system.bug or system.feature shall be created.
+// the common work item types such as system_bug or system_feature shall be created.
 func GetPopulateCommonTypes() bool {
 	return viper.GetBool(varPopulateCommonTypes)
 }

--- a/design/user_types.go
+++ b/design/user_types.go
@@ -8,7 +8,7 @@ import (
 // CreateWorkItemPayload defines the structure of work item payload
 var CreateWorkItemPayload = a.Type("CreateWorkItemPayload", func() {
 	a.Attribute("type", d.String, "The type of the newly created work item", func() {
-		a.Example("system.userstory")
+		a.Example("system_userstory")
 		a.MinLength(1)
 		a.Pattern("^[\\p{L}.]+$")
 	})
@@ -24,7 +24,7 @@ var CreateWorkItemPayload = a.Type("CreateWorkItemPayload", func() {
 // which ideally should be optional. The ID should be passed on to REST URL.
 var UpdateWorkItemPayload = a.Type("UpdateWorkItemPayload", func() {
 	a.Attribute("type", d.String, "The type of the newly created work item", func() {
-		a.Example("system.userstory")
+		a.Example("system_userstory")
 		a.MinLength(1)
 		a.Pattern("^[\\p{L}.]+$")
 	})

--- a/design/user_types.go
+++ b/design/user_types.go
@@ -8,7 +8,7 @@ import (
 // CreateWorkItemPayload defines the structure of work item payload
 var CreateWorkItemPayload = a.Type("CreateWorkItemPayload", func() {
 	a.Attribute("type", d.String, "The type of the newly created work item", func() {
-		a.Example("system_userstory")
+		a.Example("userstory")
 		a.MinLength(1)
 		a.Pattern("^[\\p{L}.]+$")
 	})
@@ -24,7 +24,7 @@ var CreateWorkItemPayload = a.Type("CreateWorkItemPayload", func() {
 // which ideally should be optional. The ID should be passed on to REST URL.
 var UpdateWorkItemPayload = a.Type("UpdateWorkItemPayload", func() {
 	a.Attribute("type", d.String, "The type of the newly created work item", func() {
-		a.Example("system_userstory")
+		a.Example("userstory")
 		a.MinLength(1)
 		a.Pattern("^[\\p{L}.]+$")
 	})

--- a/design/work-item-link-type.go
+++ b/design/work-item-link-type.go
@@ -93,7 +93,7 @@ var relationWorkItemTypeData = a.Type("RelationWorkItemTypeData", func() {
 		a.Enum("workitemtypes")
 	})
 	a.Attribute("id", d.String, "Name work item type", func() {
-		a.Example("system.bug")
+		a.Example("system_bug")
 	})
 	a.Required("type", "id")
 })

--- a/design/work-item-link-type.go
+++ b/design/work-item-link-type.go
@@ -93,7 +93,7 @@ var relationWorkItemTypeData = a.Type("RelationWorkItemTypeData", func() {
 		a.Enum("workitemtypes")
 	})
 	a.Attribute("id", d.String, "Name work item type", func() {
-		a.Example("system_bug")
+		a.Example("bug")
 	})
 	a.Required("type", "id")
 })

--- a/design/workitems.go
+++ b/design/workitems.go
@@ -42,7 +42,7 @@ var baseTypeData = a.Type("BaseTypeData", func() {
 		a.Enum("workitemtypes")
 	})
 	a.Attribute("id", d.String, func() {
-		a.Example("system_userstory")
+		a.Example("userstory")
 	})
 	a.Required("type", "id")
 })

--- a/design/workitems.go
+++ b/design/workitems.go
@@ -42,7 +42,7 @@ var baseTypeData = a.Type("BaseTypeData", func() {
 		a.Enum("workitemtypes")
 	})
 	a.Attribute("id", d.String, func() {
-		a.Example("system.userstory")
+		a.Example("system_userstory")
 	})
 	a.Required("type", "id")
 })

--- a/examples/create_workitem.json
+++ b/examples/create_workitem.json
@@ -1,1 +1,1 @@
-{"type": "system_userstory" ,"fields": { "system.creator": "tmaeder", "system.state": "new", "system.title": "My special story", "system.description": "description" }}
+{"type": "userstory" ,"fields": { "system.creator": "tmaeder", "system.state": "new", "system.title": "My special story", "system.description": "description" }}

--- a/examples/create_workitem.json
+++ b/examples/create_workitem.json
@@ -1,1 +1,1 @@
-{"type": "system.userstory" ,"fields": { "system.creator": "tmaeder", "system.state": "new", "system.title": "My special story", "system.description": "description" }}
+{"type": "system_userstory" ,"fields": { "system.creator": "tmaeder", "system.state": "new", "system.title": "My special story", "system.description": "description" }}

--- a/main.go
+++ b/main.go
@@ -114,7 +114,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Make sure the database is populated with the correct types (e.g. system.bug etc.)
+	// Make sure the database is populated with the correct types (e.g. system_bug etc.)
 	if configuration.GetPopulateCommonTypes() {
 		if err := models.Transactional(db, func(tx *gorm.DB) error {
 			return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))

--- a/main.go
+++ b/main.go
@@ -114,7 +114,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Make sure the database is populated with the correct types (e.g. system_bug etc.)
+	// Make sure the database is populated with the correct types (e.g. bug etc.)
 	if configuration.GetPopulateCommonTypes() {
 		if err := models.Transactional(db, func(tx *gorm.DB) error {
 			return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -309,7 +309,7 @@ func createOrUpdateWorkItemLinkType(ctx context.Context, linkCatRepo *link.GormW
 	return nil
 }
 
-// PopulateCommonTypes makes sure the database is populated with the correct types (e.g. system_bug etc.)
+// PopulateCommonTypes makes sure the database is populated with the correct types (e.g. bug etc.)
 func PopulateCommonTypes(ctx context.Context, db *gorm.DB, witr *workitem.GormWorkItemTypeRepository) error {
 
 	if err := createOrUpdateSystemPlannerItemType(ctx, witr, db); err != nil {

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -403,7 +403,7 @@ func createOrUpdateType(typeName string, extendedTypeName *string, fields map[st
 			if err != nil {
 				return err
 			}
-			path = extendedWit.Path + path
+			path = extendedWit.Path + workitem.GetTypePathSeparator() + path
 
 			//load fields from the extended type
 			err = loadFields(ctx, extendedWit, convertedFields)

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -395,7 +395,7 @@ func createOrUpdateType(typeName string, extendedTypeName *string, fields map[st
 		}
 	case nil:
 		log.Printf("Work item type %v exists, will update/overwrite the fields only and parentPath", typeName)
-		path := "/" + typeName
+		path := typeName
 		convertedFields, err := workitem.TEMPConvertFieldTypesToModel(fields)
 		if extendedTypeName != nil {
 			log.Printf("Work item type %v extends another type %v, will copy fields from the extended type", typeName, *extendedTypeName)

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -309,7 +309,7 @@ func createOrUpdateWorkItemLinkType(ctx context.Context, linkCatRepo *link.GormW
 	return nil
 }
 
-// PopulateCommonTypes makes sure the database is populated with the correct types (e.g. system.bug etc.)
+// PopulateCommonTypes makes sure the database is populated with the correct types (e.g. system_bug etc.)
 func PopulateCommonTypes(ctx context.Context, db *gorm.DB, witr *workitem.GormWorkItemTypeRepository) error {
 
 	if err := createOrUpdateSystemPlannerItemType(ctx, witr, db); err != nil {

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -131,7 +131,7 @@ func getMigrations() migrations {
 	m = append(m, steps{executeSQLFile("017-alter-iterations.sql")})
 
 	// Version 18
-	m = append(m, steps{executeSQLFile("018-drop-wi-links-trigger.sql")})
+	m = append(m, steps{executeSQLFile("018-rewrite-wits.sql")})
 
 	// Version N
 	//

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -130,6 +130,9 @@ func getMigrations() migrations {
 	// Version 17
 	m = append(m, steps{executeSQLFile("017-alter-iterations.sql")})
 
+	// Version 18
+	m = append(m, steps{executeSQLFile("018-drop-wi-links-trigger.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/018-rewrite-wits.sql
+++ b/migration/sql-files/018-rewrite-wits.sql
@@ -51,7 +51,7 @@ SET
 
 UPDATE
     work_item AS wi
-    INNER JOIN work_item_types AS wit ON wit.name = wi.type
+    INNER JOIN work_item_types AS wit ON wit.type = wi.type
 SET wi.type = subpath(wit.path,-1,1);
 
 -- Use the leaf of the path "tree" as the name of the work item type

--- a/migration/sql-files/018-rewrite-wits.sql
+++ b/migration/sql-files/018-rewrite-wits.sql
@@ -5,8 +5,7 @@ CREATE EXTENSION IF NOT EXISTS "ltree";
 
 -- The following update needs to be done in order to get the WIT storage in a
 -- good shape for it to be migrated to an ltree
-UPDATE work_item_types
-SET
+UPDATE work_item_types SET
     -- Remove any leading '/' from the WIT's path.
     -- Remove any occurence of 'system.'.
     -- Replace '/' with '.' as the new path separator for use with ltree.
@@ -42,16 +41,16 @@ ALTER TABLE work_item_link_types DROP CONSTRAINT work_item_link_types_source_typ
 ALTER TABLE work_item_link_types DROP CONSTRAINT work_item_link_types_target_type_name_fkey;
 
 UPDATE
-    work_item_link_types AS wilt
-    INNER JOIN work_item_types AS wit_source ON wit_source.name = wilt.source_type_name
-    INNER JOIN work_item_types AS wit_target ON wit_source.name = wilt.target_type_name
+    work_item_link_types wilt
+    LEFT JOIN work_item_types wit_source ON wit_source.name = wilt.source_type_name
+    LEFT JOIN work_item_types wit_target ON wit_target.name = wilt.target_type_name
 SET
     wilt.source_type_name = subpath(wit_source.path,-1,1)
     wilt.target_type_name = subpath(wit_target.path,-1,1)
 
 UPDATE
-    work_item AS wi
-    INNER JOIN work_item_types AS wit ON wit.type = wi.type
+    work_item wi
+    LEFT JOIN work_item_types wit ON wit.type = wi.type
 SET wi.type = subpath(wit.path,-1,1);
 
 -- Use the leaf of the path "tree" as the name of the work item type

--- a/migration/sql-files/018-rewrite-wits.sql
+++ b/migration/sql-files/018-rewrite-wits.sql
@@ -5,7 +5,8 @@ CREATE EXTENSION IF NOT EXISTS "ltree";
 
 -- The following update needs to be done in order to get the WIT storage in a
 -- good shape for it to be migrated to an ltree
-UPDATE work_item_types SET
+UPDATE work_item_types
+SET
     -- Remove any leading '/' from the WIT's path.
     -- Remove any occurence of 'system.'.
     -- Replace '/' with '.' as the new path separator for use with ltree.
@@ -21,12 +22,50 @@ UPDATE work_item_types SET
 -- Convert the path column from type text to ltree
 ALTER TABLE work_item_types ALTER COLUMN path TYPE ltree USING path::ltree;
 
--- Use the leaf of the path "tree" as the name of the work item type
-UPDATE work_item_types SET name = subpath(path,-1,1);
-
 -- Add a constraint to the work item type name 
 ALTER TABLE work_item_types ADD CONSTRAINT work_item_link_types_check_name_c_locale CHECK (name ~ '[a-zA-Z0-9_]');
 
 -- Add indexes 
 CREATE INDEX wit_path_gist_idx ON work_item_types USING GIST (path);
 CREATE INDEX wit_path_idx ON work_item_types USING BTREE (path);
+
+
+---------------------------------------------------------------------------
+-- Update work items and work item link types that point to the work items.
+---------------------------------------------------------------------------
+
+
+-- Drop the foreign keys on the work item links types that reference the work
+-- item type. We add them back once we've changed the names and it is safe to
+-- add the keys back again.
+ALTER TABLE work_item_link_types DROP CONSTRAINT work_item_link_types_source_type_name_fkey;
+ALTER TABLE work_item_link_types DROP CONSTRAINT work_item_link_types_target_type_name_fkey;
+
+UPDATE
+    work_item_link_types AS wilt
+    INNER JOIN work_item_types AS wit_source ON wit_source.name = wilt.source_type_name
+    INNER JOIN work_item_types AS wit_target ON wit_source.name = wilt.target_type_name
+SET
+    wilt.source_type_name = subpath(wit_source.path,-1,1)
+    wilt.target_type_name = subpath(wit_target.path,-1,1)
+
+UPDATE
+    work_item AS wi
+    INNER JOIN work_item_types AS wit ON wit.name = wi.type
+SET wi.name = subpath(wit.path,-1,1);
+
+-- Use the leaf of the path "tree" as the name of the work item type
+UPDATE work_item_types SET name = subpath(path,-1,1);
+
+-- Add foreign keys back in
+ALTER TABLE work_item_link_types
+    ADD CONSTRAINT "work_item_link_types_source_type_name_fkey"
+    FOREIGN KEY (source_type_name)
+    REFERENCES work_item_types(name)
+    ON DELETE CASCADE;
+
+ALTER TABLE work_item_link_types
+    ADD CONSTRAINT "work_item_link_types_target_type_name_fkey"
+    FOREIGN KEY (target_type_name)
+    REFERENCES work_item_types(name)
+    ON DELETE CASCADE;

--- a/migration/sql-files/018-rewrite-wits.sql
+++ b/migration/sql-files/018-rewrite-wits.sql
@@ -40,21 +40,25 @@ CREATE INDEX wit_path_idx ON work_item_types USING BTREE (path);
 ALTER TABLE work_item_link_types DROP CONSTRAINT work_item_link_types_source_type_name_fkey;
 ALTER TABLE work_item_link_types DROP CONSTRAINT work_item_link_types_target_type_name_fkey;
 
-UPDATE
-    work_item_link_types wilt
-    LEFT JOIN work_item_types wit_source ON wit_source.name = wilt.source_type_name
-    LEFT JOIN work_item_types wit_target ON wit_target.name = wilt.target_type_name
+UPDATE work_item_link_types
 SET
-    wilt.source_type_name = subpath(wit_source.path,-1,1)
-    wilt.target_type_name = subpath(wit_target.path,-1,1)
+    source_type_name = subpath(wit_source.path, -1, 1),
+    target_type_name = subpath(wit_target.path, -1, 1)
+FROM
+    work_item_types AS wit_source,
+    work_item_types AS wit_target
+WHERE
+    source_type_name = wit_source.name
+    AND target_type_name = wit_target.name;
 
-UPDATE
-    work_item wi
-    LEFT JOIN work_item_types wit ON wit.type = wi.type
-SET wi.type = subpath(wit.path,-1,1);
+-- Update work item's type
+UPDATE work_items
+SET type = subpath(wit.path, -1, 1)
+FROM work_item_types AS wit
+WHERE type = wit.name;
 
 -- Use the leaf of the path "tree" as the name of the work item type
-UPDATE work_item_types SET name = subpath(path,-1,1);
+UPDATE work_item_types SET name = subpath(path, -1, 1);
 
 -- Add foreign keys back in
 ALTER TABLE work_item_link_types

--- a/migration/sql-files/018-rewrite-wits.sql
+++ b/migration/sql-files/018-rewrite-wits.sql
@@ -52,7 +52,7 @@ SET
 UPDATE
     work_item AS wi
     INNER JOIN work_item_types AS wit ON wit.name = wi.type
-SET wi.name = subpath(wit.path,-1,1);
+SET wi.type = subpath(wit.path,-1,1);
 
 -- Use the leaf of the path "tree" as the name of the work item type
 UPDATE work_item_types SET name = subpath(path,-1,1);

--- a/migration/sql-files/018-rewrite-wits.sql
+++ b/migration/sql-files/018-rewrite-wits.sql
@@ -1,0 +1,32 @@
+-- See https://www.postgresql.org/docs/current/static/ltree.html for the
+-- reference See http://leapfrogonline.io/articles/2015-05-21-postgres-ltree/
+-- for an explanation
+CREATE EXTENSION IF NOT EXISTS "ltree";
+
+-- The following update needs to be done in order to get the WIT storage in a
+-- good shape for it to be migrated to an ltree
+UPDATE work_item_types SET
+    -- Remove any leading '/' from the WIT's path.
+    -- Remove any occurence of 'system.'.
+    -- Replace '/' with '.' as the new path separator for use with ltree.
+    -- Replace every non-C-LOCALE character with an underscore (the "." is an
+    -- exception because it will be used by ltree)
+    path =  regexp_replace(
+                replace(replace(ltrim(path, '/'), 'system.', ''), '/', '.'),
+                '[^a-zA-Z0-9_\.]',
+                '_'
+            )
+    ;
+
+-- Convert the path column from type text to ltree
+ALTER TABLE work_item_types ALTER COLUMN path TYPE ltree USING path::ltree;
+
+-- Use the leaf of the path "tree" as the name of the work item type
+UPDATE work_item_types SET name = subpath(path,-1,1);
+
+-- Add a constraint to the work item type name 
+ALTER TABLE work_item_types ADD CONSTRAINT work_item_link_types_check_name_c_locale CHECK (name ~ '[a-zA-Z0-9_]');
+
+-- Add indexes 
+CREATE INDEX wit_path_gist_idx ON work_item_types USING GIST (path);
+CREATE INDEX wit_path_idx ON work_item_types USING BTREE (path);

--- a/remoteworkitem/scheduler_test.go
+++ b/remoteworkitem/scheduler_test.go
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 		}
 		defer db.Close()
 
-		// Make sure the database is populated with the correct types (e.g. system_bug etc.)
+		// Make sure the database is populated with the correct types (e.g. bug etc.)
 		if err := models.Transactional(db, func(tx *gorm.DB) error {
 			return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))
 		}); err != nil {

--- a/remoteworkitem/scheduler_test.go
+++ b/remoteworkitem/scheduler_test.go
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 		}
 		defer db.Close()
 
-		// Make sure the database is populated with the correct types (e.g. system.bug etc.)
+		// Make sure the database is populated with the correct types (e.g. system_bug etc.)
 		if err := models.Transactional(db, func(tx *gorm.DB) error {
 			return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))
 		}); err != nil {

--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -284,7 +284,7 @@ func (r *GormSearchRepository) search(ctx context.Context, sqlSearchQueryParamet
 		// restrict to all given types and their subtypes
 		query := fmt.Sprintf("%[1]s.type in ("+
 			"select distinct subtype.name from %[2]s subtype "+
-			"join %[2]s supertype on subtype.path like (supertype.path || '%%') "+
+			"join %[2]s supertype on subtype.path <@ supertype.path "+
 			"where supertype.name in (?))", workitem.WorkItem{}.TableName(), workitem.WorkItemType{}.TableName())
 		db = db.Where(query, workItemTypes)
 	}

--- a/search/search_repository_blackbox_test.go
+++ b/search/search_repository_blackbox_test.go
@@ -27,7 +27,7 @@ type searchRepositoryBlackboxTest struct {
 func (s *searchRepositoryBlackboxTest) SetupSuite() {
 	s.DBTestSuite.SetupSuite()
 
-	// Make sure the database is populated with the correct types (e.g. system.bug etc.)
+	// Make sure the database is populated with the correct types (e.g. system_bug etc.)
 	if _, c := os.LookupEnv(resource.Database); c != false {
 		if err := models.Transactional(s.DB, func(tx *gorm.DB) error {
 			return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))

--- a/search/search_repository_blackbox_test.go
+++ b/search/search_repository_blackbox_test.go
@@ -27,7 +27,7 @@ type searchRepositoryBlackboxTest struct {
 func (s *searchRepositoryBlackboxTest) SetupSuite() {
 	s.DBTestSuite.SetupSuite()
 
-	// Make sure the database is populated with the correct types (e.g. system_bug etc.)
+	// Make sure the database is populated with the correct types (e.g. bug etc.)
 	if _, c := os.LookupEnv(resource.Database); c != false {
 		if err := models.Transactional(s.DB, func(tx *gorm.DB) error {
 			return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))

--- a/search/search_repository_blackbox_test.go
+++ b/search/search_repository_blackbox_test.go
@@ -59,7 +59,7 @@ func (s *searchRepositoryBlackboxTest) TestRestrictByType() {
 
 	s.DB.Unscoped().Delete(&workitem.WorkItemType{Name: "base"})
 	s.DB.Unscoped().Delete(&workitem.WorkItemType{Name: "sub1"})
-	s.DB.Unscoped().Delete(&workitem.WorkItemType{Name: "sub two"})
+	s.DB.Unscoped().Delete(&workitem.WorkItemType{Name: "subtwo"})
 
 	extended := workitem.SystemBug
 	base, err := typeRepo.Create(ctx, &extended, "base", map[string]app.FieldDefinition{})
@@ -71,7 +71,7 @@ func (s *searchRepositoryBlackboxTest) TestRestrictByType() {
 	require.NotNil(s.T(), sub1)
 	require.Nil(s.T(), err)
 
-	sub2, err := typeRepo.Create(ctx, &extended, "sub two", map[string]app.FieldDefinition{})
+	sub2, err := typeRepo.Create(ctx, &extended, "subtwo", map[string]app.FieldDefinition{})
 	require.NotNil(s.T(), sub2)
 	require.Nil(s.T(), err)
 
@@ -82,7 +82,7 @@ func (s *searchRepositoryBlackboxTest) TestRestrictByType() {
 	require.NotNil(s.T(), wi1)
 	require.Nil(s.T(), err)
 
-	wi2, err := wiRepo.Create(ctx, "sub two", map[string]interface{}{
+	wi2, err := wiRepo.Create(ctx, "subtwo", map[string]interface{}{
 		workitem.SystemTitle: "Test TestRestrictByType 2",
 		workitem.SystemState: "closed",
 	}, account.TestIdentity.ID.String())
@@ -100,7 +100,7 @@ func (s *searchRepositoryBlackboxTest) TestRestrictByType() {
 		assert.Equal(s.T(), wi1.ID, res[0].ID)
 	}
 
-	res, count, err = searchRepo.SearchFullText(ctx, "TestRestrictByType type:sub+two", nil, nil)
+	res, count, err = searchRepo.SearchFullText(ctx, "TestRestrictByType type:subtwo", nil, nil)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), uint64(1), count)
 	if count == 1 {
@@ -111,7 +111,7 @@ func (s *searchRepositoryBlackboxTest) TestRestrictByType() {
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), uint64(2), count)
 
-	res, count, err = searchRepo.SearchFullText(ctx, "TestRestrictByType type:sub+two type:sub1", nil, nil)
+	res, count, err = searchRepo.SearchFullText(ctx, "TestRestrictByType type:subtwo type:sub1", nil, nil)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), uint64(2), count)
 

--- a/search/search_repository_whitebox_test.go
+++ b/search/search_repository_whitebox_test.go
@@ -29,7 +29,7 @@ type searchRepositoryWhiteboxTest struct {
 func (s *searchRepositoryWhiteboxTest) SetupSuite() {
 	s.DBTestSuite.SetupSuite()
 
-	// Make sure the database is populated with the correct types (e.g. system.bug etc.)
+	// Make sure the database is populated with the correct types (e.g. system_bug etc.)
 	if _, c := os.LookupEnv(resource.Database); c != false {
 		if err := models.Transactional(s.DB, func(tx *gorm.DB) error {
 			return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))

--- a/search/search_repository_whitebox_test.go
+++ b/search/search_repository_whitebox_test.go
@@ -29,7 +29,7 @@ type searchRepositoryWhiteboxTest struct {
 func (s *searchRepositoryWhiteboxTest) SetupSuite() {
 	s.DBTestSuite.SetupSuite()
 
-	// Make sure the database is populated with the correct types (e.g. system_bug etc.)
+	// Make sure the database is populated with the correct types (e.g. bug etc.)
 	if _, c := os.LookupEnv(resource.Database); c != false {
 		if err := models.Transactional(s.DB, func(tx *gorm.DB) error {
 			return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))

--- a/work-item-link-blackbox_test.go
+++ b/work-item-link-blackbox_test.go
@@ -76,7 +76,7 @@ func (s *workItemLinkSuite) SetupSuite() {
 		panic("Failed to connect database: " + err.Error())
 	}
 
-	// Make sure the database is populated with the correct types (e.g. system.bug etc.)
+	// Make sure the database is populated with the correct types (e.g. system_bug etc.)
 	if err := models.Transactional(DB, func(tx *gorm.DB) error {
 		return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))
 	}); err != nil {

--- a/work-item-link-blackbox_test.go
+++ b/work-item-link-blackbox_test.go
@@ -76,7 +76,7 @@ func (s *workItemLinkSuite) SetupSuite() {
 		panic("Failed to connect database: " + err.Error())
 	}
 
-	// Make sure the database is populated with the correct types (e.g. system_bug etc.)
+	// Make sure the database is populated with the correct types (e.g. bug etc.)
 	if err := models.Transactional(DB, func(tx *gorm.DB) error {
 		return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))
 	}); err != nil {

--- a/work-item-link-category-blackbox_test.go
+++ b/work-item-link-category-blackbox_test.go
@@ -53,7 +53,7 @@ func (s *workItemLinkCategorySuite) SetupSuite() {
 		panic("Failed to connect database: " + err.Error())
 	}
 
-	// Make sure the database is populated with the correct types (e.g. system_bug etc.)
+	// Make sure the database is populated with the correct types (e.g. bug etc.)
 	if err := models.Transactional(DB, func(tx *gorm.DB) error {
 		return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))
 	}); err != nil {

--- a/work-item-link-category-blackbox_test.go
+++ b/work-item-link-category-blackbox_test.go
@@ -53,7 +53,7 @@ func (s *workItemLinkCategorySuite) SetupSuite() {
 		panic("Failed to connect database: " + err.Error())
 	}
 
-	// Make sure the database is populated with the correct types (e.g. system.bug etc.)
+	// Make sure the database is populated with the correct types (e.g. system_bug etc.)
 	if err := models.Transactional(DB, func(tx *gorm.DB) error {
 		return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))
 	}); err != nil {

--- a/work-item-link-type-blackbox_test.go
+++ b/work-item-link-type-blackbox_test.go
@@ -55,7 +55,7 @@ func (s *workItemLinkTypeSuite) SetupSuite() {
 		panic("Failed to connect database: " + err.Error())
 	}
 
-	// Make sure the database is populated with the correct types (e.g. system_bug etc.)
+	// Make sure the database is populated with the correct types (e.g. bug etc.)
 	if err := models.Transactional(DB, func(tx *gorm.DB) error {
 		return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))
 	}); err != nil {
@@ -324,8 +324,8 @@ func getWorkItemLinkTypeTestData(t *testing.T) []testSecureAPI {
 				},
 				"relationships": {
 					"link_category": {"data": {"type":"workitemlinkcategories", "id": "a75ea296-6378-4578-8573-90f11b8efb00"}},
-					"source_type": {"data": {"type":"workitemtypes", "id": "system_bug"}},
-					"target_type": {"data": {"type":"workitemtypes", "id": "system_bug"}}
+					"source_type": {"data": {"type":"workitemtypes", "id": "bug"}},
+					"target_type": {"data": {"type":"workitemtypes", "id": "bug"}}
 				}
 			}
 		}

--- a/work-item-link-type-blackbox_test.go
+++ b/work-item-link-type-blackbox_test.go
@@ -55,7 +55,7 @@ func (s *workItemLinkTypeSuite) SetupSuite() {
 		panic("Failed to connect database: " + err.Error())
 	}
 
-	// Make sure the database is populated with the correct types (e.g. system.bug etc.)
+	// Make sure the database is populated with the correct types (e.g. system_bug etc.)
 	if err := models.Transactional(DB, func(tx *gorm.DB) error {
 		return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))
 	}); err != nil {
@@ -324,8 +324,8 @@ func getWorkItemLinkTypeTestData(t *testing.T) []testSecureAPI {
 				},
 				"relationships": {
 					"link_category": {"data": {"type":"workitemlinkcategories", "id": "a75ea296-6378-4578-8573-90f11b8efb00"}},
-					"source_type": {"data": {"type":"workitemtypes", "id": "system.bug"}},
-					"target_type": {"data": {"type":"workitemtypes", "id": "system.bug"}}
+					"source_type": {"data": {"type":"workitemtypes", "id": "system_bug"}},
+					"target_type": {"data": {"type":"workitemtypes", "id": "system_bug"}}
 				}
 			}
 		}

--- a/workitem/workitem_repository_blackbox_test.go
+++ b/workitem/workitem_repository_blackbox_test.go
@@ -30,7 +30,7 @@ func (s *workItemRepoBlackBoxTest) TestFailDeleteZeroID() {
 
 	// Create at least 1 item to avoid RowsEffectedCheck
 	_, err := s.repo.Create(
-		context.Background(), "system_bug",
+		context.Background(), "bug",
 		map[string]interface{}{
 			workitem.SystemTitle: "Title",
 			workitem.SystemState: workitem.SystemStateNew,
@@ -49,7 +49,7 @@ func (s *workItemRepoBlackBoxTest) TestFailSaveZeroID() {
 
 	// Create at least 1 item to avoid RowsEffectedCheck
 	wi, err := s.repo.Create(
-		context.Background(), "system_bug",
+		context.Background(), "bug",
 		map[string]interface{}{
 			workitem.SystemTitle: "Title",
 			workitem.SystemState: workitem.SystemStateNew,
@@ -69,7 +69,7 @@ func (s *workItemRepoBlackBoxTest) TestFaiLoadZeroID() {
 
 	// Create at least 1 item to avoid RowsEffectedCheck
 	_, err := s.repo.Create(
-		context.Background(), "system_bug",
+		context.Background(), "bug",
 		map[string]interface{}{
 			workitem.SystemTitle: "Title",
 			workitem.SystemState: workitem.SystemStateNew,
@@ -87,7 +87,7 @@ func (s *workItemRepoBlackBoxTest) TestSaveAssignees() {
 	defer gormsupport.DeleteCreatedEntities(s.DB)()
 
 	wi, err := s.repo.Create(
-		context.Background(), "system_bug",
+		context.Background(), "bug",
 		map[string]interface{}{
 			workitem.SystemTitle:     "Title",
 			workitem.SystemState:     workitem.SystemStateNew,
@@ -107,7 +107,7 @@ func (s *workItemRepoBlackBoxTest) TestSaveForUnchangedCreatedDate() {
 	defer gormsupport.DeleteCreatedEntities(s.DB)()
 
 	wi, err := s.repo.Create(
-		context.Background(), "system_bug",
+		context.Background(), "bug",
 		map[string]interface{}{
 			workitem.SystemTitle: "Title",
 			workitem.SystemState: workitem.SystemStateNew,

--- a/workitem/workitem_repository_blackbox_test.go
+++ b/workitem/workitem_repository_blackbox_test.go
@@ -30,7 +30,7 @@ func (s *workItemRepoBlackBoxTest) TestFailDeleteZeroID() {
 
 	// Create at least 1 item to avoid RowsEffectedCheck
 	_, err := s.repo.Create(
-		context.Background(), "system.bug",
+		context.Background(), "system_bug",
 		map[string]interface{}{
 			workitem.SystemTitle: "Title",
 			workitem.SystemState: workitem.SystemStateNew,
@@ -49,7 +49,7 @@ func (s *workItemRepoBlackBoxTest) TestFailSaveZeroID() {
 
 	// Create at least 1 item to avoid RowsEffectedCheck
 	wi, err := s.repo.Create(
-		context.Background(), "system.bug",
+		context.Background(), "system_bug",
 		map[string]interface{}{
 			workitem.SystemTitle: "Title",
 			workitem.SystemState: workitem.SystemStateNew,
@@ -69,7 +69,7 @@ func (s *workItemRepoBlackBoxTest) TestFaiLoadZeroID() {
 
 	// Create at least 1 item to avoid RowsEffectedCheck
 	_, err := s.repo.Create(
-		context.Background(), "system.bug",
+		context.Background(), "system_bug",
 		map[string]interface{}{
 			workitem.SystemTitle: "Title",
 			workitem.SystemState: workitem.SystemStateNew,
@@ -87,7 +87,7 @@ func (s *workItemRepoBlackBoxTest) TestSaveAssignees() {
 	defer gormsupport.DeleteCreatedEntities(s.DB)()
 
 	wi, err := s.repo.Create(
-		context.Background(), "system.bug",
+		context.Background(), "system_bug",
 		map[string]interface{}{
 			workitem.SystemTitle:     "Title",
 			workitem.SystemState:     workitem.SystemStateNew,
@@ -107,7 +107,7 @@ func (s *workItemRepoBlackBoxTest) TestSaveForUnchangedCreatedDate() {
 	defer gormsupport.DeleteCreatedEntities(s.DB)()
 
 	wi, err := s.repo.Create(
-		context.Background(), "system.bug",
+		context.Background(), "system_bug",
 		map[string]interface{}{
 			workitem.SystemTitle: "Title",
 			workitem.SystemState: workitem.SystemStateNew,

--- a/workitem/workitemtype.go
+++ b/workitem/workitemtype.go
@@ -54,6 +54,11 @@ type WorkItemType struct {
 	Fields FieldDefinitions `sql:"type:jsonb"`
 }
 
+// GetTypePathSeparator returns the work item type's path separator "."
+func GetTypePathSeparator() string {
+	return pathSep
+}
+
 // TableName implements gorm.tabler
 func (wit WorkItemType) TableName() string {
 	return "work_item_types"

--- a/workitem/workitemtype.go
+++ b/workitem/workitemtype.go
@@ -24,15 +24,15 @@ const (
 	SystemIteration    = "system.iteration"
 
 	// base item type with common fields for planner item types like userstory, experience, bug, feature, etc.
-	SystemPlannerItem = "system.planneritem"
+	SystemPlannerItem = "system_planneritem"
 
-	SystemUserStory        = "system.userstory"
-	SystemValueProposition = "system.valueproposition"
-	SystemFundamental      = "system.fundamental"
-	SystemExperience       = "system.experience"
-	SystemFeature          = "system.feature"
-	SystemScenario         = "system.scenario"
-	SystemBug              = "system.bug"
+	SystemUserStory        = "system_userstory"
+	SystemValueProposition = "system_valueproposition"
+	SystemFundamental      = "system_fundamental"
+	SystemExperience       = "system_experience"
+	SystemFeature          = "system_feature"
+	SystemScenario         = "system_scenario"
+	SystemBug              = "system_bug"
 
 	SystemStateOpen       = "open"
 	SystemStateNew        = "new"

--- a/workitem/workitemtype.go
+++ b/workitem/workitemtype.go
@@ -24,15 +24,15 @@ const (
 	SystemIteration    = "system.iteration"
 
 	// base item type with common fields for planner item types like userstory, experience, bug, feature, etc.
-	SystemPlannerItem = "system_planneritem"
+	SystemPlannerItem = "planneritem"
 
-	SystemUserStory        = "system_userstory"
-	SystemValueProposition = "system_valueproposition"
-	SystemFundamental      = "system_fundamental"
-	SystemExperience       = "system_experience"
-	SystemFeature          = "system_feature"
-	SystemScenario         = "system_scenario"
-	SystemBug              = "system_bug"
+	SystemUserStory        = "userstory"
+	SystemValueProposition = "valueproposition"
+	SystemFundamental      = "fundamental"
+	SystemExperience       = "experience"
+	SystemFeature          = "feature"
+	SystemScenario         = "scenario"
+	SystemBug              = "bug"
 
 	SystemStateOpen       = "open"
 	SystemStateNew        = "new"

--- a/workitem/workitemtype.go
+++ b/workitem/workitemtype.go
@@ -121,18 +121,18 @@ func (wit WorkItemType) ConvertFromModel(workItem WorkItem) (*app.WorkItem, erro
 // IsTypeOrSubtypeOf returns true if the work item type is of the given type name,
 // or a subtype; otherwise false is returned.
 func (wit WorkItemType) IsTypeOrSubtypeOf(typeName string) bool {
-	// Remove any prefixed "/"
+	// Remove any prefixed "."
 	for strings.HasPrefix(typeName, pathSep) && len(typeName) > 0 {
 		typeName = strings.TrimPrefix(typeName, pathSep)
 	}
-	// Remove any trailing "/"
+	// Remove any trailing "."
 	for strings.HasSuffix(typeName, pathSep) && len(typeName) > 0 {
 		typeName = strings.TrimSuffix(typeName, pathSep)
 	}
 	if len(typeName) <= 0 {
 		return false
 	}
-	// Check for complete inclusion (e.g. "/bar/" is contained in "/foo/bar/cake")
-	// and for suffix (e.g. "/cake" is the suffix of "/foo/bar/cake").
+	// Check for complete inclusion (e.g. "bar" is contained in "foo.bar.cake")
+	// and for suffix (e.g. ".cake" is the suffix of "foo.bar.cake").
 	return wit.Name == typeName || strings.Contains(wit.Path, pathSep+typeName+pathSep)
 }

--- a/workitem/workitemtype.go
+++ b/workitem/workitemtype.go
@@ -134,5 +134,5 @@ func (wit WorkItemType) IsTypeOrSubtypeOf(typeName string) bool {
 	}
 	// Check for complete inclusion (e.g. "bar" is contained in "foo.bar.cake")
 	// and for suffix (e.g. ".cake" is the suffix of "foo.bar.cake").
-	return wit.Name == typeName || strings.Contains(wit.Path, pathSep+typeName+pathSep)
+	return wit.Name == typeName || strings.Contains(wit.Path, typeName+pathSep)
 }

--- a/workitem/workitemtype.go
+++ b/workitem/workitemtype.go
@@ -12,7 +12,7 @@ import (
 // String constants for the local work item types.
 const (
 	// pathSep specifies the symbol used to concatenate WIT names to form a so called "path"
-	pathSep = "/"
+	pathSep = "."
 
 	SystemRemoteItemID = "system.remote_item_id"
 	SystemTitle        = "system.title"

--- a/workitem/workitemtype_blackbox_test.go
+++ b/workitem/workitemtype_blackbox_test.go
@@ -202,21 +202,21 @@ func TestWorkItemTypeIsTypeOrSubtypeOf(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 
 	// Test types and subtypes
-	assert.True(t, workitem.WorkItemType{Name: "foo", Path: "/foo"}.IsTypeOrSubtypeOf("foo"))
-	assert.True(t, workitem.WorkItemType{Name: "bar", Path: "/foo/bar"}.IsTypeOrSubtypeOf("foo"))
-	assert.True(t, workitem.WorkItemType{Name: "bar", Path: "/foo/bar"}.IsTypeOrSubtypeOf("bar"))
-	assert.True(t, workitem.WorkItemType{Name: "cake", Path: "/foo/bar/cake"}.IsTypeOrSubtypeOf("foo"))
-	assert.True(t, workitem.WorkItemType{Name: "cake", Path: "/foo/bar/cake"}.IsTypeOrSubtypeOf("bar"))
-	assert.True(t, workitem.WorkItemType{Name: "cake", Path: "/foo/bar/cake"}.IsTypeOrSubtypeOf("cake"))
+	assert.True(t, workitem.WorkItemType{Name: "foo", Path: "foo"}.IsTypeOrSubtypeOf("foo"))
+	assert.True(t, workitem.WorkItemType{Name: "bar", Path: "foo.bar"}.IsTypeOrSubtypeOf("foo"))
+	assert.True(t, workitem.WorkItemType{Name: "bar", Path: "foo.bar"}.IsTypeOrSubtypeOf("bar"))
+	assert.True(t, workitem.WorkItemType{Name: "cake", Path: "foo.bar.cake"}.IsTypeOrSubtypeOf("foo"))
+	assert.True(t, workitem.WorkItemType{Name: "cake", Path: "foo.bar.cake"}.IsTypeOrSubtypeOf("bar"))
+	assert.True(t, workitem.WorkItemType{Name: "cake", Path: "foo.bar.cake"}.IsTypeOrSubtypeOf("cake"))
 
 	// Test we actually do return false sometimes
-	assert.False(t, workitem.WorkItemType{Name: "cake", Path: "/foo/bar/cake"}.IsTypeOrSubtypeOf("fo"))
-	assert.False(t, workitem.WorkItemType{Name: "foo", Path: "/foo"}.IsTypeOrSubtypeOf("fo"))
+	assert.False(t, workitem.WorkItemType{Name: "cake", Path: "foo.bar.cake"}.IsTypeOrSubtypeOf("fo"))
+	assert.False(t, workitem.WorkItemType{Name: "foo", Path: "foo"}.IsTypeOrSubtypeOf("fo"))
 
 	// Test wrong argument with prefixed and trailing slashes
-	assert.False(t, workitem.WorkItemType{Name: "foo", Path: "/foo"}.IsTypeOrSubtypeOf(""))
-	assert.False(t, workitem.WorkItemType{Name: "foo", Path: "/foo"}.IsTypeOrSubtypeOf("/"))
-	assert.True(t, workitem.WorkItemType{Name: "foo", Path: "/foo"}.IsTypeOrSubtypeOf("/foo"))
-	assert.True(t, workitem.WorkItemType{Name: "foo", Path: "/foo"}.IsTypeOrSubtypeOf("/foo/"))
-	assert.True(t, workitem.WorkItemType{Name: "foo", Path: "/foo"}.IsTypeOrSubtypeOf("foo/"))
+	assert.False(t, workitem.WorkItemType{Name: "foo", Path: "foo"}.IsTypeOrSubtypeOf(""))
+	assert.False(t, workitem.WorkItemType{Name: "foo", Path: "foo"}.IsTypeOrSubtypeOf("."))
+	assert.True(t, workitem.WorkItemType{Name: "foo", Path: "foo"}.IsTypeOrSubtypeOf("foo."))
+	assert.True(t, workitem.WorkItemType{Name: "foo", Path: "foo"}.IsTypeOrSubtypeOf(".foo"))
+	assert.True(t, workitem.WorkItemType{Name: "foo", Path: "foo"}.IsTypeOrSubtypeOf(".foo."))
 }

--- a/workitem/workitemtype_repository.go
+++ b/workitem/workitemtype_repository.go
@@ -72,12 +72,11 @@ func (r *GormWorkItemTypeRepository) Create(ctx context.Context, extendedTypeNam
 		return nil, errors.NewBadParameterError("name", name)
 	}
 	allFields := map[string]FieldDefinition{}
-	path := pathSep + name
+	path := name
 	if extendedTypeName != nil {
 		extendedType := WorkItemType{}
 		db := r.db.First(&extendedType, extendedTypeName)
 		if db.RecordNotFound() {
-			log.Printf("not found, res=%v", extendedType)
 			return nil, errors.NewBadParameterError("extendedTypeName", *extendedTypeName)
 		}
 		if err := db.Error; err != nil {

--- a/workitem/workitemtype_repository_blackbox_test.go
+++ b/workitem/workitemtype_repository_blackbox_test.go
@@ -27,7 +27,7 @@ func TestRunWorkItemTypeRepoBlackBoxTest(t *testing.T) {
 func (s *workItemTypeRepoBlackBoxTest) SetupTest() {
 	s.undoScript = &gormsupport.DBScript{}
 	s.repo = workitem.NewUndoableWorkItemTypeRepository(workitem.NewWorkItemTypeRepository(s.DB), s.undoScript)
-	db2 := s.DB.Unscoped().Delete(workitem.WorkItemType{Name: "foo.bar"})
+	db2 := s.DB.Unscoped().Delete(workitem.WorkItemType{Name: "foo_bar"})
 
 	if db2.Error != nil {
 		s.T().Fatalf("Could not setup test %s", db2.Error.Error())
@@ -41,7 +41,7 @@ func (s *workItemTypeRepoBlackBoxTest) TearDownTest() {
 
 func (s *workItemTypeRepoBlackBoxTest) TestCreateLoadWIT() {
 
-	wit, err := s.repo.Create(context.Background(), nil, "foo.bar", map[string]app.FieldDefinition{
+	wit, err := s.repo.Create(context.Background(), nil, "foo_bar", map[string]app.FieldDefinition{
 		"foo": app.FieldDefinition{
 			Required: true,
 			Type:     &app.FieldType{Kind: string(workitem.KindFloat)},
@@ -50,11 +50,11 @@ func (s *workItemTypeRepoBlackBoxTest) TestCreateLoadWIT() {
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), wit)
 
-	wit3, err := s.repo.Create(context.Background(), nil, "foo.bar", map[string]app.FieldDefinition{})
+	wit3, err := s.repo.Create(context.Background(), nil, "foo_bar", map[string]app.FieldDefinition{})
 	assert.IsType(s.T(), errors.BadParameterError{}, err)
 	assert.Nil(s.T(), wit3)
 
-	wit2, err := s.repo.Load(context.Background(), "foo.bar")
+	wit2, err := s.repo.Load(context.Background(), "foo_bar")
 	assert.Nil(s.T(), err)
 	require.NotNil(s.T(), wit2)
 	field := wit2.Fields["foo"]
@@ -68,7 +68,7 @@ func (s *workItemTypeRepoBlackBoxTest) TestCreateLoadWIT() {
 
 func (s *workItemTypeRepoBlackBoxTest) TestCreateLoadWITWithList() {
 	bt := "string"
-	wit, err := s.repo.Create(context.Background(), nil, "foo.bar", map[string]app.FieldDefinition{
+	wit, err := s.repo.Create(context.Background(), nil, "foo_bar", map[string]app.FieldDefinition{
 		"foo": app.FieldDefinition{
 			Required: true,
 			Type: &app.FieldType{
@@ -80,11 +80,11 @@ func (s *workItemTypeRepoBlackBoxTest) TestCreateLoadWITWithList() {
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), wit)
 
-	wit3, err := s.repo.Create(context.Background(), nil, "foo.bar", map[string]app.FieldDefinition{})
+	wit3, err := s.repo.Create(context.Background(), nil, "foo_bar", map[string]app.FieldDefinition{})
 	assert.IsType(s.T(), errors.BadParameterError{}, err)
 	assert.Nil(s.T(), wit3)
 
-	wit2, err := s.repo.Load(context.Background(), "foo.bar")
+	wit2, err := s.repo.Load(context.Background(), "foo_bar")
 	assert.Nil(s.T(), err)
 	require.NotNil(s.T(), wit2)
 	field := wit2.Fields["foo"]

--- a/workitem_blackbox_test.go
+++ b/workitem_blackbox_test.go
@@ -579,7 +579,7 @@ func (s *WorkItem2Suite) SetupSuite() {
 	s.wi2Ctrl = NewWorkitemController(s.svc, gormapplication.NewGormDB(s.db))
 	require.NotNil(s.T(), s.wi2Ctrl)
 
-	// Make sure the database is populated with the correct types (e.g. system.bug etc.)
+	// Make sure the database is populated with the correct types (e.g. system_bug etc.)
 	if configuration.GetPopulateCommonTypes() {
 		if err := models.Transactional(s.db, func(tx *gorm.DB) error {
 			return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))
@@ -745,7 +745,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWorkItem() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system.bug",
+				ID:   "system_bug",
 			},
 		},
 	}
@@ -780,7 +780,7 @@ func (s *WorkItem2Suite) TestWI2FailCreateWtihAssigneeAsField() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system.bug",
+				ID:   "system_bug",
 			},
 		},
 	}
@@ -803,7 +803,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWithAssigneeRelation() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system.bug",
+				ID:   "system_bug",
 			},
 		},
 		Assignees: &app.RelationGenericList{
@@ -834,7 +834,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWithAssigneesRelation() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system.bug",
+				ID:   "system_bug",
 			},
 		},
 		Assignees: &app.RelationGenericList{
@@ -880,7 +880,7 @@ func (s *WorkItem2Suite) TestWI2ListByAssigneeFilter() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system.bug",
+				ID:   "system_bug",
 			},
 		},
 		Assignees: &app.RelationGenericList{
@@ -913,7 +913,7 @@ func (s *WorkItem2Suite) TestWI2FailCreateInvalidAssignees() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system.bug",
+				ID:   "system_bug",
 			},
 		},
 		Assignees: &app.RelationGenericList{
@@ -934,7 +934,7 @@ func (s *WorkItem2Suite) TestWI2FailUpdateInvalidAssignees() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system.bug",
+				ID:   "system_bug",
 			},
 		},
 		Assignees: &app.RelationGenericList{
@@ -969,7 +969,7 @@ func (s *WorkItem2Suite) TestWI2SuccessUpdateWithAssigneesRelation() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system.bug",
+				ID:   "system_bug",
 			},
 		},
 		Assignees: &app.RelationGenericList{
@@ -995,7 +995,7 @@ func (s *WorkItem2Suite) TestWI2SuccessShow() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system.bug",
+				ID:   "system_bug",
 			},
 		},
 	}
@@ -1024,7 +1024,7 @@ func (s *WorkItem2Suite) TestWI2SuccessDelete() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system.bug",
+				ID:   "system_bug",
 			},
 		},
 	}
@@ -1052,7 +1052,7 @@ func (s *WorkItem2Suite) TestWI2CreateWithIteration() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system.bug",
+				ID:   "system_bug",
 			},
 		},
 		Iteration: &app.RelationGeneric{
@@ -1081,7 +1081,7 @@ func (s *WorkItem2Suite) TestWI2UpdateWithIteration() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system.bug",
+				ID:   "system_bug",
 			},
 		},
 	}
@@ -1122,7 +1122,7 @@ func (s *WorkItem2Suite) TestWI2UpdateRemoveIteration() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system.bug",
+				ID:   "system_bug",
 			},
 		},
 		Iteration: &app.RelationGeneric{
@@ -1162,7 +1162,7 @@ func (s *WorkItem2Suite) TestWI2CreateUnknownIteration() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system.bug",
+				ID:   "system_bug",
 			},
 		},
 		Iteration: &app.RelationGeneric{

--- a/workitem_blackbox_test.go
+++ b/workitem_blackbox_test.go
@@ -579,7 +579,7 @@ func (s *WorkItem2Suite) SetupSuite() {
 	s.wi2Ctrl = NewWorkitemController(s.svc, gormapplication.NewGormDB(s.db))
 	require.NotNil(s.T(), s.wi2Ctrl)
 
-	// Make sure the database is populated with the correct types (e.g. system_bug etc.)
+	// Make sure the database is populated with the correct types (e.g. bug etc.)
 	if configuration.GetPopulateCommonTypes() {
 		if err := models.Transactional(s.db, func(tx *gorm.DB) error {
 			return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))
@@ -745,7 +745,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWorkItem() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system_bug",
+				ID:   "bug",
 			},
 		},
 	}
@@ -780,7 +780,7 @@ func (s *WorkItem2Suite) TestWI2FailCreateWtihAssigneeAsField() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system_bug",
+				ID:   "bug",
 			},
 		},
 	}
@@ -803,7 +803,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWithAssigneeRelation() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system_bug",
+				ID:   "bug",
 			},
 		},
 		Assignees: &app.RelationGenericList{
@@ -834,7 +834,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWithAssigneesRelation() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system_bug",
+				ID:   "bug",
 			},
 		},
 		Assignees: &app.RelationGenericList{
@@ -880,7 +880,7 @@ func (s *WorkItem2Suite) TestWI2ListByAssigneeFilter() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system_bug",
+				ID:   "bug",
 			},
 		},
 		Assignees: &app.RelationGenericList{
@@ -913,7 +913,7 @@ func (s *WorkItem2Suite) TestWI2FailCreateInvalidAssignees() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system_bug",
+				ID:   "bug",
 			},
 		},
 		Assignees: &app.RelationGenericList{
@@ -934,7 +934,7 @@ func (s *WorkItem2Suite) TestWI2FailUpdateInvalidAssignees() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system_bug",
+				ID:   "bug",
 			},
 		},
 		Assignees: &app.RelationGenericList{
@@ -969,7 +969,7 @@ func (s *WorkItem2Suite) TestWI2SuccessUpdateWithAssigneesRelation() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system_bug",
+				ID:   "bug",
 			},
 		},
 		Assignees: &app.RelationGenericList{
@@ -995,7 +995,7 @@ func (s *WorkItem2Suite) TestWI2SuccessShow() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system_bug",
+				ID:   "bug",
 			},
 		},
 	}
@@ -1024,7 +1024,7 @@ func (s *WorkItem2Suite) TestWI2SuccessDelete() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system_bug",
+				ID:   "bug",
 			},
 		},
 	}
@@ -1052,7 +1052,7 @@ func (s *WorkItem2Suite) TestWI2CreateWithIteration() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system_bug",
+				ID:   "bug",
 			},
 		},
 		Iteration: &app.RelationGeneric{
@@ -1081,7 +1081,7 @@ func (s *WorkItem2Suite) TestWI2UpdateWithIteration() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system_bug",
+				ID:   "bug",
 			},
 		},
 	}
@@ -1122,7 +1122,7 @@ func (s *WorkItem2Suite) TestWI2UpdateRemoveIteration() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system_bug",
+				ID:   "bug",
 			},
 		},
 		Iteration: &app.RelationGeneric{
@@ -1162,7 +1162,7 @@ func (s *WorkItem2Suite) TestWI2CreateUnknownIteration() {
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
 				Type: "workitemtypes",
-				ID:   "system_bug",
+				ID:   "bug",
 			},
 		},
 		Iteration: &app.RelationGeneric{

--- a/workitem_whitebox_test.go
+++ b/workitem_whitebox_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 		}
 		defer DB.Close()
 
-		// Make sure the database is populated with the correct types (e.g. system.bug etc.)
+		// Make sure the database is populated with the correct types (e.g. system_bug etc.)
 		if configuration.GetPopulateCommonTypes() {
 			if err := models.Transactional(DB, func(tx *gorm.DB) error {
 				return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))

--- a/workitem_whitebox_test.go
+++ b/workitem_whitebox_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 		}
 		defer DB.Close()
 
-		// Make sure the database is populated with the correct types (e.g. system_bug etc.)
+		// Make sure the database is populated with the correct types (e.g. bug etc.)
 		if configuration.GetPopulateCommonTypes() {
 			if err := models.Transactional(DB, func(tx *gorm.DB) error {
 				return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))

--- a/workitemtype_blackbox_test.go
+++ b/workitemtype_blackbox_test.go
@@ -56,7 +56,7 @@ func (s *WorkItemTypeSuite) SetupSuite() {
 	s.typeCtrl = NewWorkitemtypeController(svc, gormapplication.NewGormDB(s.db))
 	assert.NotNil(s.T(), s.typeCtrl)
 
-	// Make sure the database is populated with the correct types (e.g. system.bug etc.)
+	// Make sure the database is populated with the correct types (e.g. system_bug etc.)
 	if configuration.GetPopulateCommonTypes() {
 		if err := models.Transactional(s.db, func(tx *gorm.DB) error {
 			return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))

--- a/workitemtype_blackbox_test.go
+++ b/workitemtype_blackbox_test.go
@@ -56,7 +56,7 @@ func (s *WorkItemTypeSuite) SetupSuite() {
 	s.typeCtrl = NewWorkitemtypeController(svc, gormapplication.NewGormDB(s.db))
 	assert.NotNil(s.T(), s.typeCtrl)
 
-	// Make sure the database is populated with the correct types (e.g. system_bug etc.)
+	// Make sure the database is populated with the correct types (e.g. bug etc.)
 	if configuration.GetPopulateCommonTypes() {
 		if err := models.Transactional(s.db, func(tx *gorm.DB) error {
 			return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))


### PR DESCRIPTION
In #549 I've talked about using ltree for work item type's `path` field because it simplifies building a type hierarchy and checking for sub-types.

In ltree a hierarchy is stored like this: `grandparent.parent.child`. WITs on the other hand were stored as `/system.planneritem/system.bug`.

This changes transform each WIT `path` field from for instance `/system.planneritem/system.bug` to `planneritem.bug`. Notice, that the `system.` prefix has been removed as discussed with @aslakknutsen .

The values for the WIT's `name` fields will then be set to the `path`'s leaf (`subpath(path,-1,1)`).

The prefix `system.` for WITs has been removed from the whole codebase. It remained in places where it is used for attributes (e.g. `system.title`).

**NOTE:** WIT names cannot have spaces in them any longer because only C-LOCALE characters are allowed [a-zA-Z0-9_].

## Some tips on querying the ltree using SQL:

### Get the leaf names by looking just at the paths

```sql
SELECT path, subpath(path,-1,1) FROM work_item_types;
```

outputs:

```
      path           | subpath 
---------------------+---------
 planneritem.bug     | bug
 planneritem.feature | feature
```

### Find subtypes of `planneritem` (including itself)

```sql
SELECT name, path FROM work_item_types WHERE path ~ 'planneritem.*';
```

outputs:

```
    name     |         path          
-------------+-----------------------
 bug         | planneritem.bug
 feature     | planneritem.feature
 userstory   | planneritem.userstory
 planneritem | planneritem
```