### PR TITLE
Fix Spaces API returning the same object for all found Spaces

### DIFF
--- a/space/space.go
+++ b/space/space.go
@@ -130,6 +130,7 @@ func (r *GormRepository) Save(ctx context.Context, p Space) (*Space, error) {
 func (r *GormRepository) Create(ctx context.Context, name string) (*Space, error) {
 	newSpace := Space{
 		Name: name,
+		ID:   satoriuuid.NewV4(),
 	}
 
 	tx := r.db.Create(&newSpace)
@@ -173,7 +174,6 @@ func (r *GormRepository) listSpaceFromDB(ctx context.Context, start *int, limit 
 	defer rows.Close()
 
 	result := []*Space{}
-	value := Space{}
 	columns, err := rows.Columns()
 	if err != nil {
 		return nil, 0, errors.NewInternalError(err.Error())
@@ -191,6 +191,7 @@ func (r *GormRepository) listSpaceFromDB(ctx context.Context, start *int, limit 
 	first := true
 
 	for rows.Next() {
+		value := Space{}
 		db.ScanRows(rows, &value)
 		if first {
 			first = false
@@ -199,7 +200,6 @@ func (r *GormRepository) listSpaceFromDB(ctx context.Context, start *int, limit 
 			}
 		}
 		result = append(result, &value)
-
 	}
 	if first {
 		// means 0 rows were returned from the first query (maybe becaus of offset outside of total count),

--- a/space/space_test.go
+++ b/space/space_test.go
@@ -98,6 +98,14 @@ func (test *repoBBTest) TestList() {
 	assert.Equal(test.T(), orgCount+1, newCount)
 }
 
+func (test *repoBBTest) TestListDoNotReturnPointerToSameObject() {
+	expectSpace(test.create(testSpace), test.requireOk)
+	expectSpace(test.create(testSpace2), test.requireOk)
+	spaces, newCount, _ := test.list(nil, nil)
+	assert.True(test.T(), newCount >= 2)
+	assert.True(test.T(), spaces[0].Name != spaces[1].Name)
+}
+
 type spaceExpectation func(p *space.Space, err error)
 
 func expectSpace(f func() (*space.Space, error), e spaceExpectation) (*space.Space, error) {

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -214,7 +214,6 @@ func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, criteria c
 	defer rows.Close()
 
 	result := []WorkItem{}
-	value := WorkItem{}
 	columns, err := rows.Columns()
 	if err != nil {
 		return nil, 0, errors.NewInternalError(err.Error())
@@ -232,6 +231,7 @@ func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, criteria c
 	first := true
 
 	for rows.Next() {
+		value := WorkItem{}
 		db.ScanRows(rows, &value)
 		if first {
 			first = false


### PR DESCRIPTION
The scope of the pointer reference was being reused outside of the scope
of the loop.
