### PR TITLE
WIP : Added `states` to iterations.

### DIFF
--- a/design/iterations.go
+++ b/design/iterations.go
@@ -33,6 +33,9 @@ var iterationAttributes = a.Type("IterationAttributes", func() {
 	a.Attribute("endAt", d.DateTime, "When the iteration ends", func() {
 		a.Example("2016-11-29T23:18:14Z")
 	})
+	a.Attribute("state", d.String, "State of an iteration", func() {
+		a.Enum("new", "start", "close")
+	})
 })
 
 var iterationRelationships = a.Type("IterationRelations", func() {

--- a/iteration.go
+++ b/iteration.go
@@ -119,7 +119,15 @@ func (c *IterationController) Update(ctx *app.UpdateIterationContext) error {
 		if ctx.Payload.Data.Attributes.Description != nil {
 			itr.Description = ctx.Payload.Data.Attributes.Description
 		}
-
+		if ctx.Payload.Data.Attributes.State != nil {
+			if *ctx.Payload.Data.Attributes.State == iteration.IterationStateStart {
+				res, err := appl.Iterations().CanStartIteration(ctx, itr)
+				if res == false && err != nil {
+					return jsonapi.JSONErrorResponse(ctx, err)
+				}
+			}
+			itr.State = *ctx.Payload.Data.Attributes.State
+		}
 		itr, err = appl.Iterations().Save(ctx.Context, *itr)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
@@ -164,6 +172,7 @@ func ConvertIteration(request *goa.RequestData, itr *iteration.Iteration, additi
 			StartAt:     itr.StartAt,
 			EndAt:       itr.EndAt,
 			Description: itr.Description,
+			State:       &itr.State,
 		},
 		Relationships: &app.IterationRelations{
 			Space: &app.RelationGeneric{

--- a/iteration/iteration_test.go
+++ b/iteration/iteration_test.go
@@ -94,7 +94,7 @@ func (test *TestIterationRepository) TestCreateChildIteration() {
 	repo.Create(context.Background(), &i2)
 
 	i2L, err := repo.Load(context.Background(), i2.ID)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.NotEqual(t, uuid.Nil, i2.ParentID)
 	assert.Equal(t, i2.ParentID, i2L.ParentID)
 }

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -133,6 +133,9 @@ func getMigrations() migrations {
 	// Version 18
 	m = append(m, steps{executeSQLFile("018-rewrite-wits.sql")})
 
+	// Version 19
+	m = append(m, steps{executeSQLFile("019-add-state-iterations.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/019-add-state-iterations.sql
+++ b/migration/sql-files/019-add-state-iterations.sql
@@ -1,0 +1,2 @@
+CREATE TYPE iteration_state AS ENUM ('new', 'start', 'close');
+ALTER TABLE iterations ADD state iteration_state DEFAULT 'new';

--- a/space-iterations_test.go
+++ b/space-iterations_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -72,9 +73,10 @@ func (rest *TestSpaceIterationREST) TestSuccessCreateIteration() {
 	})
 	svc, ctrl := rest.SecuredController()
 	_, c := test.CreateSpaceIterationsCreated(t, svc.Context, svc, ctrl, p.ID.String(), ci)
-	assert.NotNil(t, c.Data.ID)
-	assert.NotNil(t, c.Data.Relationships.Space)
+	require.NotNil(t, c.Data.ID)
+	require.NotNil(t, c.Data.Relationships.Space)
 	assert.Equal(t, p.ID.String(), *c.Data.Relationships.Space.Data.ID)
+	assert.Equal(t, iteration.IterationStateNew, *c.Data.Attributes.State)
 }
 
 func (rest *TestSpaceIterationREST) TestSuccessCreateIterationWithOptionalValues() {

--- a/workitem.go
+++ b/workitem.go
@@ -21,6 +21,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
+// Defines the constants to be used in json api "type" attribute
 const (
 	APIStringTypeUser         = "identities"
 	APIStringTypeWorkItem     = "workitems"


### PR DESCRIPTION
As per this [comment](https://github.com/fabric8io/fabric8-planner/issues/647#issuecomment-272883624) by Todd and related discussion on [issue-647](https://github.com/fabric8io/fabric8-planner/issues/647), it was clear that start/close/create iteration should be very flexible and no-automation needed while deciding the state. Hence added three new states to the iteration in core. By looking at this attribute, UI can decide where to put each iteration.

* Iteration state can be "new" or "start" or "close".
* By default newly created iteration will have state="new".
* When user wants to start iteration, call update API with state="start"
* When user wants to close iteration, call update API with state="close"
* If there is already an iteration with state=start then another iteration can not be started if it is in the same space.
