### PR TITLE
Add an endpoint to render markup content in HTML in 'preview' mode #635

### DIFF
--- a/design/render.go
+++ b/design/render.go
@@ -5,34 +5,64 @@ import (
 	a "github.com/goadesign/goa/design/apidsl"
 )
 
-// MarkupRenderingInputType is the media type representing a rendering input.
-var MarkupRenderingInputType = a.Type("MarkupRenderingInputType", func() {
+// MarkupRenderingPayloadData is the media type representing a rendering input.
+var markupRenderingPayloadData = a.Type("MarkupRenderingPayloadData", func() {
 	a.Description("A render type describes the values a render type instance can hold.")
-	a.Attribute("markup", d.String, "The name of the markup language used to input the content")
-	a.Attribute("content", d.String, "The content to be rendered")
-	a.Required("markup")
-	a.Required("content")
+	a.Attribute("id", d.String, "an ID to conform to the JSON-API spec, even though it is meaningless in the case of the rendering endpoint. Can be null", func() {
+		a.Example("42")
+	})
+	a.Attribute("type", d.String, func() {
+		a.Enum("rendering")
+	})
+	a.Attribute("attributes", a.HashOf(d.String, d.Any), func() {
+		a.Example(map[string]interface{}{"markup": "Markdown", "content": "# foo"})
+	})
+	a.Required("id")
+	a.Required("type")
+	a.Required("attributes")
+})
 
+// MarkupRenderingPayload wraps the data in a JSONAPI compliant request
+var markupRenderingPayload = a.Type("MarkupRenderingPayload", func() {
+	a.Attribute("data", markupRenderingPayloadData)
+	a.Required("data")
 })
 
 // MarkupRenderingMediaType is the media type representing a rendering result.
-var MarkupRenderingMediaType = a.MediaType("application/vnd.markuprendering+json", func() {
-	a.TypeName("RenderOutputMediaType")
-	a.Description("A render type describes the values a render type instance can hold.")
-	a.Attribute("rendered", d.String, "The result of the rendering of a given content in a given markup language")
-	a.Required("rendered")
-	a.View("default", func() {
-		a.Attribute("rendered")
+var markupRenderingMediaTypeData = a.Type("MarkupRendering", func() {
+	a.Description("A MarkupRendering type describes the values a render type instance can hold.")
+	a.Attribute("id", d.String, "an ID to conform to the JSON-API spec, even though it is meaningless in the case of the rendering endpoint. Can be null", func() {
+		a.Example("42")
 	})
+	a.Attribute("type", d.String, func() {
+		a.Enum("rendering")
+	})
+	a.Attribute("attributes", a.HashOf(d.String, d.Any), func() {
+		a.Example(map[string]interface{}{"renderedContent": "<h1>foo</h1>"})
+	})
+	a.Required("id")
+	a.Required("type")
+	a.Required("attributes")
 })
+
+// workItemLinkCategory is the media type for work item link categories
+var markupRenderingMediaType = JSONSingle(
+	"MarkupRendering",
+	`MarkupRenderingMediaType contains the  
+		rendering of the 'content' provided in the request, using
+		the markup language specified by the 'markup' value.`,
+	markupRenderingMediaTypeData,
+	nil,
+)
 
 var _ = a.Resource("render", func() {
 	a.BasePath("/render")
+	a.Security("jwt")
 	a.Action("render", func() {
 		a.Description("Render some content using the markup language")
 		a.Routing(a.POST(""))
-		a.Payload(MarkupRenderingInputType)
-		a.Response(d.OK, MarkupRenderingMediaType)
+		a.Payload(markupRenderingPayload)
+		a.Response(d.OK, markupRenderingMediaType)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 	})

--- a/design/render.go
+++ b/design/render.go
@@ -5,47 +5,36 @@ import (
 	a "github.com/goadesign/goa/design/apidsl"
 )
 
-// MarkupRenderingPayloadData is the media type representing a rendering input.
-var markupRenderingPayloadData = a.Type("MarkupRenderingPayloadData", func() {
-	a.Description("A render type describes the values a render type instance can hold.")
-	a.Attribute("id", d.String, "an ID to conform to the JSON-API spec, even though it is meaningless in the case of the rendering endpoint. Can be null", func() {
-		a.Example("42")
-	})
-	a.Attribute("type", d.String, func() {
-		a.Enum("rendering")
-	})
-	a.Attribute("attributes", a.HashOf(d.String, d.Any), func() {
-		a.Example(map[string]interface{}{"markup": "Markdown", "content": "# foo"})
-	})
-	a.Required("id")
-	a.Required("type")
-	a.Required("attributes")
-})
-
 // MarkupRenderingPayload wraps the data in a JSONAPI compliant request
 var markupRenderingPayload = a.Type("MarkupRenderingPayload", func() {
+	a.Description("A MarkupRenderingPayload describes the values that a render request can hold.")
 	a.Attribute("data", markupRenderingPayloadData)
 	a.Required("data")
 })
 
-// MarkupRenderingMediaType is the media type representing a rendering result.
-var markupRenderingMediaTypeData = a.Type("MarkupRendering", func() {
-	a.Description("A MarkupRendering type describes the values a render type instance can hold.")
-	a.Attribute("id", d.String, "an ID to conform to the JSON-API spec, even though it is meaningless in the case of the rendering endpoint. Can be null", func() {
-		a.Example("42")
-	})
+// MarkupRenderingPayloadData is the media type representing a rendering input.
+var markupRenderingPayloadData = a.Type("MarkupRenderingPayloadData", func() {
 	a.Attribute("type", d.String, func() {
 		a.Enum("rendering")
 	})
-	a.Attribute("attributes", a.HashOf(d.String, d.Any), func() {
-		a.Example(map[string]interface{}{"renderedContent": "<h1>foo</h1>"})
-	})
-	a.Required("id")
+	a.Attribute("attributes", markupRenderingPayloadDataAttributes)
 	a.Required("type")
 	a.Required("attributes")
 })
 
-// workItemLinkCategory is the media type for work item link categories
+// MarkupRenderingPayloadData is the media type representing a rendering input.
+var markupRenderingPayloadDataAttributes = a.Type("MarkupRenderingPayloadDataAttributes", func() {
+	a.Attribute("content", d.String, "The content to render", func() {
+		a.Example("# foo")
+	})
+	a.Attribute("markup", d.String, "The markup language associated with the content to render", func() {
+		a.Example("Markdown")
+	})
+	a.Required("content")
+	a.Required("markup")
+})
+
+// MarkupRenderingMediaType is the media type for rendering result
 var markupRenderingMediaType = JSONSingle(
 	"MarkupRendering",
 	`MarkupRenderingMediaType contains the  
@@ -54,6 +43,28 @@ var markupRenderingMediaType = JSONSingle(
 	markupRenderingMediaTypeData,
 	nil,
 )
+
+// MarkupRenderingMediaType is the data included in the rendering result response.
+var markupRenderingMediaTypeData = a.Type("MarkupRenderingData", func() {
+	a.Attribute("id", d.String, "an ID to conform to the JSON-API spec, even though it is meaningless in the case of the rendering endpoint. Can be null", func() {
+		a.Example("42")
+	})
+	a.Attribute("type", d.String, func() {
+		a.Enum("rendering")
+	})
+	a.Attribute("attributes", markupRenderingMediaTypeDataAttributes)
+	a.Required("id")
+	a.Required("type")
+	a.Required("attributes")
+})
+
+// MarkupRenderingMediaType is the data included in the rendering result response.
+var markupRenderingMediaTypeDataAttributes = a.Type("MarkupRenderingDataAttributes", func() {
+	a.Attribute("renderedContent", d.String, "The rendered content", func() {
+		a.Example("<h1>foo</h1>")
+	})
+	a.Required("renderedContent")
+})
 
 var _ = a.Resource("render", func() {
 	a.BasePath("/render")

--- a/design/render.go
+++ b/design/render.go
@@ -1,0 +1,39 @@
+package design
+
+import (
+	d "github.com/goadesign/goa/design"
+	a "github.com/goadesign/goa/design/apidsl"
+)
+
+// MarkupRenderingInputType is the media type representing a rendering input.
+var MarkupRenderingInputType = a.Type("MarkupRenderingInputType", func() {
+	a.Description("A render type describes the values a render type instance can hold.")
+	a.Attribute("markup", d.String, "The name of the markup language used to input the content")
+	a.Attribute("content", d.String, "The content to be rendered")
+	a.Required("markup")
+	a.Required("content")
+
+})
+
+// MarkupRenderingMediaType is the media type representing a rendering result.
+var MarkupRenderingMediaType = a.MediaType("application/vnd.markuprendering+json", func() {
+	a.TypeName("RenderOutputMediaType")
+	a.Description("A render type describes the values a render type instance can hold.")
+	a.Attribute("rendered", d.String, "The result of the rendering of a given content in a given markup language")
+	a.Required("rendered")
+	a.View("default", func() {
+		a.Attribute("rendered")
+	})
+})
+
+var _ = a.Resource("render", func() {
+	a.BasePath("/render")
+	a.Action("render", func() {
+		a.Description("Render some content using the markup language")
+		a.Routing(a.POST(""))
+		a.Payload(MarkupRenderingInputType)
+		a.Response(d.OK, MarkupRenderingMediaType)
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+	})
+})

--- a/main.go
+++ b/main.go
@@ -244,11 +244,17 @@ func main() {
 	iterationCtrl := NewIterationController(service, appDB)
 	app.MountIterationController(service, iterationCtrl)
 
+	// Mount "spaceiterations" controller
 	spaceIterationCtrl := NewSpaceIterationsController(service, appDB)
 	app.MountSpaceIterationsController(service, spaceIterationCtrl)
 
+	// Mount "userspace" controller
 	userspaceCtrl := NewUserspaceController(service, db)
 	app.MountUserspaceController(service, userspaceCtrl)
+
+	// Mount "render" controller
+	renderCtrl := NewRenderController(service)
+	app.MountRenderController(service, renderCtrl)
 
 	fmt.Println("Git Commit SHA: ", Commit)
 	fmt.Println("UTC Build Time: ", BuildTime)

--- a/render.go
+++ b/render.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"github.com/almighty/almighty-core/app"
+	"github.com/almighty/almighty-core/errors"
+	"github.com/almighty/almighty-core/jsonapi"
+	"github.com/almighty/almighty-core/rendering"
+	"github.com/goadesign/goa"
+)
+
+// RenderController implements the render resource.
+type RenderController struct {
+	*goa.Controller
+}
+
+// NewRenderController creates a render controller.
+func NewRenderController(service *goa.Service) *RenderController {
+	return &RenderController{Controller: service.NewController("RenderController")}
+}
+
+// Render runs the render action.
+func (c *RenderController) Render(ctx *app.RenderRenderContext) error {
+	content := ctx.Payload.Content
+	markup := ctx.Payload.Markup
+	if !rendering.IsMarkupSupported(markup) {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("Unsupported markup type", markup))
+	}
+	htmlResult := rendering.RenderMarkupToHTML(content, markup)
+	res := &app.RenderOutputMediaType{Rendered: htmlResult}
+	return ctx.OK(res)
+}

--- a/render.go
+++ b/render.go
@@ -5,7 +5,14 @@ import (
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/rendering"
+	"github.com/almighty/almighty-core/workitem"
 	"github.com/goadesign/goa"
+	uuid "github.com/satori/go.uuid"
+)
+
+const (
+	RenderingType = "rendering"
+	RenderedValue = "value"
 )
 
 // RenderController implements the render resource.
@@ -20,12 +27,17 @@ func NewRenderController(service *goa.Service) *RenderController {
 
 // Render runs the render action.
 func (c *RenderController) Render(ctx *app.RenderRenderContext) error {
-	content := ctx.Payload.Content
-	markup := ctx.Payload.Markup
+	content := ctx.Payload.Data.Attributes[workitem.ContentKey].(string)
+	markup := ctx.Payload.Data.Attributes[workitem.MarkupKey].(string)
 	if !rendering.IsMarkupSupported(markup) {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("Unsupported markup type", markup))
 	}
 	htmlResult := rendering.RenderMarkupToHTML(content, markup)
-	res := &app.RenderOutputMediaType{Rendered: htmlResult}
+	resultAttributes := make(map[string]interface{})
+	resultAttributes[RenderedValue] = htmlResult
+	res := &app.MarkupRenderingSingle{Data: &app.MarkupRendering{
+		ID:         uuid.NewV4().String(),
+		Type:       RenderingType,
+		Attributes: resultAttributes}}
 	return ctx.OK(res)
 }

--- a/render.go
+++ b/render.go
@@ -5,7 +5,6 @@ import (
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/rendering"
-	"github.com/almighty/almighty-core/workitem"
 	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
 )
@@ -27,17 +26,17 @@ func NewRenderController(service *goa.Service) *RenderController {
 
 // Render runs the render action.
 func (c *RenderController) Render(ctx *app.RenderRenderContext) error {
-	content := ctx.Payload.Data.Attributes[workitem.ContentKey].(string)
-	markup := ctx.Payload.Data.Attributes[workitem.MarkupKey].(string)
+	content := ctx.Payload.Data.Attributes.Content
+	markup := ctx.Payload.Data.Attributes.Markup
 	if !rendering.IsMarkupSupported(markup) {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("Unsupported markup type", markup))
 	}
 	htmlResult := rendering.RenderMarkupToHTML(content, markup)
-	resultAttributes := make(map[string]interface{})
-	resultAttributes[RenderedValue] = htmlResult
-	res := &app.MarkupRenderingSingle{Data: &app.MarkupRendering{
-		ID:         uuid.NewV4().String(),
-		Type:       RenderingType,
-		Attributes: resultAttributes}}
+	res := &app.MarkupRenderingSingle{Data: &app.MarkupRenderingData{
+		ID:   uuid.NewV4().String(),
+		Type: RenderingType,
+		Attributes: &app.MarkupRenderingDataAttributes{
+			RenderedContent: htmlResult,
+		}}}
 	return ctx.OK(res)
 }

--- a/rendering_blackbox_test.go
+++ b/rendering_blackbox_test.go
@@ -1,0 +1,69 @@
+package main_test
+
+import (
+	"testing"
+
+	. "github.com/almighty/almighty-core"
+	"github.com/almighty/almighty-core/app"
+	"github.com/almighty/almighty-core/app/test"
+	"github.com/almighty/almighty-core/rendering"
+	"github.com/almighty/almighty-core/resource"
+	"github.com/goadesign/goa"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// a normal test function that will kick off MarkupRenderingSuite
+func TestSuiteMarkupRendering(t *testing.T) {
+	resource.Require(t, resource.Database)
+	suite.Run(t, new(MarkupRenderingSuite))
+}
+
+// ========== MarkupRenderingSuite struct that implements SetupSuite, TearDownSuite, SetupTest, TearDownTest ==========
+type MarkupRenderingSuite struct {
+	suite.Suite
+	controller app.RenderController
+	svc        *goa.Service
+}
+
+func (s *MarkupRenderingSuite) SetupSuite() {
+}
+
+func (s *MarkupRenderingSuite) TearDownSuite() {
+}
+
+func (s *MarkupRenderingSuite) SetupTest() {
+	s.svc = goa.New("Rendering-service-test")
+	s.controller = NewRenderController(s.svc)
+}
+
+func (s *MarkupRenderingSuite) TearDownTest() {
+}
+
+func (s *MarkupRenderingSuite) TestRenderPlainText() {
+	// given
+	input := app.MarkupRenderingInputType{Markup: rendering.SystemMarkupPlainText, Content: "foo"}
+	// when
+	_, result := test.RenderRenderOK(s.T(), s.svc.Context, s.svc, s.controller, &input)
+	// then
+	require.NotNil(s.T(), result)
+	assert.Equal(s.T(), "foo", result.Rendered)
+}
+
+func (s *MarkupRenderingSuite) TestRenderMarkdown() {
+	// given
+	input := app.MarkupRenderingInputType{Markup: rendering.SystemMarkupMarkdown, Content: "foo"}
+	// when
+	_, result := test.RenderRenderOK(s.T(), s.svc.Context, s.svc, s.controller, &input)
+	// then
+	require.NotNil(s.T(), result)
+	assert.Equal(s.T(), "<p>foo</p>\n", result.Rendered)
+}
+
+func (s *MarkupRenderingSuite) TestRenderUnsupportedMarkup() {
+	// given
+	input := app.MarkupRenderingInputType{Markup: "bar", Content: "foo"}
+	// when/then
+	test.RenderRenderBadRequest(s.T(), s.svc.Context, s.svc, s.controller, &input)
+}

--- a/rendering_blackbox_test.go
+++ b/rendering_blackbox_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/almighty/almighty-core/app/test"
 	"github.com/almighty/almighty-core/rendering"
 	"github.com/almighty/almighty-core/resource"
-	"github.com/almighty/almighty-core/workitem"
 	"github.com/goadesign/goa"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,47 +43,46 @@ func (s *MarkupRenderingSuite) TearDownTest() {
 
 func (s *MarkupRenderingSuite) TestRenderPlainText() {
 	// given
-	attributes := make(map[string]interface{})
-	attributes[workitem.MarkupKey] = rendering.SystemMarkupPlainText
-	attributes[workitem.ContentKey] = "foo"
 	payload := app.MarkupRenderingPayload{Data: &app.MarkupRenderingPayloadData{
-		ID:         "1234",
-		Type:       RenderingType,
-		Attributes: attributes}}
+		Type: RenderingType,
+		Attributes: &app.MarkupRenderingPayloadDataAttributes{
+			Content: "foo",
+			Markup:  rendering.SystemMarkupPlainText,
+		}}}
 	// when
 	_, result := test.RenderRenderOK(s.T(), s.svc.Context, s.svc, s.controller, &payload)
 	// then
 	require.NotNil(s.T(), result)
 	require.NotNil(s.T(), result.Data)
-	assert.Equal(s.T(), "foo", result.Data.Attributes[RenderedValue])
+	assert.Equal(s.T(), "foo", result.Data.Attributes.RenderedContent)
 }
 
 func (s *MarkupRenderingSuite) TestRenderMarkdown() {
 	// given
-	attributes := make(map[string]interface{})
-	attributes[workitem.MarkupKey] = rendering.SystemMarkupMarkdown
-	attributes[workitem.ContentKey] = "foo"
 	payload := app.MarkupRenderingPayload{Data: &app.MarkupRenderingPayloadData{
-		ID:         "1234",
-		Type:       RenderingType,
-		Attributes: attributes}}
+		Type: RenderingType,
+		Attributes: &app.MarkupRenderingPayloadDataAttributes{
+			Content: "foo",
+			Markup:  rendering.SystemMarkupMarkdown,
+		}}}
+
 	// when
 	_, result := test.RenderRenderOK(s.T(), s.svc.Context, s.svc, s.controller, &payload)
 	// then
 	require.NotNil(s.T(), result)
 	require.NotNil(s.T(), result.Data)
-	assert.Equal(s.T(), "<p>foo</p>\n", result.Data.Attributes[RenderedValue])
+	assert.Equal(s.T(), "<p>foo</p>\n", result.Data.Attributes.RenderedContent)
 }
 
 func (s *MarkupRenderingSuite) TestRenderUnsupportedMarkup() {
 	// given
-	attributes := make(map[string]interface{})
-	attributes[workitem.MarkupKey] = "bar"
-	attributes[workitem.ContentKey] = "foo"
 	payload := app.MarkupRenderingPayload{Data: &app.MarkupRenderingPayloadData{
-		ID:         "1234",
-		Type:       RenderingType,
-		Attributes: attributes}}
+		Type: RenderingType,
+		Attributes: &app.MarkupRenderingPayloadDataAttributes{
+			Content: "foo",
+			Markup:  "bar",
+		}}}
+
 	// when/then
 	test.RenderRenderBadRequest(s.T(), s.svc.Context, s.svc, s.controller, &payload)
 }

--- a/rendering_blackbox_test.go
+++ b/rendering_blackbox_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/almighty/almighty-core/app/test"
 	"github.com/almighty/almighty-core/rendering"
 	"github.com/almighty/almighty-core/resource"
+	"github.com/almighty/almighty-core/workitem"
 	"github.com/goadesign/goa"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -43,27 +44,47 @@ func (s *MarkupRenderingSuite) TearDownTest() {
 
 func (s *MarkupRenderingSuite) TestRenderPlainText() {
 	// given
-	input := app.MarkupRenderingInputType{Markup: rendering.SystemMarkupPlainText, Content: "foo"}
+	attributes := make(map[string]interface{})
+	attributes[workitem.MarkupKey] = rendering.SystemMarkupPlainText
+	attributes[workitem.ContentKey] = "foo"
+	payload := app.MarkupRenderingPayload{Data: &app.MarkupRenderingPayloadData{
+		ID:         "1234",
+		Type:       RenderingType,
+		Attributes: attributes}}
 	// when
-	_, result := test.RenderRenderOK(s.T(), s.svc.Context, s.svc, s.controller, &input)
+	_, result := test.RenderRenderOK(s.T(), s.svc.Context, s.svc, s.controller, &payload)
 	// then
 	require.NotNil(s.T(), result)
-	assert.Equal(s.T(), "foo", result.Rendered)
+	require.NotNil(s.T(), result.Data)
+	assert.Equal(s.T(), "foo", result.Data.Attributes[RenderedValue])
 }
 
 func (s *MarkupRenderingSuite) TestRenderMarkdown() {
 	// given
-	input := app.MarkupRenderingInputType{Markup: rendering.SystemMarkupMarkdown, Content: "foo"}
+	attributes := make(map[string]interface{})
+	attributes[workitem.MarkupKey] = rendering.SystemMarkupMarkdown
+	attributes[workitem.ContentKey] = "foo"
+	payload := app.MarkupRenderingPayload{Data: &app.MarkupRenderingPayloadData{
+		ID:         "1234",
+		Type:       RenderingType,
+		Attributes: attributes}}
 	// when
-	_, result := test.RenderRenderOK(s.T(), s.svc.Context, s.svc, s.controller, &input)
+	_, result := test.RenderRenderOK(s.T(), s.svc.Context, s.svc, s.controller, &payload)
 	// then
 	require.NotNil(s.T(), result)
-	assert.Equal(s.T(), "<p>foo</p>\n", result.Rendered)
+	require.NotNil(s.T(), result.Data)
+	assert.Equal(s.T(), "<p>foo</p>\n", result.Data.Attributes[RenderedValue])
 }
 
 func (s *MarkupRenderingSuite) TestRenderUnsupportedMarkup() {
 	// given
-	input := app.MarkupRenderingInputType{Markup: "bar", Content: "foo"}
+	attributes := make(map[string]interface{})
+	attributes[workitem.MarkupKey] = "bar"
+	attributes[workitem.ContentKey] = "foo"
+	payload := app.MarkupRenderingPayload{Data: &app.MarkupRenderingPayloadData{
+		ID:         "1234",
+		Type:       RenderingType,
+		Attributes: attributes}}
 	// when/then
-	test.RenderRenderBadRequest(s.T(), s.svc.Context, s.svc, s.controller, &input)
+	test.RenderRenderBadRequest(s.T(), s.svc.Context, s.svc, s.controller, &payload)
 }


### PR DESCRIPTION
Added an endpoint at /api/render that takes a JSON document in the
POST request and convert the 'content` value of the input doc
using the `markup` value.
Returns a JSON response containing the rendered value if the markup
is supported.
Returns a BadRequest if the markup is not supported.

Fixes #635

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

