### PR TITLE
Support GET /api/spaces/{spaceName}. Fixes #696.

### DIFF
--- a/controller/namedspaces.go
+++ b/controller/namedspaces.go
@@ -1,0 +1,72 @@
+package controller
+
+import (
+	"fmt"
+	"github.com/almighty/almighty-core/account"
+	"github.com/almighty/almighty-core/app"
+	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/jsonapi"
+	"github.com/almighty/almighty-core/log"
+	"github.com/goadesign/goa"
+)
+
+// NamedspacesController implements the namedspaces resource.
+type NamedspacesController struct {
+	*goa.Controller
+	db application.DB
+}
+
+// NewNamedspacesController creates a namedspaces controller.
+func NewNamedspacesController(service *goa.Service, db application.DB) *NamedspacesController {
+	return &NamedspacesController{Controller: service.NewController("NamedspacesController"), db: db}
+}
+
+// Show runs the show action.
+func (c *NamedspacesController) Show(ctx *app.ShowNamedspacesContext) error {
+	if ctx.UserName == "" {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound("not found, userName=%v", ctx.UserName))
+	}
+
+	if ctx.SpaceName == "" {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound("not found, spaceName=%v", ctx.SpaceName))
+	}
+
+	return application.Transactional(c.db, func(appl application.Application) error {
+		identity, err := loadKeyCloakIdentityByUserName(ctx, appl, ctx.UserName)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound("not found, userName=%v", ctx.UserName))
+		}
+		s, err := appl.Spaces().LoadByOwnerAndName(ctx.Context, &identity.ID, &ctx.SpaceName)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, err)
+		}
+
+		resp := app.SpaceSingle{
+			Data: ConvertSpace(ctx.RequestData, s),
+		}
+
+		return ctx.OK(&resp)
+	})
+
+	res := &app.SpaceSingle{}
+	return ctx.OK(res)
+}
+
+func loadKeyCloakIdentityByUserName(ctx *app.ShowNamedspacesContext, appl application.Application, username string) (*account.Identity, error) {
+	identities, err := appl.Identities().Query(account.IdentityFilterByUsername(username))
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"userName": username,
+		}, "Fail to locate identity for user")
+		return nil, err
+	}
+	for _, identity := range identities {
+		if identity.ProviderType == account.KeycloakIDP {
+			return identity, nil
+		}
+	}
+	log.Error(ctx, map[string]interface{}{
+		"userName": username,
+	}, "Fail to locate Keycloak identity for user")
+	return nil, fmt.Errorf("Can't find Keycloak Identity for user %s", username)
+}

--- a/controller/namedspaces_test.go
+++ b/controller/namedspaces_test.go
@@ -1,0 +1,98 @@
+package controller_test
+
+import (
+	"github.com/almighty/almighty-core/account"
+	"github.com/almighty/almighty-core/app/test"
+	. "github.com/almighty/almighty-core/controller"
+	"github.com/almighty/almighty-core/gormapplication"
+	"github.com/almighty/almighty-core/gormsupport"
+	"github.com/almighty/almighty-core/gormsupport/cleaner"
+	"github.com/almighty/almighty-core/resource"
+	testsupport "github.com/almighty/almighty-core/test"
+	almtoken "github.com/almighty/almighty-core/token"
+	"github.com/goadesign/goa"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type TestNamedSpaceREST struct {
+	gormsupport.DBTestSuite
+
+	db    *gormapplication.GormDB
+	clean func()
+}
+
+func TestRunNamedSpacesREST(t *testing.T) {
+	suite.Run(t, &TestNamedSpaceREST{DBTestSuite: gormsupport.NewDBTestSuite("../config.yaml")})
+}
+
+func (rest *TestNamedSpaceREST) SetupTest() {
+	rest.db = gormapplication.NewGormDB(rest.DB)
+	rest.clean = cleaner.DeleteCreatedEntities(rest.DB)
+}
+
+func (rest *TestNamedSpaceREST) TearDownTest() {
+	rest.clean()
+}
+
+func (rest *TestNamedSpaceREST) SecuredNamedSpaceController(identity account.Identity) (*goa.Service, *NamedspacesController) {
+	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
+
+	svc := testsupport.ServiceAsUser("NamedSpace-Service", almtoken.NewManagerWithPrivateKey(priv), identity)
+	return svc, NewNamedspacesController(svc, rest.db)
+}
+
+func (rest *TestNamedSpaceREST) UnSecuredNamedSpaceController() (*goa.Service, *NamedspacesController) {
+	svc := goa.New("NamedSpace-Service")
+	return svc, NewNamedspacesController(svc, rest.db)
+}
+
+func (rest *TestNamedSpaceREST) SecuredSpaceController() (*goa.Service, *SpaceController) {
+	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
+
+	svc := testsupport.ServiceAsUser("Space-Service", almtoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
+	return svc, NewSpaceController(svc, rest.db)
+}
+
+func (rest *TestNamedSpaceREST) UnSecuredSpaceController() (*goa.Service, *SpaceController) {
+	svc := goa.New("Space-Service")
+	return svc, NewSpaceController(svc, rest.db)
+}
+
+func (rest *TestNamedSpaceREST) TestSuccessQuerySpace() {
+	t := rest.T()
+	resource.Require(t, resource.Database)
+
+	spaceSvc, spaceCtrl := rest.SecuredSpaceController()
+
+	identityRepo := account.NewIdentityRepository(rest.DB)
+	identity := testsupport.TestIdentity
+	identity.ProviderType = account.KeycloakIDP
+	err := identityRepo.Create(spaceSvc.Context, &identity)
+	if err != nil {
+		assert.Fail(t, "Failed to create an identity")
+	}
+
+	name := "Test 24"
+
+	p := minimumRequiredCreateSpace()
+	p.Data.Attributes.Name = &name
+
+	_, created := test.CreateSpaceCreated(t, spaceSvc.Context, spaceSvc, spaceCtrl, p)
+	assert.NotNil(t, created.Data)
+	assert.NotNil(t, created.Data.Attributes)
+	assert.NotNil(t, created.Data.Attributes.CreatedAt)
+	assert.NotNil(t, created.Data.Attributes.UpdatedAt)
+	assert.NotNil(t, created.Data.Attributes.Name)
+	assert.Equal(t, name, *created.Data.Attributes.Name)
+	assert.NotNil(t, created.Data.Links)
+	assert.NotNil(t, created.Data.Links.Self)
+
+	namedSpaceSvc, namedSpacectrl := rest.SecuredNamedSpaceController(testsupport.TestIdentity)
+	_, namedspace := test.ShowNamedspacesOK(t, namedSpaceSvc.Context, namedSpaceSvc, namedSpacectrl, testsupport.TestIdentity.Username, name)
+	assert.NotNil(t, namedspace)
+	assert.Equal(t, created.Data.Attributes.Name, namedspace.Data.Attributes.Name)
+	assert.Equal(t, created.Data.Attributes.Description, namedspace.Data.Attributes.Description)
+	assert.Equal(t, created.Data.Links.Self, namedspace.Data.Links.Self)
+}

--- a/controller/space_test.go
+++ b/controller/space_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
 	. "github.com/almighty/almighty-core/controller"
@@ -39,10 +40,10 @@ func (rest *TestSpaceREST) TearDownTest() {
 	rest.clean()
 }
 
-func (rest *TestSpaceREST) SecuredController() (*goa.Service, *SpaceController) {
+func (rest *TestSpaceREST) SecuredController(identity account.Identity) (*goa.Service, *SpaceController) {
 	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
 
-	svc := testsupport.ServiceAsUser("Space-Service", almtoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
+	svc := testsupport.ServiceAsUser("Space-Service", almtoken.NewManagerWithPrivateKey(priv), identity)
 	return svc, NewSpaceController(svc, rest.db)
 }
 
@@ -67,7 +68,7 @@ func (rest *TestSpaceREST) TestFailCreateSpaceMissingName() {
 
 	p := minimumRequiredCreateSpace()
 
-	svc, ctrl := rest.SecuredController()
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
 	test.CreateSpaceBadRequest(t, svc.Context, svc, ctrl, p)
 }
 
@@ -80,7 +81,7 @@ func (rest *TestSpaceREST) TestSuccessCreateSpace() {
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 
-	svc, ctrl := rest.SecuredController()
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
 	_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
 	assert.NotNil(t, created.Data)
 	assert.NotNil(t, created.Data.Attributes)
@@ -103,7 +104,7 @@ func (rest *TestSpaceREST) TestSuccessCreateSpaceWithDescription() {
 	p.Data.Attributes.Name = &name
 	p.Data.Attributes.Description = &description
 
-	svc, ctrl := rest.SecuredController()
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
 	_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
 	assert.NotNil(t, created.Data)
 	assert.NotNil(t, created.Data.Attributes)
@@ -130,7 +131,7 @@ func (rest *TestSpaceREST) TestSuccessUpdateProject() {
 	p.Data.Attributes.Name = &name
 	p.Data.Attributes.Description = &description
 
-	svc, ctrl := rest.SecuredController()
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
 	_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
 
 	u := minimumRequiredUpdateSpace()
@@ -142,6 +143,34 @@ func (rest *TestSpaceREST) TestSuccessUpdateProject() {
 	_, updated := test.UpdateSpaceOK(t, svc.Context, svc, ctrl, created.Data.ID.String(), u)
 	assert.Equal(t, newName, *updated.Data.Attributes.Name)
 	assert.Equal(t, newDescription, *updated.Data.Attributes.Description)
+}
+
+func (rest *TestSpaceREST) TestFailUpdateProjectDifferentOwner() {
+	t := rest.T()
+	resource.Require(t, resource.Database)
+
+	name := "Test 25"
+	description := "Space for Test 25"
+	newName := "Test 26"
+	newDescription := "Space for Test 25"
+
+	p := minimumRequiredCreateSpace()
+	p.Data.Attributes.Name = &name
+	p.Data.Attributes.Description = &description
+
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
+	_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+
+	u := minimumRequiredUpdateSpace()
+	u.Data.ID = created.Data.ID
+	u.Data.Attributes.Version = created.Data.Attributes.Version
+	u.Data.Attributes.Name = &newName
+	u.Data.Attributes.Description = &newDescription
+
+	svc2, ctrl2 := rest.SecuredController(testsupport.TestIdentity2)
+	_, errors := test.UpdateSpaceForbidden(t, svc2.Context, svc2, ctrl2, created.Data.ID.String(), u)
+	assert.NotEmpty(t, errors.Errors)
+	assert.Contains(t, errors.Errors[0].Detail, "User is not the space owner")
 }
 
 func (rest *TestSpaceREST) TestFailUpdateProjectUnSecure() {
@@ -167,7 +196,7 @@ func (rest *TestSpaceREST) TestFailUpdateSpaceNotFound() {
 	u.Data.Attributes.Version = &version
 	u.Data.ID = &id
 
-	svc, ctrl := rest.SecuredController()
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
 	test.UpdateSpaceNotFound(t, svc.Context, svc, ctrl, id.String(), u)
 }
 
@@ -180,7 +209,7 @@ func (rest *TestSpaceREST) TestFailUpdateSpaceMissingName() {
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 
-	svc, ctrl := rest.SecuredController()
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
 	_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
 
 	u := minimumRequiredUpdateSpace()
@@ -200,7 +229,7 @@ func (rest *TestSpaceREST) TestFailUpdateSpaceMissingVersion() {
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 
-	svc, ctrl := rest.SecuredController()
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
 	_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
 
 	u := minimumRequiredUpdateSpace()
@@ -220,7 +249,7 @@ func (rest *TestSpaceREST) TestSuccessShowProject() {
 	p.Data.Attributes.Name = &name
 	p.Data.Attributes.Description = &description
 
-	svc, ctrl := rest.SecuredController()
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
 	_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
 
 	_, fetched := test.ShowSpaceOK(t, svc.Context, svc, ctrl, created.Data.ID.String())
@@ -255,7 +284,7 @@ func (rest *TestSpaceREST) TestSuccessListSpaces() {
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 
-	svc, ctrl := rest.SecuredController()
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
 	test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
 
 	_, list := test.ListSpaceOK(t, svc.Context, svc, ctrl, nil, nil)

--- a/design/namedspaces.go
+++ b/design/namedspaces.go
@@ -1,0 +1,27 @@
+package design
+
+import (
+	d "github.com/goadesign/goa/design"
+	a "github.com/goadesign/goa/design/apidsl"
+)
+
+var _ = a.Resource("namedspaces", func() {
+	a.BasePath("/namedspaces")
+
+	a.Action("show", func() {
+		a.Routing(
+			a.GET("/:userName/:spaceName"),
+		)
+		a.Description("Retrieve space (as JSONAPI) for the given user name and space name.")
+		a.Params(func() {
+			a.Param("userName", d.String, "User name of the owner of the space")
+			a.Param("spaceName", d.String, "Name of the space, unique to a group of spaces owned by a user")
+		})
+		a.Response(d.OK, func() {
+			a.Media(spaceSingle)
+		})
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+	})
+})

--- a/design/spaces.go
+++ b/design/spaces.go
@@ -19,9 +19,15 @@ var space = a.Type("Space", func() {
 })
 
 var spaceRelationships = a.Type("SpaceRelationships", func() {
+	a.Attribute("owned-by", spaceOwnedBy, "The owner of the Space")
 	a.Attribute("iterations", relationGeneric, "Space can have one or many iterations")
 	a.Attribute("areas", relationGeneric, "Space can have one or many areas")
 	a.Attribute("workitemlinktypes", relationGeneric, "Space can have one or many work item link types")
+})
+
+var spaceOwnedBy = a.Type("SpaceOwnedBy", func() {
+	a.Attribute("data", identityRelationData)
+	a.Required("data")
 })
 
 var spaceAttributes = a.Type("SpaceAttributes", func() {
@@ -159,5 +165,6 @@ var _ = a.Resource("space", func() {
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.Forbidden, JSONAPIErrors)
 	})
 })

--- a/main.go
+++ b/main.go
@@ -280,6 +280,10 @@ func main() {
 	filterCtrl := controller.NewFilterController(service)
 	app.MountFilterController(service, filterCtrl)
 
+	// Mount "namedspaces" controller
+	namedSpacesCtrl := controller.NewNamedspacesController(service, appDB)
+	app.MountNamedspacesController(service, namedSpacesCtrl)
+
 	log.Logger().Infoln("Git Commit SHA: ", controller.Commit)
 	log.Logger().Infoln("UTC Build Time: ", controller.BuildTime)
 	log.Logger().Infoln("UTC Start Time: ", controller.StartTime)

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -206,6 +206,9 @@ func getMigrations() migrations {
 	// Version 33
 	m = append(m, steps{executeSQLFile("033-add-space-id-wilt.sql", space.SystemSpace.String(), "system.space", "Description of the space")})
 
+	// version 34
+	m = append(m, steps{executeSQLFile("034-space-owner.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/034-space-owner.sql
+++ b/migration/sql-files/034-space-owner.sql
@@ -1,0 +1,1 @@
+ALTER TABLE spaces ADD owner_id uuid;


### PR DESCRIPTION
Modified REST API URL from /api/spaces/{spaceId} to /api/spaces/{spaceName}.

This allows spaces to be queried by name through a path, without the use of a filter query parameter for the name attribute.

This also modifies URIs of sub-resources like iterations. Modified tests accordingly.