### PR TITLE
Issue 698 : simplify error handling workitem

### DIFF
--- a/workitem.go
+++ b/workitem.go
@@ -87,6 +87,7 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 		}
 		wi, err := appl.WorkItems().Load(ctx, *ctx.Payload.Data.ID)
 		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(fmt.Sprintf("Fail to load work item with id %v", *ctx.Payload.Data.ID)))
 		}
 		if wi == nil {
 			return jsonapi.JSONErrorResponse(ctx, errors.NewNotFoundError("work item", *ctx.Payload.Data.ID))

--- a/workitem.go
+++ b/workitem.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 
 	"golang.org/x/net/context"
@@ -49,11 +48,9 @@ func NewWorkitemController(service *goa.Service, db application.DB) *WorkitemCon
 // Last will always be present. Total Item count needs to be computed from the "Last" link.
 func (c *WorkitemController) List(ctx *app.ListWorkitemContext) error {
 	var additionalQuery []string
-
 	exp, err := query.Parse(ctx.Filter)
 	if err != nil {
-		jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("could not parse filter: %s", err.Error())))
-		return ctx.BadRequest(jerrors)
+		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("could not parse filter", err))
 	}
 	if ctx.FilterAssignee != nil {
 		assignee := ctx.FilterAssignee
@@ -66,65 +63,46 @@ func (c *WorkitemController) List(ctx *app.ListWorkitemContext) error {
 		additionalQuery = append(additionalQuery, "filter[iteration]="+*iteration)
 	}
 	offset, limit := computePagingLimts(ctx.PageOffset, ctx.PageLimit)
-
 	return application.Transactional(c.db, func(tx application.Application) error {
 		result, tc, err := tx.WorkItems().List(ctx.Context, exp, &offset, &limit)
 		count := int(tc)
 		if err != nil {
-			cause := errs.Cause(err)
-			switch cause.(type) {
-			case errors.BadParameterError:
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error listing work items: %s", err.Error())))
-				return ctx.BadRequest(jerrors)
-			default:
-				log.Printf("Error listing work items: %s", err.Error())
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInternal(fmt.Sprintf("Error listing work items: %s", err.Error())))
-				return ctx.InternalServerError(jerrors)
-			}
+			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error listing work items")))
 		}
-
 		response := app.WorkItem2List{
 			Links: &app.PagingLinks{},
 			Meta:  &app.WorkItemListResponseMeta{TotalCount: count},
 			Data:  ConvertWorkItems(ctx.RequestData, result),
 		}
-
 		setPagingLinks(response.Links, buildAbsoluteURL(ctx.RequestData), len(result), offset, limit, count, additionalQuery...)
-
 		return ctx.OK(&response)
 	})
-
 }
 
 // Update does PATCH workitem
 func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 	return application.Transactional(c.db, func(appl application.Application) error {
-
 		if ctx.Payload == nil || ctx.Payload.Data == nil || ctx.Payload.Data.ID == nil {
-			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(errors.NewBadParameterError("data.id", nil))
-			return ctx.NotFound(jerrors)
+			return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("missing data.ID element in request", nil))
 		}
-
 		wi, err := appl.WorkItems().Load(ctx, *ctx.Payload.Data.ID)
 		if err != nil {
-			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrNotFound(fmt.Sprintf("Error updating work item: %s", err.Error())))
-			return ctx.NotFound(jerrors)
+		}
+		if wi == nil {
+			return jsonapi.JSONErrorResponse(ctx, errors.NewNotFoundError("work item", *ctx.Payload.Data.ID))
 		}
 		// Type changes of WI are not allowed which is why we overwrite it the
 		// type with the old one after the WI has been converted.
 		oldType := wi.Type
 		err = ConvertJSONAPIToWorkItem(appl, *ctx.Payload.Data, wi)
 		if err != nil {
-			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
-			return ctx.BadRequest(jerrors)
+			return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("Error updating work item", err))
 		}
 		wi.Type = oldType
-
 		wi, err = appl.WorkItems().Save(ctx, *wi)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error updating work item")))
 		}
-
 		wi2 := ConvertWorkItem(ctx.RequestData, wi)
 		resp := &app.WorkItem2Single{
 			Data: wi2,
@@ -132,7 +110,6 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 				Self: buildAbsoluteURL(ctx.RequestData),
 			},
 		}
-
 		return ctx.OK(resp)
 	})
 }
@@ -144,43 +121,24 @@ func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
 		jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(err.Error()))
 		return ctx.Unauthorized(jerrors)
 	}
-
 	var wit *string
-	if ctx.Payload.Data != nil && ctx.Payload.Data.Relationships != nil && ctx.Payload.Data.Relationships.BaseType != nil {
-		if ctx.Payload.Data.Relationships.BaseType.Data != nil {
-			wit = &ctx.Payload.Data.Relationships.BaseType.Data.ID
-		}
+	if ctx.Payload.Data != nil && ctx.Payload.Data.Relationships != nil &&
+		ctx.Payload.Data.Relationships.BaseType != nil && ctx.Payload.Data.Relationships.BaseType.Data != nil {
+		wit = &ctx.Payload.Data.Relationships.BaseType.Data.ID
 	}
 	if wit == nil { // TODO Figure out path source etc. Should be a required relation
-		jerrors, _ := jsonapi.ErrorToJSONAPIErrors(errors.NewBadParameterError("data.relationships.basetype.data.id", nil))
-		return ctx.BadRequest(jerrors)
-
+		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("Missing Data.Relationships.BaseType.Data.ID element in request", err))
 	}
-
 	wi := app.WorkItem{
 		Fields: make(map[string]interface{}),
 	}
-
 	return application.Transactional(c.db, func(appl application.Application) error {
 		ConvertJSONAPIToWorkItem(appl, *ctx.Payload.Data, &wi)
 
 		wi, err := appl.WorkItems().Create(ctx, *wit, wi.Fields, currentUser)
 		if err != nil {
-			cause := errs.Cause(err)
-			switch cause.(type) {
-			case errors.BadParameterError:
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
-				return ctx.BadRequest(jerrors)
-			case errors.VersionConflictError:
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
-				return ctx.BadRequest(jerrors)
-			default:
-				log.Printf("Error updating work items: %s", err.Error())
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInternal(err.Error()))
-				return ctx.InternalServerError(jerrors)
-			}
+			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error updating work item")))
 		}
-
 		wi2 := ConvertWorkItem(ctx.RequestData, wi)
 		resp := &app.WorkItem2Single{
 			Data: wi2,
@@ -196,29 +154,11 @@ func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
 // Show does GET workitem
 func (c *WorkitemController) Show(ctx *app.ShowWorkitemContext) error {
 	return application.Transactional(c.db, func(appl application.Application) error {
-
 		comments := WorkItemIncludeCommentsAndTotal(ctx, c.db, ctx.ID)
-
 		wi, err := appl.WorkItems().Load(ctx, ctx.ID)
 		if err != nil {
-			cause := errs.Cause(err)
-			switch cause.(type) {
-			case errors.NotFoundError:
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrNotFound(err.Error()))
-				return ctx.NotFound(jerrors)
-			case errors.BadParameterError:
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
-				return ctx.BadRequest(jerrors)
-			case errors.VersionConflictError:
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
-				return ctx.BadRequest(jerrors)
-			default:
-				log.Printf("Error updating work items: %s", err.Error())
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInternal(err.Error()))
-				return ctx.InternalServerError(jerrors)
-			}
+			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error showing work item")))
 		}
-
 		wi2 := ConvertWorkItem(ctx.RequestData, wi, comments)
 		resp := &app.WorkItem2Single{
 			Data: wi2,
@@ -230,25 +170,9 @@ func (c *WorkitemController) Show(ctx *app.ShowWorkitemContext) error {
 // Delete does DELETE workitem
 func (c *WorkitemController) Delete(ctx *app.DeleteWorkitemContext) error {
 	return application.Transactional(c.db, func(appl application.Application) error {
-
 		err := appl.WorkItems().Delete(ctx, ctx.ID)
 		if err != nil {
-			cause := errs.Cause(err)
-			switch cause.(type) {
-			case errors.NotFoundError:
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrNotFound(err.Error()))
-				return ctx.NotFound(jerrors)
-			case errors.BadParameterError:
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
-				return ctx.BadRequest(jerrors)
-			case errors.VersionConflictError:
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
-				return ctx.BadRequest(jerrors)
-			default:
-				log.Printf("Error updating work items: %s", err.Error())
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInternal(err.Error()))
-				return ctx.InternalServerError(jerrors)
-			}
+			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error deleting work item")))
 		}
 		return ctx.OK([]byte{})
 	})
@@ -258,14 +182,9 @@ func (c *WorkitemController) Delete(ctx *app.DeleteWorkitemContext) error {
 // response resource object by jsonapi.org specifications
 func ConvertJSONAPIToWorkItem(appl application.Application, source app.WorkItem2, target *app.WorkItem) error {
 	// construct default values from input WI
-
-	var version = -1
-	if source.Attributes["version"] != nil {
-		v, err := strconv.Atoi(fmt.Sprintf("%v", source.Attributes["version"]))
-		if err != nil {
-			return errors.NewBadParameterError("data.attributes.version", source.Attributes["version"])
-		}
-		version = v
+	version, err := getVersion(source.Attributes["version"])
+	if err != nil {
+		return err
 	}
 	target.Version = version
 
@@ -279,13 +198,11 @@ func ConvertJSONAPIToWorkItem(appl application.Application, source app.WorkItem2
 				if err != nil {
 					return errors.NewBadParameterError("data.relationships.assignees.data.id", *d.ID)
 				}
-				ok := appl.Identities().ValidIdentity(context.Background(), assigneeUUID)
-				if !ok {
+				if ok := appl.Identities().ValidIdentity(context.Background(), assigneeUUID); !ok {
 					return errors.NewBadParameterError("data.relationships.assignees.data.id", *d.ID)
 				}
 				ids = append(ids, assigneeUUID.String())
 			}
-
 			target.Fields[workitem.SystemAssignees] = ids
 		}
 	}
@@ -298,8 +215,7 @@ func ConvertJSONAPIToWorkItem(appl application.Application, source app.WorkItem2
 			if err != nil {
 				return errors.NewBadParameterError("data.relationships.iteration.data.id", *d.ID)
 			}
-			_, err = appl.Iterations().Load(context.Background(), iterationUUID)
-			if err != nil {
+			if _, err = appl.Iterations().Load(context.Background(), iterationUUID); err != nil {
 				return errors.NewBadParameterError("data.relationships.iteration.data.id", *d.ID)
 			}
 			target.Fields[workitem.SystemIteration] = iterationUUID.String()
@@ -320,6 +236,17 @@ func ConvertJSONAPIToWorkItem(appl application.Application, source app.WorkItem2
 		}
 	}
 	return nil
+}
+
+func getVersion(version interface{}) (int, error) {
+	if version != nil {
+		v, err := strconv.Atoi(fmt.Sprintf("%v", version))
+		if err != nil {
+			return -1, errors.NewBadParameterError("data.attributes.version", version)
+		}
+		return v, nil
+	}
+	return -1, nil
 }
 
 // WorkItemConvertFunc is a open ended function to add additional links/data/relations to a Comment during

--- a/workitem.go
+++ b/workitem.go
@@ -88,10 +88,7 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 		}
 		wi, err := appl.WorkItems().Load(ctx, *ctx.Payload.Data.ID)
 		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(fmt.Sprintf("Fail to load work item with id %v", *ctx.Payload.Data.ID)))
-		}
-		if wi == nil {
-			return jsonapi.JSONErrorResponse(ctx, errors.NewNotFoundError("work item", *ctx.Payload.Data.ID))
+			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Fail to load work item with id %v", *ctx.Payload.Data.ID)))
 		}
 		// Type changes of WI are not allowed which is why we overwrite it the
 		// type with the old one after the WI has been converted.
@@ -162,7 +159,7 @@ func (c *WorkitemController) Show(ctx *app.ShowWorkitemContext) error {
 		comments := WorkItemIncludeCommentsAndTotal(ctx, c.db, ctx.ID)
 		wi, err := appl.WorkItems().Load(ctx, ctx.ID)
 		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error showing work item")))
+			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Fail to load work item with id %v", ctx.ID)))
 		}
 		wi2 := ConvertWorkItem(ctx.RequestData, wi, comments)
 		resp := &app.WorkItem2Single{

--- a/workitem.go
+++ b/workitem.go
@@ -68,7 +68,7 @@ func (c *WorkitemController) List(ctx *app.ListWorkitemContext) error {
 		result, tc, err := tx.WorkItems().List(ctx.Context, exp, &offset, &limit)
 		count := int(tc)
 		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error listing work items")))
+			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "Error listing work items"))
 		}
 		response := app.WorkItem2List{
 			Links: &app.PagingLinks{},
@@ -88,19 +88,19 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 		}
 		wi, err := appl.WorkItems().Load(ctx, *ctx.Payload.Data.ID)
 		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Fail to load work item with id %v", *ctx.Payload.Data.ID)))
+			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Failed to load work item with id %v", *ctx.Payload.Data.ID)))
 		}
 		// Type changes of WI are not allowed which is why we overwrite it the
 		// type with the old one after the WI has been converted.
 		oldType := wi.Type
 		err = ConvertJSONAPIToWorkItem(appl, *ctx.Payload.Data, wi)
 		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("Error updating work item", err))
+			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 		wi.Type = oldType
 		wi, err = appl.WorkItems().Save(ctx, *wi)
 		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error updating work item")))
+			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "Error updating work item"))
 		}
 		wi2 := ConvertWorkItem(ctx.RequestData, wi)
 		resp := &app.WorkItem2Single{
@@ -126,7 +126,7 @@ func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
 		wit = &ctx.Payload.Data.Relationships.BaseType.Data.ID
 	}
 	if wit == nil { // TODO Figure out path source etc. Should be a required relation
-		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("Missing Data.Relationships.BaseType.Data.ID element in request", err))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("Data.Relationships.BaseType.Data.ID", err))
 	}
 	wi := app.WorkItem{
 		Fields: make(map[string]interface{}),

--- a/workitem.go
+++ b/workitem.go
@@ -122,22 +122,7 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 
 		wi, err = appl.WorkItems().Save(ctx, *wi)
 		if err != nil {
-			cause := errs.Cause(err)
-			switch cause.(type) {
-			case errors.BadParameterError:
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
-				return ctx.BadRequest(jerrors)
-			case errors.NotFoundError:
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrNotFound(err.Error()))
-				return ctx.NotFound(jerrors)
-			case errors.VersionConflictError:
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("Error updating work item: %s", err.Error())))
-				return ctx.BadRequest(jerrors)
-			default:
-				log.Printf("Error updating work items: %s", err.Error())
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInternal(err.Error()))
-				return ctx.InternalServerError(jerrors)
-			}
+			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error updating work item")))
 		}
 
 		wi2 := ConvertWorkItem(ctx.RequestData, wi)


### PR DESCRIPTION
Refactored code to use the `jsonapi.JSONErrorResponse(ctx, err)`
wherever it was possible. Also, used a more compact syntax to
handle errors on function calls, when applicable.

Fixes #698