### PR TITLE
Use gravatar as an avatar image for authorized users

### DIFF
--- a/login/service_whitebox_test.go
+++ b/login/service_whitebox_test.go
@@ -69,10 +69,6 @@ func TestInvalidOAuthAccessToken(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	if loginService == nil {
-		setup()
-	}
-
 	invalidAccessToken := "7423742yuuiy-INVALID-73842342389h"
 
 	accessToken := &oauth2.Token{
@@ -89,4 +85,11 @@ func TestGetUser(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 
 	t.Skip("Not implemented")
+}
+
+func TestGravatarURLGeneration(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	grURL, err := generateGravatarURL("alkazako@redhat.com")
+	assert.Nil(t, err)
+	assert.Equal(t, "https://www.gravatar.com/avatar/0fa6cfaa2812a200c566f671803cdf2d.jpg", grURL)
 }


### PR DESCRIPTION
Fixes #671

Keycloak currently doesn't provide user's avatars. This PR generates a gravatar URL by user's email and save it as avatar URL.

How it looks in case of existing gravatar:

![screenshot from 2017-01-23 14-57-40](https://cloud.githubusercontent.com/assets/620087/22229906/6e269090-e18f-11e6-8f34-a5e57c0afea9.png)

And if there is no gravatar for this email then the generated gravatar URL will refers to the default gravatar:

![screenshot from 2017-01-23 14-57-07](https://cloud.githubusercontent.com/assets/620087/22229941/aeb5687a-e18f-11e6-83ff-30334744ede7.png)

If we want to use our own default image then we should add it to all the generated URLs as the following param:

`https://www.gravatar.com/avatar/<hash>.jpg?d=<defultImageURL>`

The d= param will be ignored by gravatar.com if there is an existing image for that email. IMO we should add ?d=... on the UI side instead of hardcoding it in backend.
cc: @joshuawilson 