### PR TITLE
Prevent creating workitem with empty title

### DIFF
--- a/workitem.go
+++ b/workitem.go
@@ -322,9 +322,6 @@ func ConvertJSONAPIToWorkItem(appl application.Application, source app.WorkItem2
 		}
 	}
 
-	if title, ok := source.Attributes[workitem.SystemTitle]; !ok || title == "" {
-		return errors.NewBadParameterError("data.attributes["+workitem.SystemTitle+"]", source.Attributes[workitem.SystemTitle])
-	}
 	for key, val := range source.Attributes {
 		// convert legacy description to markup content
 		if key == workitem.SystemDescription && reflect.TypeOf(val).Kind() == reflect.String {

--- a/workitem.go
+++ b/workitem.go
@@ -172,21 +172,29 @@ func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
 	}
 
 	return application.Transactional(c.db, func(appl application.Application) error {
-		ConvertJSONAPIToWorkItem(appl, *ctx.Payload.Data, &wi)
-
-		wi, err := appl.WorkItems().Create(ctx, *wit, wi.Fields, currentUser)
+		err = ConvertJSONAPIToWorkItem(appl, *ctx.Payload.Data, &wi)
 		if err != nil {
+			message := fmt.Sprintf("Error creating work item: %s", err.Error())
 			cause := errs.Cause(err)
 			switch cause.(type) {
-			case errors.BadParameterError:
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
-				return ctx.BadRequest(jerrors)
-			case errors.VersionConflictError:
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
+			case errors.BadParameterError, errors.VersionConflictError, errors.ConversionError:
+				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(message))
 				return ctx.BadRequest(jerrors)
 			default:
-				log.Printf("Error updating work items: %s", err.Error())
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInternal(err.Error()))
+				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInternal(message))
+				return ctx.InternalServerError(jerrors)
+			}
+		}
+		wi, err := appl.WorkItems().Create(ctx, *wit, wi.Fields, currentUser)
+		if err != nil {
+			message := fmt.Sprintf("Error creating work item: %s", err.Error())
+			cause := errs.Cause(err)
+			switch cause.(type) {
+			case errors.BadParameterError, errors.VersionConflictError, errors.ConversionError:
+				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(message))
+				return ctx.BadRequest(jerrors)
+			default:
+				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInternal(message))
 				return ctx.InternalServerError(jerrors)
 			}
 		}
@@ -216,10 +224,7 @@ func (c *WorkitemController) Show(ctx *app.ShowWorkitemContext) error {
 			case errors.NotFoundError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrNotFound(err.Error()))
 				return ctx.NotFound(jerrors)
-			case errors.BadParameterError:
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
-				return ctx.BadRequest(jerrors)
-			case errors.VersionConflictError:
+			case errors.BadParameterError, errors.VersionConflictError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
 				return ctx.BadRequest(jerrors)
 			default:
@@ -248,14 +253,11 @@ func (c *WorkitemController) Delete(ctx *app.DeleteWorkitemContext) error {
 			case errors.NotFoundError:
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrNotFound(err.Error()))
 				return ctx.NotFound(jerrors)
-			case errors.BadParameterError:
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
-				return ctx.BadRequest(jerrors)
-			case errors.VersionConflictError:
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
+			case errors.BadParameterError, errors.VersionConflictError:
+				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error deleting work item: %s", err.Error())))
 				return ctx.BadRequest(jerrors)
 			default:
-				log.Printf("Error updating work items: %s", err.Error())
+				log.Printf("Error deleting work items: %s", err.Error())
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInternal(err.Error()))
 				return ctx.InternalServerError(jerrors)
 			}
@@ -268,7 +270,6 @@ func (c *WorkitemController) Delete(ctx *app.DeleteWorkitemContext) error {
 // response resource object by jsonapi.org specifications
 func ConvertJSONAPIToWorkItem(appl application.Application, source app.WorkItem2, target *app.WorkItem) error {
 	// construct default values from input WI
-
 	var version = -1
 	if source.Attributes["version"] != nil {
 		v, err := strconv.Atoi(fmt.Sprintf("%v", source.Attributes["version"]))
@@ -319,6 +320,10 @@ func ConvertJSONAPIToWorkItem(appl application.Application, source app.WorkItem2
 		if source.Relationships.BaseType.Data != nil {
 			target.Type = source.Relationships.BaseType.Data.ID
 		}
+	}
+
+	if title, ok := source.Attributes[workitem.SystemTitle]; !ok || title == "" {
+		return errors.NewBadParameterError("data.attributes["+workitem.SystemTitle+"]", source.Attributes[workitem.SystemTitle])
 	}
 	for key, val := range source.Attributes {
 		// convert legacy description to markup content

--- a/workitem/field_definition.go
+++ b/workitem/field_definition.go
@@ -70,7 +70,6 @@ func (self FieldDefinition) Equal(u convert.Equaler) bool {
 
 // ConvertToModel converts a field value for use in the persistence layer
 func (f FieldDefinition) ConvertToModel(name string, value interface{}) (interface{}, error) {
-	fmt.Println(fmt.Sprintf("Converting attribute '%s' (required: %t) with value: '%v'", name, f.Required, value))
 	if f.Required && (value == nil || (f.Type.GetKind() == KindString && strings.TrimSpace(value.(string)) == "")) {
 		return nil, fmt.Errorf("Value %s is required", name)
 	}

--- a/workitem/field_definition.go
+++ b/workitem/field_definition.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"strings"
+
 	"github.com/almighty/almighty-core/convert"
 	"github.com/pkg/errors"
 )
@@ -68,7 +70,8 @@ func (self FieldDefinition) Equal(u convert.Equaler) bool {
 
 // ConvertToModel converts a field value for use in the persistence layer
 func (f FieldDefinition) ConvertToModel(name string, value interface{}) (interface{}, error) {
-	if f.Required && value == nil {
+	fmt.Println(fmt.Sprintf("Converting attribute '%s' (required: %t) with value: '%v'", name, f.Required, value))
+	if f.Required && (value == nil || (f.Type.GetKind() == KindString && strings.TrimSpace(value.(string)) == "")) {
 		return nil, fmt.Errorf("Value %s is required", name)
 	}
 	return f.Type.ConvertToModel(value)

--- a/workitem_whitebox_test.go
+++ b/workitem_whitebox_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/configuration"
-	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/migration"
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/remoteworkitem"
@@ -249,23 +248,27 @@ func TestConvertJSONAPIToWorkItemWithTitle(t *testing.T) {
 }
 
 func TestConvertJSONAPIToWorkItemWithMissingTitle(t *testing.T) {
+	// given
 	appl := new(application.Application)
 	attributes := map[string]interface{}{}
 	source := app.WorkItem2{Type: workitem.SystemBug, Attributes: attributes}
 	target := &app.WorkItem{Fields: map[string]interface{}{}}
+	// when
 	err := ConvertJSONAPIToWorkItem(*appl, source, target)
-	require.NotNil(t, err)
-	assert.IsType(t, errors.BadParameterError{}, err)
+	// then: no error expected at this level, even though the title is missing
+	require.Nil(t, err)
 }
 
 func TestConvertJSONAPIToWorkItemWithEmptyTitle(t *testing.T) {
+	// given
 	appl := new(application.Application)
 	attributes := map[string]interface{}{
 		workitem.SystemTitle: "",
 	}
 	source := app.WorkItem2{Type: workitem.SystemBug, Attributes: attributes}
 	target := &app.WorkItem{Fields: map[string]interface{}{}}
+	// when
 	err := ConvertJSONAPIToWorkItem(*appl, source, target)
-	require.NotNil(t, err)
-	assert.IsType(t, errors.BadParameterError{}, err)
+	// then: no error expected at this level, even though the title is missing
+	require.Nil(t, err)
 }

--- a/workitem_whitebox_test.go
+++ b/workitem_whitebox_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/configuration"
+	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/migration"
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/remoteworkitem"
@@ -230,4 +231,41 @@ func TestConvertJSONAPIToWorkItemWithDescriptionContentAndMarkup(t *testing.T) {
 	require.NotNil(t, target.Fields)
 	expectedDescription := workitem.MarkupContent{Content: "description", Markup: workitem.SystemMarkupMarkdown}
 	assert.Equal(t, expectedDescription, target.Fields[workitem.SystemDescription])
+}
+
+func TestConvertJSONAPIToWorkItemWithTitle(t *testing.T) {
+	title := "title"
+	appl := new(application.Application)
+	attributes := map[string]interface{}{
+		workitem.SystemTitle: title,
+	}
+	source := app.WorkItem2{Type: workitem.SystemBug, Attributes: attributes}
+	target := &app.WorkItem{Fields: map[string]interface{}{}}
+	err := ConvertJSONAPIToWorkItem(*appl, source, target)
+	require.Nil(t, err)
+	require.NotNil(t, target)
+	require.NotNil(t, target.Fields)
+	assert.Equal(t, title, target.Fields[workitem.SystemTitle])
+}
+
+func TestConvertJSONAPIToWorkItemWithMissingTitle(t *testing.T) {
+	appl := new(application.Application)
+	attributes := map[string]interface{}{}
+	source := app.WorkItem2{Type: workitem.SystemBug, Attributes: attributes}
+	target := &app.WorkItem{Fields: map[string]interface{}{}}
+	err := ConvertJSONAPIToWorkItem(*appl, source, target)
+	require.NotNil(t, err)
+	assert.IsType(t, errors.BadParameterError{}, err)
+}
+
+func TestConvertJSONAPIToWorkItemWithEmptyTitle(t *testing.T) {
+	appl := new(application.Application)
+	attributes := map[string]interface{}{
+		workitem.SystemTitle: "",
+	}
+	source := app.WorkItem2{Type: workitem.SystemBug, Attributes: attributes}
+	target := &app.WorkItem{Fields: map[string]interface{}{}}
+	err := ConvertJSONAPIToWorkItem(*appl, source, target)
+	require.NotNil(t, err)
+	assert.IsType(t, errors.BadParameterError{}, err)
 }


### PR DESCRIPTION
Added a validation step in the `ConvertJSONAPIToWorkItem`
function to verify that the `system.title` is not nil nor
empty.

Refactored some error handling switches to remove duplicate
code

Added tests.

Fixes #462

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
