### PR TITLE
Use the auto-generated method to generate resource URL for iteration

### DIFF
--- a/iteration.go
+++ b/iteration.go
@@ -162,8 +162,8 @@ func ConvertIteration(request *goa.RequestData, itr *iteration.Iteration, additi
 	spaceID := itr.SpaceID.String()
 
 	selfURL := rest.AbsoluteURL(request, app.IterationHref(itr.ID))
-	spaceSelfURL := rest.AbsoluteURL(request, "/api/spaces/"+spaceID)
-	workitemsRelatedURL := rest.AbsoluteURL(request, "/api/workitems?filter[iteration]="+itr.ID.String())
+	spaceSelfURL := rest.AbsoluteURL(request, app.SpaceHref(spaceID))
+	workitemsRelatedURL := rest.AbsoluteURL(request, app.WorkitemHref("?filter[iteration]="+itr.ID.String()))
 
 	i := &app.Iteration{
 		Type: iterationType,

--- a/iteration/iteration_test.go
+++ b/iteration/iteration_test.go
@@ -55,11 +55,11 @@ func (test *TestIterationRepository) TestCreateIteration() {
 
 	repo.Create(context.Background(), &i)
 	if i.ID == uuid.Nil {
-		t.Errorf("Comment was not created, ID nil")
+		t.Errorf("Iteration was not created, ID nil")
 	}
 
 	if i.CreatedAt.After(time.Now()) {
-		t.Errorf("Comment was not created, CreatedAt after Now()?")
+		t.Errorf("Iteration was not created, CreatedAt after Now()?")
 	}
 	assert.Equal(t, start, *i.StartAt)
 	assert.Equal(t, end, *i.EndAt)

--- a/iteration_test.go
+++ b/iteration_test.go
@@ -1,6 +1,7 @@
 package main_test
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -283,7 +284,8 @@ func assertIterationLinking(t *testing.T, target *app.Iteration) {
 	assert.NotNil(t, target.Links.Self)
 	assert.NotNil(t, target.Relationships)
 	assert.NotNil(t, target.Relationships.Space)
-	assert.NotNil(t, target.Relationships.Space.Links.Self)
+	require.NotNil(t, target.Relationships.Space.Links.Self) // check for non-nil before comparison in the next statement
+	assert.True(t, strings.Contains(*target.Relationships.Space.Links.Self, "/api/spaces/"))
 }
 
 func assertChildIterationLinking(t *testing.T, target *app.Iteration) {

--- a/iteration_test.go
+++ b/iteration_test.go
@@ -282,14 +282,17 @@ func assertIterationLinking(t *testing.T, target *app.Iteration) {
 	assert.NotNil(t, target.ID)
 	assert.Equal(t, iteration.APIStringTypeIteration, target.Type)
 	assert.NotNil(t, target.Links.Self)
-	assert.NotNil(t, target.Relationships)
-	assert.NotNil(t, target.Relationships.Space)
-	require.NotNil(t, target.Relationships.Space.Links.Self) // check for non-nil before comparison in the next statement
+	require.NotNil(t, target.Relationships)
+	require.NotNil(t, target.Relationships.Space)
+	require.NotNil(t, target.Relationships.Space.Links)
+	require.NotNil(t, target.Relationships.Space.Links.Self)
 	assert.True(t, strings.Contains(*target.Relationships.Space.Links.Self, "/api/spaces/"))
 }
 
 func assertChildIterationLinking(t *testing.T, target *app.Iteration) {
 	assertIterationLinking(t, target)
-	assert.NotNil(t, target.Relationships.Parent)
-	assert.NotNil(t, target.Relationships.Parent.Links.Self)
+	require.NotNil(t, target.Relationships)
+	require.NotNil(t, target.Relationships.Parent)
+	require.NotNil(t, target.Relationships.Parent.Links)
+	require.NotNil(t, target.Relationships.Parent.Links.Self)
 }


### PR DESCRIPTION
- consumed resource href method
- changed logged string in tests.