### PR TITLE
Move `MarkupContent` structure in the `rendering` package (#709)

### DIFF
--- a/remoteworkitem/remoteworkitem.go
+++ b/remoteworkitem/remoteworkitem.go
@@ -86,7 +86,7 @@ func (converter MarkupConverter) Convert(value interface{}, item AttributeAccess
 	}
 	switch value.(type) {
 	case string:
-		return workitem.NewMarkupContent(value.(string), converter.markup), nil
+		return rendering.NewMarkupContent(value.(string), converter.markup), nil
 	default:
 		return nil, errors.Errorf("Unexpected type of value to convert: %T", value)
 	}

--- a/remoteworkitem/trackeritem_repository_test.go
+++ b/remoteworkitem/trackeritem_repository_test.go
@@ -49,7 +49,7 @@ func TestConvertNewWorkItem(t *testing.T) {
 		assert.Equal(t, "pranav", workItem.Fields[workitem.SystemAssignees].([]interface{})[0])
 		assert.Equal(t, "closed", workItem.Fields[workitem.SystemState])
 		require.NotNil(t, workItem.Fields[workitem.SystemDescription])
-		description := workItem.Fields[workitem.SystemDescription].(workitem.MarkupContent)
+		description := workItem.Fields[workitem.SystemDescription].(rendering.MarkupContent)
 		assert.Equal(t, "body of issue", description.Content)
 		assert.Equal(t, rendering.SystemMarkupMarkdown, description.Markup)
 

--- a/rendering/markup_content.go
+++ b/rendering/markup_content.go
@@ -1,6 +1,4 @@
-package workitem
-
-import "github.com/almighty/almighty-core/rendering"
+package rendering
 
 // MarkupContent defines the raw content of a field along with the markup language used to input the content.
 type MarkupContent struct {
@@ -15,11 +13,11 @@ const (
 	MarkupKey = "markup"
 )
 
-func (markupContent *MarkupContent) toMap() map[string]interface{} {
+func (markupContent *MarkupContent) ToMap() map[string]interface{} {
 	result := make(map[string]interface{})
 	result[ContentKey] = markupContent.Content
 	if markupContent.Markup == "" {
-		result[MarkupKey] = rendering.SystemMarkupDefault
+		result[MarkupKey] = SystemMarkupDefault
 	} else {
 		result[MarkupKey] = markupContent.Markup
 	}
@@ -31,12 +29,12 @@ func (markupContent *MarkupContent) toMap() map[string]interface{} {
 // This avoids filling the DB with invalid markup types.
 func NewMarkupContentFromMap(value map[string]interface{}) MarkupContent {
 	content := value[ContentKey].(string)
-	markup := rendering.SystemMarkupDefault
+	markup := SystemMarkupDefault
 	if m, ok := value[MarkupKey]; ok {
 		markup = m.(string)
 		// use default markup if the input is not supported
-		if !rendering.IsMarkupSupported(markup) {
-			markup = rendering.SystemMarkupDefault
+		if !IsMarkupSupported(markup) {
+			markup = SystemMarkupDefault
 		}
 	}
 	return MarkupContent{Content: content, Markup: markup}
@@ -44,7 +42,7 @@ func NewMarkupContentFromMap(value map[string]interface{}) MarkupContent {
 
 // NewMarkupContentFromLegacy creates a MarkupContent from the given content, using the default markup.
 func NewMarkupContentFromLegacy(content string) MarkupContent {
-	return MarkupContent{Content: content, Markup: rendering.SystemMarkupDefault}
+	return MarkupContent{Content: content, Markup: SystemMarkupDefault}
 }
 
 // NewMarkupContent creates a MarkupContent from the given content, using the default markup.

--- a/search/search_repository_whitebox_test.go
+++ b/search/search_repository_whitebox_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/migration"
 	"github.com/almighty/almighty-core/models"
+	"github.com/almighty/almighty-core/rendering"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/jinzhu/gorm"
@@ -58,7 +59,7 @@ func (s *searchRepositoryWhiteboxTest) TestSearchByText() {
 			wi: app.WorkItem{
 				Fields: map[string]interface{}{
 					workitem.SystemTitle:       "test sbose title '12345678asdfgh'",
-					workitem.SystemDescription: workitem.NewMarkupContentFromLegacy(`"description" for search test`),
+					workitem.SystemDescription: rendering.NewMarkupContentFromLegacy(`"description" for search test`),
 					workitem.SystemCreator:     "sbose78",
 					workitem.SystemAssignees:   []string{"pranav"},
 					workitem.SystemState:       "closed",
@@ -71,7 +72,7 @@ func (s *searchRepositoryWhiteboxTest) TestSearchByText() {
 			wi: app.WorkItem{
 				Fields: map[string]interface{}{
 					workitem.SystemTitle:       "add new error types in models/errors.go'",
-					workitem.SystemDescription: workitem.NewMarkupContentFromLegacy(`Make sure remoteworkitem can access..`),
+					workitem.SystemDescription: rendering.NewMarkupContentFromLegacy(`Make sure remoteworkitem can access..`),
 					workitem.SystemCreator:     "sbose78",
 					workitem.SystemAssignees:   []string{"pranav"},
 					workitem.SystemState:       "closed",
@@ -84,7 +85,7 @@ func (s *searchRepositoryWhiteboxTest) TestSearchByText() {
 			wi: app.WorkItem{
 				Fields: map[string]interface{}{
 					workitem.SystemTitle:       "test sbose title '12345678asdfgh'",
-					workitem.SystemDescription: workitem.NewMarkupContentFromLegacy(`"description" for search test`),
+					workitem.SystemDescription: rendering.NewMarkupContentFromLegacy(`"description" for search test`),
 					workitem.SystemCreator:     "sbose78",
 					workitem.SystemAssignees:   []string{"pranav"},
 					workitem.SystemState:       "closed",
@@ -206,7 +207,7 @@ func (s *searchRepositoryWhiteboxTest) TestSearchByText() {
 					}
 					workItemDescription := ""
 					if workItemValue.Fields[workitem.SystemDescription] != nil {
-						descriptionField := workItemValue.Fields[workitem.SystemDescription].(workitem.MarkupContent)
+						descriptionField := workItemValue.Fields[workitem.SystemDescription].(rendering.MarkupContent)
 						workItemDescription = strings.ToLower(descriptionField.Content)
 					}
 					keyWord = strings.ToLower(keyWord)
@@ -248,7 +249,7 @@ func (s *searchRepositoryWhiteboxTest) TestSearchByID() {
 
 		workItem.Fields = map[string]interface{}{
 			workitem.SystemTitle:       "Search Test Sbose",
-			workitem.SystemDescription: workitem.NewMarkupContentFromLegacy("Description"),
+			workitem.SystemDescription: rendering.NewMarkupContentFromLegacy("Description"),
 			workitem.SystemCreator:     "sbose78",
 			workitem.SystemAssignees:   []string{"pranav"},
 			workitem.SystemState:       "closed",

--- a/search_blackbox_test.go
+++ b/search_blackbox_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/almighty/almighty-core/app/test"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/gormsupport"
+	"github.com/almighty/almighty-core/rendering"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/almighty/almighty-core/search"
 	testsupport "github.com/almighty/almighty-core/test"
@@ -121,7 +122,7 @@ func TestSearchWithDomainPortCombination(t *testing.T) {
 	wiRepo := workitem.NewWorkItemRepository(DB)
 
 	description := "http://localhost:8080/detail/154687364529310 is related issue"
-	expectedDescription := workitem.NewMarkupContentFromLegacy(description)
+	expectedDescription := rendering.NewMarkupContentFromLegacy(description)
 	_, err := wiRepo.Create(
 		context.Background(),
 		workitem.SystemBug,
@@ -148,7 +149,7 @@ func TestSearchURLWithoutPort(t *testing.T) {
 	wiRepo := workitem.NewWorkItemRepository(DB)
 
 	description := "This issue is related to http://localhost/detail/876394"
-	expectedDescription := workitem.NewMarkupContentFromLegacy(description)
+	expectedDescription := rendering.NewMarkupContentFromLegacy(description)
 	_, err := wiRepo.Create(
 		context.Background(),
 		workitem.SystemBug,
@@ -176,7 +177,7 @@ func TestUnregisteredURLWithPort(t *testing.T) {
 	wiRepo := workitem.NewWorkItemRepository(DB)
 
 	description := "Related to http://some-other-domain:8080/different-path/154687364529310/ok issue"
-	expectedDescription := workitem.NewMarkupContentFromLegacy(description)
+	expectedDescription := rendering.NewMarkupContentFromLegacy(description)
 	_, err := wiRepo.Create(
 		context.Background(),
 		workitem.SystemBug,
@@ -203,7 +204,7 @@ func TestUnwantedCharactersRelatedToSearchLogic(t *testing.T) {
 	service := getServiceAsUser()
 	wiRepo := workitem.NewWorkItemRepository(DB)
 
-	expectedDescription := workitem.NewMarkupContentFromLegacy("Related to http://example-domain:8080/different-path/ok issue")
+	expectedDescription := rendering.NewMarkupContentFromLegacy("Related to http://example-domain:8080/different-path/ok issue")
 
 	_, err := wiRepo.Create(
 		context.Background(),

--- a/workitem.go
+++ b/workitem.go
@@ -323,12 +323,12 @@ func ConvertJSONAPIToWorkItem(appl application.Application, source app.WorkItem2
 	for key, val := range source.Attributes {
 		// convert legacy description to markup content
 		if key == workitem.SystemDescription && reflect.TypeOf(val).Kind() == reflect.String {
-			target.Fields[key] = workitem.NewMarkupContentFromLegacy(val.(string))
+			target.Fields[key] = rendering.NewMarkupContentFromLegacy(val.(string))
 		} else {
 			target.Fields[key] = val
 		}
 	}
-	if description, ok := target.Fields[workitem.SystemDescription].(workitem.MarkupContent); ok {
+	if description, ok := target.Fields[workitem.SystemDescription].(rendering.MarkupContent); ok {
 		// verify the description markup
 		if !rendering.IsMarkupSupported(description.Markup) {
 			return errors.NewBadParameterError("data.relationships.attributes[system.description].markup", description.Markup)
@@ -402,7 +402,7 @@ func ConvertWorkItem(request *goa.RequestData, wi *app.WorkItem, additional ...W
 			}
 
 		case workitem.SystemDescription:
-			description := workitem.NewMarkupContentFromValue(val)
+			description := rendering.NewMarkupContentFromValue(val)
 			if description != nil {
 				op.Attributes[name] = (*description).Content
 				op.Attributes[workitem.SystemDescriptionMarkup] = (*description).Markup

--- a/workitem/fieldtype_blackbox_test.go
+++ b/workitem/fieldtype_blackbox_test.go
@@ -74,8 +74,8 @@ func TestSimpleTypeConversion(t *testing.T) {
 		// {stList, []int{}, []int{}, false}, need to find out the way for empty array.
 		// because slices do not have equality operator.
 
-		{stMarkup, NewMarkupContent("## description", rendering.SystemMarkupDefault), markupContent1, false},
-		{stMarkup, NewMarkupContent("## description", rendering.SystemMarkupMarkdown), markupContent2, false},
+		{stMarkup, rendering.NewMarkupContent("## description", rendering.SystemMarkupDefault), markupContent1, false},
+		{stMarkup, rendering.NewMarkupContent("## description", rendering.SystemMarkupMarkdown), markupContent2, false},
 		{stMarkup, nil, nil, false},
 		{stMarkup, 1, nil, true},
 	}

--- a/workitem/markup_content_blackbox_test.go
+++ b/workitem/markup_content_blackbox_test.go
@@ -4,53 +4,52 @@ import (
 	"testing"
 
 	"github.com/almighty/almighty-core/rendering"
-	"github.com/almighty/almighty-core/workitem"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewMarkupContentFromMapWithValidMarkup(t *testing.T) {
 	// given
 	input := make(map[string]interface{})
-	input[workitem.ContentKey] = "foo"
-	input[workitem.MarkupKey] = rendering.SystemMarkupMarkdown
+	input[rendering.ContentKey] = "foo"
+	input[rendering.MarkupKey] = rendering.SystemMarkupMarkdown
 	// when
-	result := workitem.NewMarkupContentFromMap(input)
+	result := rendering.NewMarkupContentFromMap(input)
 	// then
-	assert.Equal(t, input[workitem.ContentKey].(string), result.Content)
-	assert.Equal(t, input[workitem.MarkupKey].(string), result.Markup)
+	assert.Equal(t, input[rendering.ContentKey].(string), result.Content)
+	assert.Equal(t, input[rendering.MarkupKey].(string), result.Markup)
 }
 
 func TestNewMarkupContentFromMapWithInvalidMarkup(t *testing.T) {
 	// given
 	input := make(map[string]interface{})
-	input[workitem.ContentKey] = "foo"
-	input[workitem.MarkupKey] = "bar"
+	input[rendering.ContentKey] = "foo"
+	input[rendering.MarkupKey] = "bar"
 	// when
-	result := workitem.NewMarkupContentFromMap(input)
+	result := rendering.NewMarkupContentFromMap(input)
 	// then
-	assert.Equal(t, input[workitem.ContentKey].(string), result.Content)
+	assert.Equal(t, input[rendering.ContentKey].(string), result.Content)
 	assert.Equal(t, rendering.SystemMarkupDefault, result.Markup)
 }
 
 func TestNewMarkupContentFromMapWithMissingMarkup(t *testing.T) {
 	// given
 	input := make(map[string]interface{})
-	input[workitem.ContentKey] = "foo"
+	input[rendering.ContentKey] = "foo"
 	// when
-	result := workitem.NewMarkupContentFromMap(input)
+	result := rendering.NewMarkupContentFromMap(input)
 	// then
-	assert.Equal(t, input[workitem.ContentKey].(string), result.Content)
+	assert.Equal(t, input[rendering.ContentKey].(string), result.Content)
 	assert.Equal(t, rendering.SystemMarkupDefault, result.Markup)
 }
 
 func TestNewMarkupContentFromMapWithEmptyMarkup(t *testing.T) {
 	// given
 	input := make(map[string]interface{})
-	input[workitem.ContentKey] = "foo"
-	input[workitem.MarkupKey] = ""
+	input[rendering.ContentKey] = "foo"
+	input[rendering.MarkupKey] = ""
 	// when
-	result := workitem.NewMarkupContentFromMap(input)
+	result := rendering.NewMarkupContentFromMap(input)
 	// then
-	assert.Equal(t, input[workitem.ContentKey].(string), result.Content)
+	assert.Equal(t, input[rendering.ContentKey].(string), result.Content)
 	assert.Equal(t, rendering.SystemMarkupDefault, result.Markup)
 }

--- a/workitem/simple_type.go
+++ b/workitem/simple_type.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/almighty/almighty-core/convert"
+	"github.com/almighty/almighty-core/rendering"
 	"github.com/asaskevich/govalidator"
 	"github.com/pkg/errors"
 )
@@ -87,9 +88,9 @@ func (fieldType SimpleType) ConvertToModel(value interface{}) (interface{}, erro
 		// 'markup' is just a string in the API layer for now:
 		// it corresponds to the MarkupContent.Content field. The MarkupContent.Markup is set to the default value
 		switch value.(type) {
-		case MarkupContent:
-			markupContent := value.(MarkupContent)
-			return markupContent.toMap(), nil
+		case rendering.MarkupContent:
+			markupContent := value.(rendering.MarkupContent)
+			return markupContent.ToMap(), nil
 		default:
 			return nil, errors.Errorf("value %v should be %s, but is %s", value, "MarkupContent", valueType)
 		}
@@ -118,7 +119,7 @@ func (fieldType SimpleType) ConvertFromModel(value interface{}) (interface{}, er
 		if valueType.Kind() != reflect.Map {
 			return nil, errors.Errorf("value %v should be %s, but is %s", value, reflect.Map, valueType.Name())
 		}
-		markupContent := NewMarkupContentFromMap(value.(map[string]interface{}))
+		markupContent := rendering.NewMarkupContentFromMap(value.(map[string]interface{}))
 		return markupContent, nil
 	default:
 		return nil, errors.Errorf("unexpected field type: %s", fieldType.GetKind())

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -163,7 +163,7 @@ func (r *GormWorkItemRepository) Create(ctx context.Context, typeID string, fiel
 			return nil, errors.NewBadParameterError(fieldName, fieldValue)
 		}
 		if fieldName == SystemDescription && wi.Fields[fieldName] != nil {
-			description := NewMarkupContentFromMap(wi.Fields[fieldName].(map[string]interface{}))
+			description := rendering.NewMarkupContentFromMap(wi.Fields[fieldName].(map[string]interface{}))
 			if !rendering.IsMarkupSupported(description.Markup) {
 				return nil, errors.NewBadParameterError(fieldName, fieldValue)
 			}

--- a/workitem/workitem_repository_blackbox_test.go
+++ b/workitem/workitem_repository_blackbox_test.go
@@ -117,14 +117,14 @@ func (s *workItemRepoBlackBoxTest) TestCreateWorkItemWithDescriptionNoMarkup() {
 		context.Background(), workitem.SystemBug,
 		map[string]interface{}{
 			workitem.SystemTitle:       "Title",
-			workitem.SystemDescription: workitem.NewMarkupContentFromLegacy("Description"),
+			workitem.SystemDescription: rendering.NewMarkupContentFromLegacy("Description"),
 			workitem.SystemState:       workitem.SystemStateNew,
 		}, "xx")
 	require.Nil(s.T(), err, "Could not create workitem")
 
 	wi, err = s.repo.Load(context.Background(), wi.ID)
 	// app.WorkItem does not contain the markup associated with the description (yet)
-	assert.Equal(s.T(), workitem.NewMarkupContentFromLegacy("Description"), wi.Fields[workitem.SystemDescription])
+	assert.Equal(s.T(), rendering.NewMarkupContentFromLegacy("Description"), wi.Fields[workitem.SystemDescription])
 }
 
 func (s *workItemRepoBlackBoxTest) TestCreateWorkItemWithDescriptionMarkup() {
@@ -133,13 +133,13 @@ func (s *workItemRepoBlackBoxTest) TestCreateWorkItemWithDescriptionMarkup() {
 		context.Background(), workitem.SystemBug,
 		map[string]interface{}{
 			workitem.SystemTitle:       "Title",
-			workitem.SystemDescription: workitem.NewMarkupContent("Description", rendering.SystemMarkupMarkdown),
+			workitem.SystemDescription: rendering.NewMarkupContent("Description", rendering.SystemMarkupMarkdown),
 			workitem.SystemState:       workitem.SystemStateNew,
 		}, "xx")
 	require.Nil(s.T(), err, "Could not create workitem")
 	wi, err = s.repo.Load(context.Background(), wi.ID)
 	// app.WorkItem does not contain the markup associated with the description (yet)
-	assert.Equal(s.T(), workitem.NewMarkupContent("Description", rendering.SystemMarkupMarkdown), wi.Fields[workitem.SystemDescription])
+	assert.Equal(s.T(), rendering.NewMarkupContent("Description", rendering.SystemMarkupMarkdown), wi.Fields[workitem.SystemDescription])
 }
 
 // TestTypeChangeIsNotProhibitedOnDBLayer tests that you can change the type of

--- a/workitem_blackbox_test.go
+++ b/workitem_blackbox_test.go
@@ -696,7 +696,7 @@ func (s *WorkItem2Suite) TestWI2UpdateOnlyLegacyDescription() {
 
 func (s *WorkItem2Suite) TestWI2UpdateOnlyMarkupDescriptionWithoutMarkup() {
 	s.minimumPayload.Data.Attributes[workitem.SystemTitle] = "Test title"
-	modifiedDescription := workitem.NewMarkupContentFromLegacy("Only Description is modified")
+	modifiedDescription := rendering.NewMarkupContentFromLegacy("Only Description is modified")
 	expectedDescription := "Only Description is modified"
 	expectedRenderedDescription := "Only Description is modified"
 	s.minimumPayload.Data.Attributes[workitem.SystemDescription] = modifiedDescription
@@ -709,7 +709,7 @@ func (s *WorkItem2Suite) TestWI2UpdateOnlyMarkupDescriptionWithoutMarkup() {
 
 func (s *WorkItem2Suite) TestWI2UpdateOnlyMarkupDescriptionWithMarkup() {
 	s.minimumPayload.Data.Attributes[workitem.SystemTitle] = "Test title"
-	modifiedDescription := workitem.NewMarkupContent("Only Description is modified", rendering.SystemMarkupMarkdown)
+	modifiedDescription := rendering.NewMarkupContent("Only Description is modified", rendering.SystemMarkupMarkdown)
 	expectedDescription := "Only Description is modified"
 	expectedRenderedDescription := "<p>Only Description is modified</p>\n"
 	s.minimumPayload.Data.Attributes[workitem.SystemDescription] = modifiedDescription
@@ -875,7 +875,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWorkItemWithDescriptionAndMarkup() 
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
-	c.Data.Attributes[workitem.SystemDescription] = workitem.NewMarkupContent("Description", rendering.SystemMarkupMarkdown)
+	c.Data.Attributes[workitem.SystemDescription] = rendering.NewMarkupContent("Description", rendering.SystemMarkupMarkdown)
 	c.Data.Relationships = &app.WorkItemRelationships{
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
@@ -902,7 +902,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWorkItemWithDescriptionAndNoMarkup(
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
-	c.Data.Attributes[workitem.SystemDescription] = workitem.NewMarkupContentFromLegacy("Description")
+	c.Data.Attributes[workitem.SystemDescription] = rendering.NewMarkupContentFromLegacy("Description")
 	c.Data.Relationships = &app.WorkItemRelationships{
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{
@@ -929,7 +929,7 @@ func (s *WorkItem2Suite) TestWI2FailCreateWorkItemWithDescriptionAndUnsupportedM
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
-	c.Data.Attributes[workitem.SystemDescription] = workitem.NewMarkupContent("Description", "foo")
+	c.Data.Attributes[workitem.SystemDescription] = rendering.NewMarkupContent("Description", "foo")
 	c.Data.Relationships = &app.WorkItemRelationships{
 		BaseType: &app.RelationBaseType{
 			Data: &app.BaseTypeData{

--- a/workitem_whitebox_test.go
+++ b/workitem_whitebox_test.go
@@ -197,7 +197,7 @@ func TestConvertJSONAPIToWorkItemWithLegacyDescription(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, target)
 	require.NotNil(t, target.Fields)
-	expectedDescription := workitem.NewMarkupContentFromLegacy("description")
+	expectedDescription := rendering.NewMarkupContentFromLegacy("description")
 	assert.Equal(t, expectedDescription, target.Fields[workitem.SystemDescription])
 }
 
@@ -205,7 +205,7 @@ func TestConvertJSONAPIToWorkItemWithDescriptionContentNoMarkup(t *testing.T) {
 	appl := new(application.Application)
 	attributes := map[string]interface{}{
 		workitem.SystemTitle:       "title",
-		workitem.SystemDescription: workitem.NewMarkupContentFromLegacy("description"),
+		workitem.SystemDescription: rendering.NewMarkupContentFromLegacy("description"),
 	}
 	source := app.WorkItem2{Type: workitem.SystemBug, Attributes: attributes}
 	target := &app.WorkItem{Fields: map[string]interface{}{}}
@@ -213,7 +213,7 @@ func TestConvertJSONAPIToWorkItemWithDescriptionContentNoMarkup(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, target)
 	require.NotNil(t, target.Fields)
-	expectedDescription := workitem.NewMarkupContentFromLegacy("description")
+	expectedDescription := rendering.NewMarkupContentFromLegacy("description")
 	assert.Equal(t, expectedDescription, target.Fields[workitem.SystemDescription])
 }
 
@@ -221,7 +221,7 @@ func TestConvertJSONAPIToWorkItemWithDescriptionContentAndMarkup(t *testing.T) {
 	appl := new(application.Application)
 	attributes := map[string]interface{}{
 		workitem.SystemTitle:       "title",
-		workitem.SystemDescription: workitem.NewMarkupContent("description", rendering.SystemMarkupMarkdown),
+		workitem.SystemDescription: rendering.NewMarkupContent("description", rendering.SystemMarkupMarkdown),
 	}
 	source := app.WorkItem2{Type: workitem.SystemBug, Attributes: attributes}
 	target := &app.WorkItem{Fields: map[string]interface{}{}}
@@ -229,7 +229,7 @@ func TestConvertJSONAPIToWorkItemWithDescriptionContentAndMarkup(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, target)
 	require.NotNil(t, target.Fields)
-	expectedDescription := workitem.NewMarkupContent("description", rendering.SystemMarkupMarkdown)
+	expectedDescription := rendering.NewMarkupContent("description", rendering.SystemMarkupMarkdown)
 	assert.Equal(t, expectedDescription, target.Fields[workitem.SystemDescription])
 }
 


### PR DESCRIPTION
Moved the `MarkupContent` struct and its utility functions
into the `rendering` package.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

