### PR TITLE
Rewire configuration framework to use dedicated viper instance.

### DIFF
--- a/account/user_test.go
+++ b/account/user_test.go
@@ -5,14 +5,14 @@ import (
 	"os"
 	"testing"
 
+	config "github.com/almighty/almighty-core/configuration"
 	"golang.org/x/net/context"
 
 	"github.com/almighty/almighty-core/account"
-	"github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/migration"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/jinzhu/gorm"
-	_ "github.com/lib/pq"
+
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 )
@@ -21,8 +21,8 @@ var db *gorm.DB
 
 func TestMain(m *testing.M) {
 	if _, c := os.LookupEnv(resource.Database); c != false {
-		var err error
-		if err = configuration.Setup(""); err != nil {
+		configuration, err := config.NewConfigurationData("../" + config.GetDefaultConfigurationFile())
+		if err != nil {
 			panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 		}
 

--- a/comment/comment_test.go
+++ b/comment/comment_test.go
@@ -7,7 +7,9 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/almighty/almighty-core/comment"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormsupport"
+
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/resource"
 	uuid "github.com/satori/go.uuid"
@@ -22,7 +24,7 @@ type TestCommentRepository struct {
 
 func TestRunCommentRepository(t *testing.T) {
 	resource.Require(t, resource.Database)
-	suite.Run(t, &TestCommentRepository{DBTestSuite: gormsupport.NewDBTestSuite("../config.yaml")})
+	suite.Run(t, &TestCommentRepository{DBTestSuite: gormsupport.NewDBTestSuite("../" + config.GetDefaultConfigurationFile())})
 }
 
 func (test *TestCommentRepository) SetupTest() {

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -2,58 +2,24 @@ package configuration
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	yaml "gopkg.in/yaml.v2"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 )
 
 // String returns the current configuration as a string
-func String() string {
-	allSettings := viper.AllSettings()
+func (c *ConfigurationData) String() (string, error) {
+	allSettings := c.v.AllSettings()
 	y, err := yaml.Marshal(&allSettings)
 	if err != nil {
-		panic(fmt.Errorf("Failed to marshall config to string: %s", err.Error()))
+		return "", errors.Wrap(err, "Failed to marshall config to string")
 	}
-	return fmt.Sprintf("%s\n", y)
-}
-
-// Setup sets up defaults for viper configuration options and
-// overrides these values with the values from the given configuration file
-// if it is not empty. Those values again are overwritten by environment
-// variables.
-func Setup(configFilePath string) error {
-	viper.Reset()
-
-	// Expect environment variables to be prefix with "ALMIGHTY_".
-	viper.SetEnvPrefix("ALMIGHTY")
-
-	// Automatically map environment variables to viper values
-	viper.AutomaticEnv()
-
-	// To override nested variables through environment variables, we
-	// need to make sure that we don't have to use dots (".") inside the
-	// environment variable names.
-	// To override foo.bar you need to set ALM_FOO_BAR
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-
-	viper.SetTypeByDefaultValue(true)
-	setConfigDefaults()
-
-	// Read the config
-	// Explicitly specify which file to load config from
-	if configFilePath != "" {
-		viper.SetConfigFile(configFilePath)
-		viper.SetConfigType("yaml")
-		err := viper.ReadInConfig() // Find and read the config file
-		if err != nil {             // Handle errors reading the config file
-			return fmt.Errorf("Fatal error config file: %s \n", err)
-		}
-	}
-
-	return nil
+	return fmt.Sprintf("%s\n", y), nil
 }
 
 // Constants for viper variable names. Will be used to set
@@ -78,163 +44,212 @@ const (
 	varKeycloakEndpointUserinfo     = "keycloak.endpoint.userinfo"
 	varTokenPublicKey               = "token.publickey"
 	varTokenPrivateKey              = "token.privatekey"
+	defaultConfigFile               = "config.yaml"
 )
 
-func setConfigDefaults() {
+func (c *ConfigurationData) setConfigDefaults() {
 	//---------
 	// Postgres
 	//---------
-	viper.SetTypeByDefaultValue(true)
-	viper.SetDefault(varPostgresHost, "localhost")
-	viper.SetDefault(varPostgresPort, 5432)
-	viper.SetDefault(varPostgresUser, "postgres")
-	viper.SetDefault(varPostgresDatabase, "postgres")
-	viper.SetDefault(varPostgresPassword, "mysecretpassword")
-	viper.SetDefault(varPostgresSSLMode, "disable")
+	c.v.SetTypeByDefaultValue(true)
+	c.v.SetDefault(varPostgresHost, "localhost")
+	c.v.SetDefault(varPostgresPort, 5432)
+	c.v.SetDefault(varPostgresUser, "postgres")
+	c.v.SetDefault(varPostgresDatabase, "postgres")
+	c.v.SetDefault(varPostgresPassword, "mysecretpassword")
+	c.v.SetDefault(varPostgresSSLMode, "disable")
 	// The number of times alm server will attempt to open a connection to the database before it gives up
-	viper.SetDefault(varPostgresConnectionMaxRetries, 50)
+	c.v.SetDefault(varPostgresConnectionMaxRetries, 50)
 	// Number of seconds to wait before trying to connect again
-	viper.SetDefault(varPostgresConnectionRetrySleep, time.Duration(time.Second))
+	c.v.SetDefault(varPostgresConnectionRetrySleep, time.Duration(time.Second))
 
 	//-----
 	// HTTP
 	//-----
-	viper.SetDefault(varHTTPAddress, "0.0.0.0:8080")
+	c.v.SetDefault(varHTTPAddress, "0.0.0.0:8080")
 
 	//-----
 	// Misc
 	//-----
 
 	// Enable development related features, e.g. token generation endpoint
-	viper.SetDefault(varDeveloperModeEnabled, false)
+	c.v.SetDefault(varDeveloperModeEnabled, false)
 
-	viper.SetDefault(varPopulateCommonTypes, true)
+	c.v.SetDefault(varPopulateCommonTypes, true)
 
 	// Auth-related defaults
-	viper.SetDefault(varTokenPublicKey, defaultTokenPublicKey)
-	viper.SetDefault(varTokenPrivateKey, defaultTokenPrivateKey)
-	viper.SetDefault(varKeycloakClientID, defaultKeycloakClientID)
-	viper.SetDefault(varKeycloakSecret, defaultKeycloakSecret)
-	viper.SetDefault(varGithubAuthToken, defaultActualToken)
-	viper.SetDefault(varKeycloakEndpointAuth, defaultKeycloakEndpointAuth)
-	viper.SetDefault(varKeycloakEndpointToken, defaultKeycloakEndpointToken)
-	viper.SetDefault(varKeycloakEndpointUserinfo, defaultKeycloakEndpointUserinfo)
+	c.v.SetDefault(varTokenPublicKey, defaultTokenPublicKey)
+	c.v.SetDefault(varTokenPrivateKey, defaultTokenPrivateKey)
+	c.v.SetDefault(varKeycloakClientID, defaultKeycloakClientID)
+	c.v.SetDefault(varKeycloakSecret, defaultKeycloakSecret)
+	c.v.SetDefault(varGithubAuthToken, defaultActualToken)
+	c.v.SetDefault(varKeycloakEndpointAuth, defaultKeycloakEndpointAuth)
+	c.v.SetDefault(varKeycloakEndpointToken, defaultKeycloakEndpointToken)
+	c.v.SetDefault(varKeycloakEndpointUserinfo, defaultKeycloakEndpointUserinfo)
+}
+
+// ConfigurationData encapsulates the Viper configuration object which stores the configuration data in-memory.
+type ConfigurationData struct {
+	v *viper.Viper
+}
+
+func getConfigFilePath() string {
+	// This was either passed as a env var Or, set inside main.go from --config
+	envConfigPath, ok := os.LookupEnv("ALMIGHTY_CONFIG_FILE_PATH")
+	if !ok {
+		return ""
+	}
+	return envConfigPath
+}
+
+// GetDefaultConfigurationFilereturns the default configuration file.
+func GetDefaultConfigurationFile() string {
+	return defaultConfigFile
+}
+
+// GetConfigurationData is a wrapper over NewConfigurationData which reads configuration file path
+// from the environment variable.
+func GetConfigurationData() (*ConfigurationData, error) {
+	cd, err := NewConfigurationData(getConfigFilePath())
+	return cd, err
+}
+
+// NewConfigurationData creates a configuration reader object using a configurable configuration file path
+func NewConfigurationData(configFilePath string) (*ConfigurationData, error) {
+	c := ConfigurationData{
+		v: viper.New(),
+	}
+	c.v.SetEnvPrefix("ALMIGHTY")
+	c.v.AutomaticEnv()
+	c.v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	c.v.SetTypeByDefaultValue(true)
+	c.setConfigDefaults()
+
+	if configFilePath != "" {
+		c.v.SetConfigType("yaml")
+		c.v.SetConfigFile(configFilePath)
+		err := c.v.ReadInConfig() // Find and read the config file
+		if err != nil {           // Handle errors reading the config file
+			return nil, errors.Errorf("Fatal error config file: %s \n", err)
+		}
+	}
+	return &c, nil
+}
+
+// GetKeycloakEndpointToken returns the keycloak endpoint token as set via default, config file, or environment variable
+func (c *ConfigurationData) GetKeycloakEndpointToken() string {
+	return c.v.GetString(varKeycloakEndpointToken)
 }
 
 // GetPostgresHost returns the postgres host as set via default, config file, or environment variable
-func GetPostgresHost() string {
-	return viper.GetString(varPostgresHost)
+func (c *ConfigurationData) GetPostgresHost() string {
+	return c.v.GetString(varPostgresHost)
 }
 
 // GetPostgresPort returns the postgres port as set via default, config file, or environment variable
-func GetPostgresPort() int64 {
-	return viper.GetInt64(varPostgresPort)
+func (c *ConfigurationData) GetPostgresPort() int64 {
+	return c.v.GetInt64(varPostgresPort)
 }
 
 // GetPostgresUser returns the postgres user as set via default, config file, or environment variable
-func GetPostgresUser() string {
-	return viper.GetString(varPostgresUser)
+func (c *ConfigurationData) GetPostgresUser() string {
+	return c.v.GetString(varPostgresUser)
 }
 
 // GetPostgresDatabase returns the postgres database as set via default, config file, or environment variable
-func GetPostgresDatabase() string {
-	return viper.GetString(varPostgresDatabase)
+func (c *ConfigurationData) GetPostgresDatabase() string {
+	return c.v.GetString(varPostgresDatabase)
 }
 
 // GetPostgresPassword returns the postgres password as set via default, config file, or environment variable
-func GetPostgresPassword() string {
-	return viper.GetString(varPostgresPassword)
+func (c *ConfigurationData) GetPostgresPassword() string {
+	return c.v.GetString(varPostgresPassword)
 }
 
 // GetPostgresSSLMode returns the postgres sslmode as set via default, config file, or environment variable
-func GetPostgresSSLMode() string {
-	return viper.GetString(varPostgresSSLMode)
+func (c *ConfigurationData) GetPostgresSSLMode() string {
+	return c.v.GetString(varPostgresSSLMode)
 }
 
 // GetPostgresConnectionMaxRetries returns the number of times (as set via default, config file, or environment variable)
 // alm server will attempt to open a connection to the database before it gives up
-func GetPostgresConnectionMaxRetries() int {
-	return viper.GetInt(varPostgresConnectionMaxRetries)
+func (c *ConfigurationData) GetPostgresConnectionMaxRetries() int {
+	return c.v.GetInt(varPostgresConnectionMaxRetries)
 }
 
 // GetPostgresConnectionRetrySleep returns the number of seconds (as set via default, config file, or environment variable)
 // to wait before trying to connect again
-func GetPostgresConnectionRetrySleep() time.Duration {
-	return viper.GetDuration(varPostgresConnectionRetrySleep)
+func (c *ConfigurationData) GetPostgresConnectionRetrySleep() time.Duration {
+	return c.v.GetDuration(varPostgresConnectionRetrySleep)
 }
 
 // GetPostgresConfigString returns a ready to use string for usage in sql.Open()
-func GetPostgresConfigString() string {
+func (c *ConfigurationData) GetPostgresConfigString() string {
 	return fmt.Sprintf("host=%s port=%d user=%s password=%s DB.name=%s sslmode=%s",
-		GetPostgresHost(),
-		GetPostgresPort(),
-		GetPostgresUser(),
-		GetPostgresPassword(),
-		GetPostgresDatabase(),
-		GetPostgresSSLMode(),
+		c.GetPostgresHost(),
+		c.GetPostgresPort(),
+		c.GetPostgresUser(),
+		c.GetPostgresPassword(),
+		c.GetPostgresDatabase(),
+		c.GetPostgresSSLMode(),
 	)
 }
 
 // GetPopulateCommonTypes returns true if the (as set via default, config file, or environment variable)
 // the common work item types such as bug or feature shall be created.
-func GetPopulateCommonTypes() bool {
-	return viper.GetBool(varPopulateCommonTypes)
+func (c *ConfigurationData) GetPopulateCommonTypes() bool {
+	return c.v.GetBool(varPopulateCommonTypes)
 }
 
 // GetHTTPAddress returns the HTTP address (as set via default, config file, or environment variable)
 // that the alm server binds to (e.g. "0.0.0.0:8080")
-func GetHTTPAddress() string {
-	return viper.GetString(varHTTPAddress)
+func (c *ConfigurationData) GetHTTPAddress() string {
+	return c.v.GetString(varHTTPAddress)
 }
 
 // IsPostgresDeveloperModeEnabled returns if development related features (as set via default, config file, or environment variable),
 // e.g. token generation endpoint are enabled
-func IsPostgresDeveloperModeEnabled() bool {
-	return viper.GetBool(varDeveloperModeEnabled)
+func (c *ConfigurationData) IsPostgresDeveloperModeEnabled() bool {
+	return c.v.GetBool(varDeveloperModeEnabled)
 }
 
 // GetTokenPrivateKey returns the private key (as set via config file or environment variable)
 // that is used to sign the authentication token.
-func GetTokenPrivateKey() []byte {
-	return []byte(viper.GetString(varTokenPrivateKey))
+func (c *ConfigurationData) GetTokenPrivateKey() []byte {
+	return []byte(c.v.GetString(varTokenPrivateKey))
 }
 
 // GetTokenPublicKey returns the public key (as set via config file or environment variable)
 // that is used to decrypt the authentication token.
-func GetTokenPublicKey() []byte {
-	return []byte(viper.GetString(varTokenPublicKey))
+func (c *ConfigurationData) GetTokenPublicKey() []byte {
+	return []byte(c.v.GetString(varTokenPublicKey))
 }
 
 // GetGithubAuthToken returns the actual Github OAuth Access Token
-func GetGithubAuthToken() string {
-	return viper.GetString(varGithubAuthToken)
+func (c *ConfigurationData) GetGithubAuthToken() string {
+	return c.v.GetString(varGithubAuthToken)
 }
 
 // GetKeycloakSecret returns the keycloak client secret (as set via config file or environment variable)
 // that is used to make authorized Keycloak API Calls.
-func GetKeycloakSecret() string {
-	return viper.GetString(varKeycloakSecret)
+func (c *ConfigurationData) GetKeycloakSecret() string {
+	return c.v.GetString(varKeycloakSecret)
 }
 
 // GetKeycloakClientID returns the keycloak client ID (as set via config file or environment variable)
 // that is used to make authorized Keycloak API Calls.
-func GetKeycloakClientID() string {
-	return viper.GetString(varKeycloakClientID)
+func (c *ConfigurationData) GetKeycloakClientID() string {
+	return c.v.GetString(varKeycloakClientID)
 }
 
 // GetKeycloakEndpointAuth returns the keycloak auth endpoint (as set via config file or environment variable)
-func GetKeycloakEndpointAuth() string {
-	return viper.GetString(varKeycloakEndpointAuth)
-}
-
-// GetKeycloakEndpointToken returns the keycloak token endpoint (as set via config file or environment variable)
-func GetKeycloakEndpointToken() string {
-	return viper.GetString(varKeycloakEndpointToken)
+func (c *ConfigurationData) GetKeycloakEndpointAuth() string {
+	return c.v.GetString(varKeycloakEndpointAuth)
 }
 
 // GetKeycloakEndpointUserinfo returns the keycloak userinfo endpoint (as set via config file or environment variable)
-func GetKeycloakEndpointUserinfo() string {
-	return viper.GetString(varKeycloakEndpointUserinfo)
+func (c *ConfigurationData) GetKeycloakEndpointUserinfo() string {
+	return c.v.GetString(varKeycloakEndpointUserinfo)
 }
 
 // Auth-related defaults

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -109,7 +109,6 @@ func TestGetPostgresHost(t *testing.T) {
 	require.Nil(t, err)
 	expectedValue := testConfigFileMap.PostgresHost
 
-	assert.NotNil(t, viperValue)
 	assert.Equal(t, expectedValue, viperValue)
 
 	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
@@ -148,7 +147,6 @@ func TestGetPostgresPort(t *testing.T) {
 	require.Nil(t, err)
 	expectedValue := testConfigFileMap.PostgresPort
 
-	assert.NotNil(t, viperValue)
 	assert.Equal(t, expectedValue, viperValue)
 
 	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
@@ -186,7 +184,6 @@ func TestGetPostgresUser(t *testing.T) {
 	require.Nil(t, err)
 	expectedValue := testConfigFileMap.PostgresUser
 
-	assert.NotNil(t, viperValue)
 	assert.Equal(t, expectedValue, viperValue)
 
 	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
@@ -225,7 +222,6 @@ func TestGetPostgresDatabase(t *testing.T) {
 	require.Nil(t, err)
 	expectedValue := testConfigFileMap.PostgresDatabase
 
-	assert.NotNil(t, viperValue)
 	assert.Equal(t, expectedValue, viperValue)
 
 	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
@@ -263,7 +259,6 @@ func TestGetPostgresPassword(t *testing.T) {
 	require.Nil(t, err)
 	expectedValue := testConfigFileMap.PostgresPassword
 
-	assert.NotNil(t, viperValue)
 	assert.Equal(t, expectedValue, viperValue)
 
 	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
@@ -301,7 +296,6 @@ func TestGetPostgresSSLMode(t *testing.T) {
 	require.Nil(t, err)
 	expectedValue := testConfigFileMap.PostgresSSLMode
 
-	assert.NotNil(t, viperValue)
 	assert.Equal(t, expectedValue, viperValue)
 
 	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
@@ -339,7 +333,6 @@ func TestGetPostgresConnectionMaxRetries(t *testing.T) {
 	require.Nil(t, err)
 	expectedValue := testConfigFileMap.PostgresConnectionMaxRetries
 
-	assert.NotNil(t, viperValue)
 	assert.Equal(t, expectedValue, viperValue)
 
 	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
@@ -377,7 +370,6 @@ func TestGetPostgresConnectionRetrySleep(t *testing.T) {
 	require.Nil(t, err)
 	expectedValue := testConfigFileMap.PostgresConnectionRetrySleep
 
-	assert.NotNil(t, viperValue)
 	assert.Equal(t, cast.ToDuration(expectedValue), viperValue)
 
 	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
@@ -424,7 +416,6 @@ func TestGetPopulateCommonTypes(t *testing.T) {
 	require.Nil(t, err)
 	expectedValue := testConfigFileMap.PopulateCommonTypes
 
-	assert.NotNil(t, viperValue)
 	assert.Equal(t, expectedValue, viperValue)
 
 	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
@@ -462,7 +453,6 @@ func TestGetHTTPAddress(t *testing.T) {
 	require.Nil(t, err)
 	expectedValue := testConfigFileMap.HTTPAddress
 
-	assert.NotNil(t, viperValue)
 	assert.Equal(t, expectedValue, viperValue)
 
 	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
@@ -500,7 +490,6 @@ func IsPostgresDeveloperModeEnabled(t *testing.T) {
 	require.Nil(t, err)
 	expectedValue := testConfigFileMap.DeveloperModeEnabled
 
-	assert.NotNil(t, viperValue)
 	assert.Equal(t, expectedValue, viperValue)
 
 	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
@@ -538,7 +527,6 @@ func TestGetTokenPrivateKey(t *testing.T) {
 	require.Nil(t, err)
 	expectedValue := testConfigFileMap.TokenPrivateKey
 
-	assert.NotNil(t, viperValue)
 	assert.Equal(t, []byte(expectedValue), viperValue)
 
 	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
@@ -576,7 +564,6 @@ func TestGetTokenPublicKey(t *testing.T) {
 	require.Nil(t, err)
 	expectedValue := testConfigFileMap.TokenPublicKey
 
-	assert.NotNil(t, viperValue)
 	assert.Equal(t, []byte(expectedValue), viperValue)
 
 	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
@@ -614,7 +601,6 @@ func TestGetKeycloakSecret(t *testing.T) {
 	require.Nil(t, err)
 	expectedValue := testConfigFileMap.KeycloakSecret
 
-	assert.NotNil(t, viperValue)
 	assert.Equal(t, expectedValue, viperValue)
 
 	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
@@ -652,7 +638,6 @@ func TestGetKeycloakClientID(t *testing.T) {
 	require.Nil(t, err)
 	expectedValue := testConfigFileMap.KeycloakClientID
 
-	assert.NotNil(t, viperValue)
 	assert.Equal(t, expectedValue, viperValue)
 
 	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
@@ -690,7 +675,6 @@ func TestGetKeycloakEndpointAuth(t *testing.T) {
 	require.Nil(t, err)
 	expectedValue := testConfigFileMap.KeycloakEndpointAuth
 
-	assert.NotNil(t, viperValue)
 	assert.Equal(t, expectedValue, viperValue)
 
 	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
@@ -728,7 +712,6 @@ func TestGetKeycloakEndpointUserinfo(t *testing.T) {
 	require.Nil(t, err)
 	expectedValue := testConfigFileMap.KeycloakEndpointUserinfo
 
-	assert.NotNil(t, viperValue)
 	assert.Equal(t, expectedValue, viperValue)
 
 	// env variable will now be SET, so now we check with env variable and NOT With config.yaml

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -40,6 +40,8 @@ func TestGetDefaultConfigurationFile(t *testing.T) {
 
 func TestGetConfigurationDataSucess(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
+
 	// this, in reality gets set in main
 	os.Setenv(tEnvironmentVariableNameConfigFile, tTestConfigFilePath)
 	cd, err := configuration.GetConfigurationData()
@@ -69,6 +71,7 @@ func TestNewConfigurationDataFail(t *testing.T) {
 
 func TestGetKeycloakEndpointToken(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	cd := getConfigurationDataHandler()
 	require.NotNil(t, cd)
@@ -85,6 +88,7 @@ func TestGetKeycloakEndpointToken(t *testing.T) {
 
 func TestGetPostgresHost(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	envKey := generateEnvKey(varPostgresHost)
 
@@ -123,6 +127,7 @@ func TestGetPostgresHost(t *testing.T) {
 
 func TestGetPostgresPort(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	envKey := generateEnvKey(varPostgresPort)
 
@@ -160,6 +165,7 @@ func TestGetPostgresPort(t *testing.T) {
 
 func TestGetPostgresUser(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	envKey := generateEnvKey(varPostgresUser)
 
@@ -198,6 +204,7 @@ func TestGetPostgresUser(t *testing.T) {
 
 func TestGetPostgresDatabase(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	envKey := generateEnvKey(varPostgresDatabase)
 
@@ -235,6 +242,7 @@ func TestGetPostgresDatabase(t *testing.T) {
 
 func TestGetPostgresPassword(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	envKey := generateEnvKey(varPostgresPassword)
 
@@ -272,6 +280,7 @@ func TestGetPostgresPassword(t *testing.T) {
 
 func TestGetPostgresSSLMode(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	envKey := generateEnvKey(varPostgresSSLMode)
 
@@ -309,6 +318,7 @@ func TestGetPostgresSSLMode(t *testing.T) {
 
 func TestGetPostgresConnectionMaxRetries(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	envKey := generateEnvKey(varPostgresConnectionMaxRetries)
 
@@ -346,6 +356,7 @@ func TestGetPostgresConnectionMaxRetries(t *testing.T) {
 
 func TestGetPostgresConnectionRetrySleep(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	envKey := generateEnvKey(varPostgresConnectionRetrySleep)
 
@@ -383,6 +394,7 @@ func TestGetPostgresConnectionRetrySleep(t *testing.T) {
 
 func TestGetPostgresConfigString(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	configurationData := getConfigurationDataHandler()
 	// This is a derviced config parameter, not present as is, in the config file.
@@ -391,6 +403,7 @@ func TestGetPostgresConfigString(t *testing.T) {
 
 func TestGetPopulateCommonTypes(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	envKey := generateEnvKey(varPopulateCommonTypes)
 
@@ -428,6 +441,7 @@ func TestGetPopulateCommonTypes(t *testing.T) {
 
 func TestGetHTTPAddress(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	envKey := generateEnvKey(varHTTPAddress)
 
@@ -465,6 +479,7 @@ func TestGetHTTPAddress(t *testing.T) {
 
 func IsPostgresDeveloperModeEnabled(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	envKey := generateEnvKey(varDeveloperModeEnabled)
 
@@ -502,6 +517,7 @@ func IsPostgresDeveloperModeEnabled(t *testing.T) {
 
 func TestGetTokenPrivateKey(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	envKey := generateEnvKey(varTokenPrivateKey)
 
@@ -539,6 +555,7 @@ func TestGetTokenPrivateKey(t *testing.T) {
 
 func TestGetTokenPublicKey(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	envKey := generateEnvKey(varTokenPublicKey)
 
@@ -576,6 +593,7 @@ func TestGetTokenPublicKey(t *testing.T) {
 
 func TestGetKeycloakSecret(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	envKey := generateEnvKey(varKeycloakSecret)
 
@@ -613,6 +631,7 @@ func TestGetKeycloakSecret(t *testing.T) {
 
 func TestGetKeycloakClientID(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	envKey := generateEnvKey(varKeycloakClientID)
 
@@ -650,6 +669,7 @@ func TestGetKeycloakClientID(t *testing.T) {
 
 func TestGetKeycloakEndpointAuth(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	envKey := generateEnvKey(varKeycloakEndpointAuth)
 
@@ -687,6 +707,7 @@ func TestGetKeycloakEndpointAuth(t *testing.T) {
 
 func TestGetKeycloakEndpointUserinfo(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	envKey := generateEnvKey(varKeycloakEndpointUserinfo)
 
@@ -729,6 +750,7 @@ and checks whether one doesn't override the other.append
 
 func TestMultipleConfigurations(t *testing.T) {
 	t.Parallel()
+	resource.Require(t, resource.UnitTest)
 
 	configurationData1, err := configuration.NewConfigurationData(tEnvironmentVariableValueConfigFile)
 	require.Nil(t, err)

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -1,0 +1,831 @@
+package configuration_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"testing"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"strings"
+
+	"github.com/almighty/almighty-core/configuration"
+	"github.com/almighty/almighty-core/resource"
+	"github.com/spf13/cast"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	tDefaultConfigurationFile           = "config.yaml"
+	tEnvironmentVariableNameConfigFile  = "ALMIGHTY_CONFIG_FILE_PATH"
+	tEnvironmentVariableValueConfigFile = "../config.yaml"
+	tInvalidConfigFilePath              = "../invalid_config.yaml"
+	tTestConfigFilePath                 = "../test/data/multiple_config.yaml"
+
+	// The following will be used to set env variables for testing.
+	tTestEnvString         = "ALMIGHTH_CONFIG_VALUE"
+	tTestEnvInt64    int64 = 12345
+	tTestEnvInt      int   = 12
+	tTestEnvDuration       = "1s"
+	tTestEnvBool           = false
+)
+
+func TestGetDefaultConfigurationFile(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, configuration.GetDefaultConfigurationFile(), tDefaultConfigurationFile)
+}
+
+func TestGetConfigurationDataSucess(t *testing.T) {
+	t.Parallel()
+	// this, in reality gets set in main
+	os.Setenv(tEnvironmentVariableNameConfigFile, tEnvironmentVariableValueConfigFile)
+	cd, err := configuration.GetConfigurationData()
+	assert.Nil(t, err)
+	assert.NotNil(t, cd)
+}
+
+func TestNewConfigurationDataSuccess(t *testing.T) {
+	t.Parallel()
+	resource.Require(t, resource.UnitTest)
+	configFilePath := tEnvironmentVariableValueConfigFile
+	cd, err := configuration.NewConfigurationData(configFilePath)
+	assert.Nil(t, err)
+	assert.NotNil(t, cd)
+
+}
+
+func TestNewConfigurationDataFail(t *testing.T) {
+	t.Parallel()
+	resource.Require(t, resource.UnitTest)
+	configFilePath := tInvalidConfigFilePath
+	_, err := configuration.NewConfigurationData(configFilePath)
+	assert.NotNil(t, err)
+
+}
+
+func TestGetKeycloakEndpointToken(t *testing.T) {
+	t.Parallel()
+
+	cd := getConfigurationDataHandler()
+	require.NotNil(t, cd)
+
+	viperValue := cd.GetKeycloakEndpointToken()
+
+	testConfigFileMap, err := getConfigFileMap("")
+	require.Nil(t, err)
+	expectedValue := testConfigFileMap.KeycloakEndpointToken
+
+	assert.Equal(t, expectedValue, viperValue)
+
+}
+
+func TestGetPostgresHost(t *testing.T) {
+	t.Parallel()
+
+	envKey := generateEnvKey(varPostgresHost)
+
+	realEnvValue := os.Getenv(envKey) // could be "" as well.
+
+	os.Unsetenv(envKey)
+	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+
+	// env variable NOT set, so we check with config.yaml's value
+
+	configurationData := getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	viperValue := configurationData.GetPostgresHost()
+
+	// now check with the config yaml file.
+	testConfigFileMap, err := getConfigFileMap(tEnvironmentVariableValueConfigFile)
+	require.Nil(t, err)
+	expectedValue := testConfigFileMap.PostgresHost
+
+	assert.NotNil(t, viperValue)
+	assert.Equal(t, expectedValue, viperValue)
+
+	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
+	os.Setenv(envKey, tTestEnvString)
+
+	configurationData = getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	require.Nil(t, err)
+
+	viperValue = configurationData.GetPostgresHost()
+	assert.Equal(t, tTestEnvString, viperValue)
+
+}
+
+func TestGetPostgresPort(t *testing.T) {
+	t.Parallel()
+
+	envKey := generateEnvKey(varPostgresPort)
+
+	realEnvValue := os.Getenv(envKey) // could be "" as well.
+
+	os.Unsetenv(envKey)
+	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+
+	// env variable NOT set, so we check with config.yaml's value
+
+	configurationData := getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	viperValue := configurationData.GetPostgresPort()
+
+	// now check with the config yaml file.
+	testConfigFileMap, err := getConfigFileMap("")
+	require.Nil(t, err)
+	expectedValue := testConfigFileMap.PostgresPort
+
+	assert.NotNil(t, viperValue)
+	assert.Equal(t, expectedValue, viperValue)
+
+	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
+	os.Setenv(envKey, strconv.FormatInt(tTestEnvInt64, 10))
+
+	configurationData = getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	require.Nil(t, err)
+
+	viperValue = configurationData.GetPostgresPort()
+	assert.Equal(t, tTestEnvInt64, viperValue)
+}
+
+func TestGetPostgresUser(t *testing.T) {
+	t.Parallel()
+
+	envKey := generateEnvKey(varPostgresUser)
+
+	realEnvValue := os.Getenv(envKey) // could be "" as well.
+
+	os.Unsetenv(envKey)
+	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+
+	// env variable NOT set, so we check with config.yaml's value
+
+	configurationData := getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	viperValue := configurationData.GetPostgresUser()
+
+	// now check with the config yaml file.
+	testConfigFileMap, err := getConfigFileMap("")
+	require.Nil(t, err)
+	expectedValue := testConfigFileMap.PostgresUser
+
+	assert.NotNil(t, viperValue)
+	assert.Equal(t, expectedValue, viperValue)
+
+	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
+	os.Setenv(envKey, tTestEnvString)
+
+	configurationData = getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	require.Nil(t, err)
+
+	viperValue = configurationData.GetPostgresUser()
+	assert.Equal(t, tTestEnvString, viperValue)
+
+}
+
+func TestGetPostgresDatabase(t *testing.T) {
+	t.Parallel()
+
+	envKey := generateEnvKey(varPostgresDatabase)
+
+	realEnvValue := os.Getenv(envKey) // could be "" as well.
+
+	os.Unsetenv(envKey)
+	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+
+	// env variable NOT set, so we check with config.yaml's value
+
+	configurationData := getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	viperValue := configurationData.GetPostgresDatabase()
+
+	// now check with the config yaml file.
+	testConfigFileMap, err := getConfigFileMap("")
+	require.Nil(t, err)
+	expectedValue := testConfigFileMap.PostgresDatabase
+
+	assert.NotNil(t, viperValue)
+	assert.Equal(t, expectedValue, viperValue)
+
+	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
+	os.Setenv(envKey, tTestEnvString)
+
+	configurationData = getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	require.Nil(t, err)
+
+	viperValue = configurationData.GetPostgresDatabase()
+	assert.Equal(t, tTestEnvString, viperValue)
+}
+
+func TestGetPostgresPassword(t *testing.T) {
+	t.Parallel()
+
+	envKey := generateEnvKey(varPostgresPassword)
+
+	realEnvValue := os.Getenv(envKey) // could be "" as well.
+
+	os.Unsetenv(envKey)
+	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+
+	// env variable NOT set, so we check with config.yaml's value
+
+	configurationData := getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	viperValue := configurationData.GetPostgresPassword()
+
+	// now check with the config yaml file.
+	testConfigFileMap, err := getConfigFileMap("")
+	require.Nil(t, err)
+	expectedValue := testConfigFileMap.PostgresPassword
+
+	assert.NotNil(t, viperValue)
+	assert.Equal(t, expectedValue, viperValue)
+
+	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
+	os.Setenv(envKey, tTestEnvString)
+
+	configurationData = getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	require.Nil(t, err)
+
+	viperValue = configurationData.GetPostgresPassword()
+	assert.Equal(t, tTestEnvString, viperValue)
+}
+
+func TestGetPostgresSSLMode(t *testing.T) {
+	t.Parallel()
+
+	envKey := generateEnvKey(varPostgresSSLMode)
+
+	realEnvValue := os.Getenv(envKey) // could be "" as well.
+
+	os.Unsetenv(envKey)
+	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+
+	// env variable NOT set, so we check with config.yaml's value
+
+	configurationData := getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	viperValue := configurationData.GetPostgresSSLMode()
+
+	// now check with the config yaml file.
+	testConfigFileMap, err := getConfigFileMap("")
+	require.Nil(t, err)
+	expectedValue := testConfigFileMap.PostgresSSLMode
+
+	assert.NotNil(t, viperValue)
+	assert.Equal(t, expectedValue, viperValue)
+
+	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
+	os.Setenv(envKey, tTestEnvString)
+
+	configurationData = getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	require.Nil(t, err)
+
+	viperValue = configurationData.GetPostgresSSLMode()
+	assert.Equal(t, tTestEnvString, viperValue)
+}
+
+func TestGetPostgresConnectionMaxRetries(t *testing.T) {
+	t.Parallel()
+
+	envKey := generateEnvKey(varPostgresConnectionMaxRetries)
+
+	realEnvValue := os.Getenv(envKey) // could be "" as well.
+
+	os.Unsetenv(envKey)
+	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+
+	// env variable NOT set, so we check with config.yaml's value
+
+	configurationData := getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	viperValue := configurationData.GetPostgresConnectionMaxRetries()
+
+	// now check with the config yaml file.
+	testConfigFileMap, err := getConfigFileMap("")
+	require.Nil(t, err)
+	expectedValue := testConfigFileMap.PostgresConnectionMaxRetries
+
+	assert.NotNil(t, viperValue)
+	assert.Equal(t, expectedValue, viperValue)
+
+	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
+	os.Setenv(envKey, strconv.Itoa(tTestEnvInt))
+
+	configurationData = getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	require.Nil(t, err)
+
+	viperValue = configurationData.GetPostgresConnectionMaxRetries()
+	assert.Equal(t, tTestEnvInt, viperValue)
+}
+
+func TestGetPostgresConnectionRetrySleep(t *testing.T) {
+	t.Parallel()
+
+	envKey := generateEnvKey(varPostgresConnectionRetrySleep)
+
+	realEnvValue := os.Getenv(envKey) // could be "" as well.
+
+	os.Unsetenv(envKey)
+	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+
+	// env variable NOT set, so we check with config.yaml's value
+
+	configurationData := getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	viperValue := configurationData.GetPostgresConnectionRetrySleep()
+
+	// now check with the config yaml file.
+	testConfigFileMap, err := getConfigFileMap("")
+	require.Nil(t, err)
+	expectedValue := testConfigFileMap.PostgresConnectionRetrySleep
+
+	assert.NotNil(t, viperValue)
+	assert.Equal(t, cast.ToDuration(expectedValue), viperValue)
+
+	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
+	os.Setenv(envKey, tTestEnvString)
+
+	configurationData = getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	require.Nil(t, err)
+
+	viperValue = configurationData.GetPostgresConnectionRetrySleep()
+	assert.Equal(t, cast.ToDuration(tTestEnvString), viperValue)
+}
+
+func TestGetPostgresConfigString(t *testing.T) {
+	t.Parallel()
+
+	configurationData := getConfigurationDataHandler()
+	// This is a derviced config parameter, not present as is, in the config file.
+	assert.NotNil(t, configurationData.GetPostgresConfigString())
+}
+
+func TestGetPopulateCommonTypes(t *testing.T) {
+	t.Parallel()
+
+	envKey := generateEnvKey(varPopulateCommonTypes)
+
+	realEnvValue := os.Getenv(envKey) // could be "" as well.
+
+	os.Unsetenv(envKey)
+	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+
+	// env variable NOT set, so we check with config.yaml's value
+
+	configurationData := getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	viperValue := configurationData.GetPopulateCommonTypes()
+
+	// now check with the config yaml file.
+	testConfigFileMap, err := getConfigFileMap("")
+	require.Nil(t, err)
+	expectedValue := testConfigFileMap.PopulateCommonTypes
+
+	assert.NotNil(t, viperValue)
+	assert.Equal(t, expectedValue, viperValue)
+
+	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
+	os.Setenv(envKey, strconv.FormatBool(tTestEnvBool))
+
+	configurationData = getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	require.Nil(t, err)
+
+	viperValue = configurationData.GetPopulateCommonTypes()
+	assert.Equal(t, tTestEnvBool, viperValue)
+}
+
+func TestGetHTTPAddress(t *testing.T) {
+	t.Parallel()
+
+	envKey := generateEnvKey(varHTTPAddress)
+
+	realEnvValue := os.Getenv(envKey) // could be "" as well.
+
+	os.Unsetenv(envKey)
+	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+
+	// env variable NOT set, so we check with config.yaml's value
+
+	configurationData := getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	viperValue := configurationData.GetHTTPAddress()
+
+	// now check with the config yaml file.
+	testConfigFileMap, err := getConfigFileMap("")
+	require.Nil(t, err)
+	expectedValue := testConfigFileMap.HTTPAddress
+
+	assert.NotNil(t, viperValue)
+	assert.Equal(t, expectedValue, viperValue)
+
+	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
+	os.Setenv(envKey, tTestEnvString)
+
+	configurationData = getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	require.Nil(t, err)
+
+	viperValue = configurationData.GetHTTPAddress()
+	assert.Equal(t, tTestEnvString, viperValue)
+}
+
+func IsPostgresDeveloperModeEnabled(t *testing.T) {
+	t.Parallel()
+
+	envKey := generateEnvKey(varDeveloperModeEnabled)
+
+	realEnvValue := os.Getenv(envKey) // could be "" as well.
+
+	os.Unsetenv(envKey)
+	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+
+	// env variable NOT set, so we check with config.yaml's value
+
+	configurationData := getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	viperValue := configurationData.IsPostgresDeveloperModeEnabled()
+
+	// now check with the config yaml file.
+	testConfigFileMap, err := getConfigFileMap("")
+	require.Nil(t, err)
+	expectedValue := testConfigFileMap.DeveloperModeEnabled
+
+	assert.NotNil(t, viperValue)
+	assert.Equal(t, expectedValue, viperValue)
+
+	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
+	os.Setenv(envKey, tTestEnvString)
+
+	configurationData = getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	require.Nil(t, err)
+
+	viperValue = configurationData.IsPostgresDeveloperModeEnabled()
+	assert.Equal(t, tTestEnvString, viperValue)
+}
+
+func TestGetTokenPrivateKey(t *testing.T) {
+	t.Parallel()
+
+	envKey := generateEnvKey(varTokenPrivateKey)
+
+	realEnvValue := os.Getenv(envKey) // could be "" as well.
+
+	os.Unsetenv(envKey)
+	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+
+	// env variable NOT set, so we check with config.yaml's value
+
+	configurationData := getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	viperValue := configurationData.GetTokenPrivateKey()
+
+	// now check with the config yaml file.
+	testConfigFileMap, err := getConfigFileMap("")
+	require.Nil(t, err)
+	expectedValue := testConfigFileMap.TokenPrivateKey
+
+	assert.NotNil(t, viperValue)
+	assert.Equal(t, []byte(expectedValue), viperValue)
+
+	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
+	os.Setenv(envKey, tTestEnvString)
+
+	configurationData = getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	require.Nil(t, err)
+
+	viperValue = configurationData.GetTokenPrivateKey()
+	assert.Equal(t, []byte(tTestEnvString), viperValue)
+}
+
+func TestGetTokenPublicKey(t *testing.T) {
+	t.Parallel()
+
+	envKey := generateEnvKey(varTokenPublicKey)
+
+	realEnvValue := os.Getenv(envKey) // could be "" as well.
+
+	os.Unsetenv(envKey)
+	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+
+	// env variable NOT set, so we check with config.yaml's value
+
+	configurationData := getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	viperValue := configurationData.GetTokenPublicKey()
+
+	// now check with the config yaml file.
+	testConfigFileMap, err := getConfigFileMap("")
+	require.Nil(t, err)
+	expectedValue := testConfigFileMap.TokenPublicKey
+
+	assert.NotNil(t, viperValue)
+	assert.Equal(t, []byte(expectedValue), viperValue)
+
+	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
+	os.Setenv(envKey, tTestEnvString)
+
+	configurationData = getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	require.Nil(t, err)
+
+	viperValue = configurationData.GetTokenPublicKey()
+	assert.Equal(t, []byte(tTestEnvString), viperValue)
+}
+
+func TestGetKeycloakSecret(t *testing.T) {
+	t.Parallel()
+
+	envKey := generateEnvKey(varKeycloakSecret)
+
+	realEnvValue := os.Getenv(envKey) // could be "" as well.
+
+	os.Unsetenv(envKey)
+	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+
+	// env variable NOT set, so we check with config.yaml's value
+
+	configurationData := getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	viperValue := configurationData.GetKeycloakSecret()
+
+	// now check with the config yaml file.
+	testConfigFileMap, err := getConfigFileMap("")
+	require.Nil(t, err)
+	expectedValue := testConfigFileMap.KeycloakSecret
+
+	assert.NotNil(t, viperValue)
+	assert.Equal(t, expectedValue, viperValue)
+
+	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
+	os.Setenv(envKey, tTestEnvString)
+
+	configurationData = getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	require.Nil(t, err)
+
+	viperValue = configurationData.GetKeycloakSecret()
+	assert.Equal(t, tTestEnvString, viperValue)
+}
+
+func TestGetKeycloakClientID(t *testing.T) {
+	t.Parallel()
+
+	envKey := generateEnvKey(varKeycloakClientID)
+
+	realEnvValue := os.Getenv(envKey) // could be "" as well.
+
+	os.Unsetenv(envKey)
+	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+
+	// env variable NOT set, so we check with config.yaml's value
+
+	configurationData := getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	viperValue := configurationData.GetKeycloakClientID()
+
+	// now check with the config yaml file.
+	testConfigFileMap, err := getConfigFileMap("")
+	require.Nil(t, err)
+	expectedValue := testConfigFileMap.KeycloakClientID
+
+	assert.NotNil(t, viperValue)
+	assert.Equal(t, expectedValue, viperValue)
+
+	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
+	os.Setenv(envKey, tTestEnvString)
+
+	configurationData = getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	require.Nil(t, err)
+
+	viperValue = configurationData.GetKeycloakClientID()
+	assert.Equal(t, tTestEnvString, viperValue)
+}
+
+func TestGetKeycloakEndpointAuth(t *testing.T) {
+	t.Parallel()
+
+	envKey := generateEnvKey(varKeycloakEndpointAuth)
+
+	realEnvValue := os.Getenv(envKey) // could be "" as well.
+
+	os.Unsetenv(envKey)
+	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+
+	// env variable NOT set, so we check with config.yaml's value
+
+	configurationData := getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	viperValue := configurationData.GetKeycloakEndpointAuth()
+
+	// now check with the config yaml file.
+	testConfigFileMap, err := getConfigFileMap("")
+	require.Nil(t, err)
+	expectedValue := testConfigFileMap.KeycloakEndpointAuth
+
+	assert.NotNil(t, viperValue)
+	assert.Equal(t, expectedValue, viperValue)
+
+	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
+	os.Setenv(envKey, tTestEnvString)
+
+	configurationData = getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	require.Nil(t, err)
+
+	viperValue = configurationData.GetKeycloakEndpointAuth()
+	assert.Equal(t, tTestEnvString, viperValue)
+}
+
+func TestGetKeycloakEndpointUserinfo(t *testing.T) {
+	t.Parallel()
+
+	envKey := generateEnvKey(varKeycloakEndpointUserinfo)
+
+	realEnvValue := os.Getenv(envKey) // could be "" as well.
+
+	os.Unsetenv(envKey)
+	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+
+	// env variable NOT set, so we check with config.yaml's value
+
+	configurationData := getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	viperValue := configurationData.GetKeycloakEndpointUserinfo()
+
+	// now check with the config yaml file.
+	testConfigFileMap, err := getConfigFileMap("")
+	require.Nil(t, err)
+	expectedValue := testConfigFileMap.KeycloakEndpointUserinfo
+
+	assert.NotNil(t, viperValue)
+	assert.Equal(t, expectedValue, viperValue)
+
+	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
+	os.Setenv(envKey, tTestEnvString)
+
+	configurationData = getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	require.Nil(t, err)
+
+	viperValue = configurationData.GetKeycloakEndpointUserinfo()
+	assert.Equal(t, tTestEnvString, viperValue)
+}
+
+/*
+TestMultipleConfigurations creates configuration objects using 2 different config files
+and checks whether one doesn't override the other.append
+*/
+
+func TestMultipleConfigurations(t *testing.T) {
+	t.Parallel()
+
+	configurationData1, err := configuration.NewConfigurationData(tEnvironmentVariableValueConfigFile)
+	require.Nil(t, err)
+	require.NotNil(t, configurationData1)
+
+	configurationData2, err := configuration.NewConfigurationData(tTestConfigFilePath)
+	require.Nil(t, err)
+	require.NotNil(t, configurationData2)
+
+	assert.NotEqual(t, configurationData1.GetPostgresHost, configurationData2.GetPostgresHost)
+	assert.NotEqual(t, configurationData1.GetPostgresPort, configurationData2.GetPostgresPort)
+
+}
+
+func getConfigurationDataHandler() *configuration.ConfigurationData {
+
+	configFilePath := tEnvironmentVariableValueConfigFile
+	cd, err := configuration.NewConfigurationData(configFilePath)
+	if err == nil {
+		return cd
+	}
+	return nil
+}
+
+type testConfig struct {
+	PostgresHost                 string `yaml:"postgres.host"`
+	PostgresPort                 int64  `yaml:"postgres.port"`
+	PostgresUser                 string `yaml:"postgres.user"`
+	PostgresDatabase             string `yaml:"postgres.database"`
+	PostgresPassword             string `yaml:"postgres.password"`
+	PostgresSSLMode              string `yaml:"postgres.sslmode"`
+	PostgresConnectionMaxRetries int    `yaml:"postgres.connection.maxretries"`
+	PostgresConnectionRetrySleep string `yaml:"postgres.connection.retrysleep"`
+	PopulateCommonTypes          bool   `yaml:"populate.commontypes"`
+	HTTPAddress                  string `yaml:"http.address"`
+	DeveloperModeEnabled         bool   `yaml:"developer.mode.enabled"`
+	KeycloakSecret               string `yaml:"keycloak.secret"`
+	KeycloakClientID             string `yaml:"keycloak.client.id"`
+	KeycloakEndpointAuth         string `yaml:"keycloak.endpoint.auth"`
+	KeycloakEndpointToken        string `yaml:"keycloak.endpoint.token"`
+	KeycloakEndpointUserinfo     string `yaml:"keycloak.endpoint.userinfo"`
+	TokenPublicKey               string `yaml:"token.publickey"`
+	TokenPrivateKey              string `yaml:"token.privatekey"`
+}
+
+// Copy-pasted this from configuration package because they are inaccesible from
+// configuration_test package. They will be consumed to determine what the
+// environment variable would be
+const (
+	varPostgresHost                 = "postgres.host"
+	varPostgresPort                 = "postgres.port"
+	varPostgresUser                 = "postgres.user"
+	varPostgresDatabase             = "postgres.database"
+	varPostgresPassword             = "postgres.password"
+	varPostgresSSLMode              = "postgres.sslmode"
+	varPostgresConnectionMaxRetries = "postgres.connection.maxretries"
+	varPostgresConnectionRetrySleep = "postgres.connection.retrysleep"
+	varPopulateCommonTypes          = "populate.commontypes"
+	varHTTPAddress                  = "http.address"
+	varDeveloperModeEnabled         = "developer.mode.enabled"
+	varGithubAuthToken              = "github.auth.token"
+	varKeycloakSecret               = "keycloak.secret"
+	varKeycloakClientID             = "keycloak.client.id"
+	varKeycloakEndpointAuth         = "keycloak.endpoint.auth"
+	varKeycloakEndpointToken        = "keycloak.endpoint.token"
+	varKeycloakEndpointUserinfo     = "keycloak.endpoint.userinfo"
+	varTokenPublicKey               = "token.publickey"
+	varTokenPrivateKey              = "token.privatekey"
+	defaultConfigFile               = "config.yaml"
+)
+
+func generateEnvKey(yamlKey string) string {
+	return "ALMIGHTY_" + strings.ToUpper(strings.Replace(yamlKey, ".", "_", -1))
+}
+
+func TestGenerateEnvKey(t *testing.T) {
+	assert.Equal(t, "ALMIGHTY_POSTGRES_HOST", generateEnvKey("postgres.host"))
+}
+
+func getConfigFileMap(configFilePath string) (testConfig, error) {
+	if configFilePath == "" {
+		//use default
+		configFilePath = tEnvironmentVariableValueConfigFile
+	}
+	yamlFile, err := ioutil.ReadFile(configFilePath)
+	if err != nil {
+		// its okay to return defaults, they would eventually fail in the assert statememts
+		fmt.Print(err)
+		return testConfig{}, err
+	}
+
+	var config testConfig
+	err = yaml.Unmarshal(yamlFile, &config)
+	if err != nil {
+		fmt.Println(err)
+		return testConfig{}, err
+	}
+	//fmt.Printf("Value: %#v\n", config)
+	//spew.Dump(config)
+	return config, nil
+}

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -211,6 +211,15 @@ func testSingleConfigReadFromConfigFile(t *testing.T, c configTestDescriptor) {
 	configurationData := getConfigurationDataHandler()
 	require.NotNil(t, configurationData)
 
+	/*
+
+		If  ConfigValueFunc: (*configuration.ConfigurationData).GetPostgresPassword
+		was passed in configTestDescriptor , then the following 2 lines
+		make the following functional call
+
+		configurationData.GetPostgresPassword()
+
+	*/
 	configurationDataFunction := getConfigurationDataFunction(c.ConfigValueFunc, configurationData)
 	viperValue := configurationDataFunction.Interface()
 
@@ -218,6 +227,9 @@ func testSingleConfigReadFromConfigFile(t *testing.T, c configTestDescriptor) {
 	testConfigFileMap, err := getConfigFileMap("")
 	require.Nil(t, err)
 	expectedValue := testConfigFileMap.getTestConfigMapValue(c.ConfigKey)
+
+	// PostgresConnectionRetrySleep  was passed as a string in the config file,
+	// let's parse it to the approrpriate type.
 	if c.ConfigKey == varPostgresConnectionRetrySleep {
 		expectedValue = cast.ToDuration(fmt.Sprintf("%v", expectedValue))
 		viperValue = cast.ToDuration(fmt.Sprintf("%v", viperValue))
@@ -249,12 +261,23 @@ func testSingleConfigReadFromEnvVariable(t *testing.T, c configTestDescriptor) {
 	}
 	os.Setenv(envKey, fmt.Sprintf("%v", testEnvValue))
 
+	/*
+
+		If  ConfigValueFunc: (*configuration.ConfigurationData).GetPostgresPassword
+		was passed in configTestDescriptor , then the following 2 lines
+		make the following functional call
+
+		configurationData.GetPostgresPassword()
+
+	*/
 	configurationData := getConfigurationDataHandler()
 	require.NotNil(t, configurationData)
 
 	configurationDataFunction := getConfigurationDataFunction(c.ConfigValueFunc, configurationData)
 	viperValue := configurationDataFunction.Interface()
 
+	// PostgresConnectionRetrySleep  was passed as a string in the config file,
+	// let's parse it to the approrpriate type.
 	if c.ConfigKey == varPostgresConnectionRetrySleep {
 		testEnvValue = cast.ToDuration(fmt.Sprintf("%v", testEnvValue))
 		viperValue = cast.ToDuration(fmt.Sprintf("%v", viperValue))
@@ -296,6 +319,7 @@ func TestAllConfigs(t *testing.T) {
 	}
 	for _, c := range testData {
 		testSingleConfigReadFromConfigFile(t, c)
+		testSingleConfigReadFromEnvVariable(t, c)
 	}
 
 }

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -41,19 +41,20 @@ func TestGetDefaultConfigurationFile(t *testing.T) {
 func TestGetConfigurationDataSucess(t *testing.T) {
 	t.Parallel()
 	// this, in reality gets set in main
-	os.Setenv(tEnvironmentVariableNameConfigFile, tEnvironmentVariableValueConfigFile)
+	os.Setenv(tEnvironmentVariableNameConfigFile, tTestConfigFilePath)
 	cd, err := configuration.GetConfigurationData()
 	assert.Nil(t, err)
 	assert.NotNil(t, cd)
+	assert.Equal(t, "mysecretpassword2", cd.GetPostgresPassword())
 }
 
 func TestNewConfigurationDataSuccess(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
-	configFilePath := tEnvironmentVariableValueConfigFile
-	cd, err := configuration.NewConfigurationData(configFilePath)
+	cd, err := configuration.NewConfigurationData(tTestConfigFilePath)
 	assert.Nil(t, err)
 	assert.NotNil(t, cd)
+	assert.Equal(t, "mysecretpassword2", cd.GetPostgresPassword())
 
 }
 

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -26,7 +26,7 @@ const (
 	tTestConfigFilePath                 = "../test/data/multiple_config.yaml"
 
 	// The following will be used to set env variables for testing.
-	tTestEnvString         = "ALMIGHTH_CONFIG_VALUE"
+	tTestEnvString         = "ALMIGHTY_CONFIG_VALUE"
 	tTestEnvInt64    int64 = 12345
 	tTestEnvInt      int   = 12
 	tTestEnvDuration       = "1s"

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strconv"
+	"reflect"
 	"testing"
 
 	yaml "gopkg.in/yaml.v2"
@@ -69,668 +69,10 @@ func TestNewConfigurationDataFail(t *testing.T) {
 
 }
 
-func TestGetKeycloakEndpointToken(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	cd := getConfigurationDataHandler()
-	require.NotNil(t, cd)
-
-	viperValue := cd.GetKeycloakEndpointToken()
-
-	testConfigFileMap, err := getConfigFileMap("")
-	require.Nil(t, err)
-	expectedValue := testConfigFileMap.KeycloakEndpointToken
-
-	assert.Equal(t, expectedValue, viperValue)
-
-}
-
-func TestGetPostgresHost(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	envKey := generateEnvKey(varPostgresHost)
-
-	realEnvValue := os.Getenv(envKey) // could be "" as well.
-
-	os.Unsetenv(envKey)
-	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
-
-	// env variable NOT set, so we check with config.yaml's value
-
-	configurationData := getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	viperValue := configurationData.GetPostgresHost()
-
-	// now check with the config yaml file.
-	testConfigFileMap, err := getConfigFileMap(tEnvironmentVariableValueConfigFile)
-	require.Nil(t, err)
-	expectedValue := testConfigFileMap.PostgresHost
-
-	assert.Equal(t, expectedValue, viperValue)
-
-	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
-	os.Setenv(envKey, tTestEnvString)
-
-	configurationData = getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	require.Nil(t, err)
-
-	viperValue = configurationData.GetPostgresHost()
-	assert.Equal(t, tTestEnvString, viperValue)
-
-}
-
-func TestGetPostgresPort(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	envKey := generateEnvKey(varPostgresPort)
-
-	realEnvValue := os.Getenv(envKey) // could be "" as well.
-
-	os.Unsetenv(envKey)
-	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
-
-	// env variable NOT set, so we check with config.yaml's value
-
-	configurationData := getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	viperValue := configurationData.GetPostgresPort()
-
-	// now check with the config yaml file.
-	testConfigFileMap, err := getConfigFileMap("")
-	require.Nil(t, err)
-	expectedValue := testConfigFileMap.PostgresPort
-
-	assert.Equal(t, expectedValue, viperValue)
-
-	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
-	os.Setenv(envKey, strconv.FormatInt(tTestEnvInt64, 10))
-
-	configurationData = getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	require.Nil(t, err)
-
-	viperValue = configurationData.GetPostgresPort()
-	assert.Equal(t, tTestEnvInt64, viperValue)
-}
-
-func TestGetPostgresUser(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	envKey := generateEnvKey(varPostgresUser)
-
-	realEnvValue := os.Getenv(envKey) // could be "" as well.
-
-	os.Unsetenv(envKey)
-	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
-
-	// env variable NOT set, so we check with config.yaml's value
-
-	configurationData := getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	viperValue := configurationData.GetPostgresUser()
-
-	// now check with the config yaml file.
-	testConfigFileMap, err := getConfigFileMap("")
-	require.Nil(t, err)
-	expectedValue := testConfigFileMap.PostgresUser
-
-	assert.Equal(t, expectedValue, viperValue)
-
-	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
-	os.Setenv(envKey, tTestEnvString)
-
-	configurationData = getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	require.Nil(t, err)
-
-	viperValue = configurationData.GetPostgresUser()
-	assert.Equal(t, tTestEnvString, viperValue)
-
-}
-
-func TestGetPostgresDatabase(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	envKey := generateEnvKey(varPostgresDatabase)
-
-	realEnvValue := os.Getenv(envKey) // could be "" as well.
-
-	os.Unsetenv(envKey)
-	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
-
-	// env variable NOT set, so we check with config.yaml's value
-
-	configurationData := getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	viperValue := configurationData.GetPostgresDatabase()
-
-	// now check with the config yaml file.
-	testConfigFileMap, err := getConfigFileMap("")
-	require.Nil(t, err)
-	expectedValue := testConfigFileMap.PostgresDatabase
-
-	assert.Equal(t, expectedValue, viperValue)
-
-	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
-	os.Setenv(envKey, tTestEnvString)
-
-	configurationData = getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	require.Nil(t, err)
-
-	viperValue = configurationData.GetPostgresDatabase()
-	assert.Equal(t, tTestEnvString, viperValue)
-}
-
-func TestGetPostgresPassword(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	envKey := generateEnvKey(varPostgresPassword)
-
-	realEnvValue := os.Getenv(envKey) // could be "" as well.
-
-	os.Unsetenv(envKey)
-	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
-
-	// env variable NOT set, so we check with config.yaml's value
-
-	configurationData := getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	viperValue := configurationData.GetPostgresPassword()
-
-	// now check with the config yaml file.
-	testConfigFileMap, err := getConfigFileMap("")
-	require.Nil(t, err)
-	expectedValue := testConfigFileMap.PostgresPassword
-
-	assert.Equal(t, expectedValue, viperValue)
-
-	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
-	os.Setenv(envKey, tTestEnvString)
-
-	configurationData = getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	require.Nil(t, err)
-
-	viperValue = configurationData.GetPostgresPassword()
-	assert.Equal(t, tTestEnvString, viperValue)
-}
-
-func TestGetPostgresSSLMode(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	envKey := generateEnvKey(varPostgresSSLMode)
-
-	realEnvValue := os.Getenv(envKey) // could be "" as well.
-
-	os.Unsetenv(envKey)
-	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
-
-	// env variable NOT set, so we check with config.yaml's value
-
-	configurationData := getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	viperValue := configurationData.GetPostgresSSLMode()
-
-	// now check with the config yaml file.
-	testConfigFileMap, err := getConfigFileMap("")
-	require.Nil(t, err)
-	expectedValue := testConfigFileMap.PostgresSSLMode
-
-	assert.Equal(t, expectedValue, viperValue)
-
-	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
-	os.Setenv(envKey, tTestEnvString)
-
-	configurationData = getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	require.Nil(t, err)
-
-	viperValue = configurationData.GetPostgresSSLMode()
-	assert.Equal(t, tTestEnvString, viperValue)
-}
-
-func TestGetPostgresConnectionMaxRetries(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	envKey := generateEnvKey(varPostgresConnectionMaxRetries)
-
-	realEnvValue := os.Getenv(envKey) // could be "" as well.
-
-	os.Unsetenv(envKey)
-	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
-
-	// env variable NOT set, so we check with config.yaml's value
-
-	configurationData := getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	viperValue := configurationData.GetPostgresConnectionMaxRetries()
-
-	// now check with the config yaml file.
-	testConfigFileMap, err := getConfigFileMap("")
-	require.Nil(t, err)
-	expectedValue := testConfigFileMap.PostgresConnectionMaxRetries
-
-	assert.Equal(t, expectedValue, viperValue)
-
-	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
-	os.Setenv(envKey, strconv.Itoa(tTestEnvInt))
-
-	configurationData = getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	require.Nil(t, err)
-
-	viperValue = configurationData.GetPostgresConnectionMaxRetries()
-	assert.Equal(t, tTestEnvInt, viperValue)
-}
-
-func TestGetPostgresConnectionRetrySleep(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	envKey := generateEnvKey(varPostgresConnectionRetrySleep)
-
-	realEnvValue := os.Getenv(envKey) // could be "" as well.
-
-	os.Unsetenv(envKey)
-	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
-
-	// env variable NOT set, so we check with config.yaml's value
-
-	configurationData := getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	viperValue := configurationData.GetPostgresConnectionRetrySleep()
-
-	// now check with the config yaml file.
-	testConfigFileMap, err := getConfigFileMap("")
-	require.Nil(t, err)
-	expectedValue := testConfigFileMap.PostgresConnectionRetrySleep
-
-	assert.Equal(t, cast.ToDuration(expectedValue), viperValue)
-
-	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
-	os.Setenv(envKey, tTestEnvString)
-
-	configurationData = getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	require.Nil(t, err)
-
-	viperValue = configurationData.GetPostgresConnectionRetrySleep()
-	assert.Equal(t, cast.ToDuration(tTestEnvString), viperValue)
-}
-
-func TestGetPostgresConfigString(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	configurationData := getConfigurationDataHandler()
-	// This is a derviced config parameter, not present as is, in the config file.
-	assert.NotNil(t, configurationData.GetPostgresConfigString())
-}
-
-func TestGetPopulateCommonTypes(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	envKey := generateEnvKey(varPopulateCommonTypes)
-
-	realEnvValue := os.Getenv(envKey) // could be "" as well.
-
-	os.Unsetenv(envKey)
-	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
-
-	// env variable NOT set, so we check with config.yaml's value
-
-	configurationData := getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	viperValue := configurationData.GetPopulateCommonTypes()
-
-	// now check with the config yaml file.
-	testConfigFileMap, err := getConfigFileMap("")
-	require.Nil(t, err)
-	expectedValue := testConfigFileMap.PopulateCommonTypes
-
-	assert.Equal(t, expectedValue, viperValue)
-
-	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
-	os.Setenv(envKey, strconv.FormatBool(tTestEnvBool))
-
-	configurationData = getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	require.Nil(t, err)
-
-	viperValue = configurationData.GetPopulateCommonTypes()
-	assert.Equal(t, tTestEnvBool, viperValue)
-}
-
-func TestGetHTTPAddress(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	envKey := generateEnvKey(varHTTPAddress)
-
-	realEnvValue := os.Getenv(envKey) // could be "" as well.
-
-	os.Unsetenv(envKey)
-	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
-
-	// env variable NOT set, so we check with config.yaml's value
-
-	configurationData := getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	viperValue := configurationData.GetHTTPAddress()
-
-	// now check with the config yaml file.
-	testConfigFileMap, err := getConfigFileMap("")
-	require.Nil(t, err)
-	expectedValue := testConfigFileMap.HTTPAddress
-
-	assert.Equal(t, expectedValue, viperValue)
-
-	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
-	os.Setenv(envKey, tTestEnvString)
-
-	configurationData = getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	require.Nil(t, err)
-
-	viperValue = configurationData.GetHTTPAddress()
-	assert.Equal(t, tTestEnvString, viperValue)
-}
-
-func IsPostgresDeveloperModeEnabled(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	envKey := generateEnvKey(varDeveloperModeEnabled)
-
-	realEnvValue := os.Getenv(envKey) // could be "" as well.
-
-	os.Unsetenv(envKey)
-	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
-
-	// env variable NOT set, so we check with config.yaml's value
-
-	configurationData := getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	viperValue := configurationData.IsPostgresDeveloperModeEnabled()
-
-	// now check with the config yaml file.
-	testConfigFileMap, err := getConfigFileMap("")
-	require.Nil(t, err)
-	expectedValue := testConfigFileMap.DeveloperModeEnabled
-
-	assert.Equal(t, expectedValue, viperValue)
-
-	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
-	os.Setenv(envKey, tTestEnvString)
-
-	configurationData = getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	require.Nil(t, err)
-
-	viperValue = configurationData.IsPostgresDeveloperModeEnabled()
-	assert.Equal(t, tTestEnvString, viperValue)
-}
-
-func TestGetTokenPrivateKey(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	envKey := generateEnvKey(varTokenPrivateKey)
-
-	realEnvValue := os.Getenv(envKey) // could be "" as well.
-
-	os.Unsetenv(envKey)
-	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
-
-	// env variable NOT set, so we check with config.yaml's value
-
-	configurationData := getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	viperValue := configurationData.GetTokenPrivateKey()
-
-	// now check with the config yaml file.
-	testConfigFileMap, err := getConfigFileMap("")
-	require.Nil(t, err)
-	expectedValue := testConfigFileMap.TokenPrivateKey
-
-	assert.Equal(t, []byte(expectedValue), viperValue)
-
-	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
-	os.Setenv(envKey, tTestEnvString)
-
-	configurationData = getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	require.Nil(t, err)
-
-	viperValue = configurationData.GetTokenPrivateKey()
-	assert.Equal(t, []byte(tTestEnvString), viperValue)
-}
-
-func TestGetTokenPublicKey(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	envKey := generateEnvKey(varTokenPublicKey)
-
-	realEnvValue := os.Getenv(envKey) // could be "" as well.
-
-	os.Unsetenv(envKey)
-	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
-
-	// env variable NOT set, so we check with config.yaml's value
-
-	configurationData := getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	viperValue := configurationData.GetTokenPublicKey()
-
-	// now check with the config yaml file.
-	testConfigFileMap, err := getConfigFileMap("")
-	require.Nil(t, err)
-	expectedValue := testConfigFileMap.TokenPublicKey
-
-	assert.Equal(t, []byte(expectedValue), viperValue)
-
-	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
-	os.Setenv(envKey, tTestEnvString)
-
-	configurationData = getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	require.Nil(t, err)
-
-	viperValue = configurationData.GetTokenPublicKey()
-	assert.Equal(t, []byte(tTestEnvString), viperValue)
-}
-
-func TestGetKeycloakSecret(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	envKey := generateEnvKey(varKeycloakSecret)
-
-	realEnvValue := os.Getenv(envKey) // could be "" as well.
-
-	os.Unsetenv(envKey)
-	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
-
-	// env variable NOT set, so we check with config.yaml's value
-
-	configurationData := getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	viperValue := configurationData.GetKeycloakSecret()
-
-	// now check with the config yaml file.
-	testConfigFileMap, err := getConfigFileMap("")
-	require.Nil(t, err)
-	expectedValue := testConfigFileMap.KeycloakSecret
-
-	assert.Equal(t, expectedValue, viperValue)
-
-	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
-	os.Setenv(envKey, tTestEnvString)
-
-	configurationData = getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	require.Nil(t, err)
-
-	viperValue = configurationData.GetKeycloakSecret()
-	assert.Equal(t, tTestEnvString, viperValue)
-}
-
-func TestGetKeycloakClientID(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	envKey := generateEnvKey(varKeycloakClientID)
-
-	realEnvValue := os.Getenv(envKey) // could be "" as well.
-
-	os.Unsetenv(envKey)
-	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
-
-	// env variable NOT set, so we check with config.yaml's value
-
-	configurationData := getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	viperValue := configurationData.GetKeycloakClientID()
-
-	// now check with the config yaml file.
-	testConfigFileMap, err := getConfigFileMap("")
-	require.Nil(t, err)
-	expectedValue := testConfigFileMap.KeycloakClientID
-
-	assert.Equal(t, expectedValue, viperValue)
-
-	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
-	os.Setenv(envKey, tTestEnvString)
-
-	configurationData = getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	require.Nil(t, err)
-
-	viperValue = configurationData.GetKeycloakClientID()
-	assert.Equal(t, tTestEnvString, viperValue)
-}
-
-func TestGetKeycloakEndpointAuth(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	envKey := generateEnvKey(varKeycloakEndpointAuth)
-
-	realEnvValue := os.Getenv(envKey) // could be "" as well.
-
-	os.Unsetenv(envKey)
-	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
-
-	// env variable NOT set, so we check with config.yaml's value
-
-	configurationData := getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	viperValue := configurationData.GetKeycloakEndpointAuth()
-
-	// now check with the config yaml file.
-	testConfigFileMap, err := getConfigFileMap("")
-	require.Nil(t, err)
-	expectedValue := testConfigFileMap.KeycloakEndpointAuth
-
-	assert.Equal(t, expectedValue, viperValue)
-
-	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
-	os.Setenv(envKey, tTestEnvString)
-
-	configurationData = getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	require.Nil(t, err)
-
-	viperValue = configurationData.GetKeycloakEndpointAuth()
-	assert.Equal(t, tTestEnvString, viperValue)
-}
-
-func TestGetKeycloakEndpointUserinfo(t *testing.T) {
-	t.Parallel()
-	resource.Require(t, resource.UnitTest)
-
-	envKey := generateEnvKey(varKeycloakEndpointUserinfo)
-
-	realEnvValue := os.Getenv(envKey) // could be "" as well.
-
-	os.Unsetenv(envKey)
-	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
-
-	// env variable NOT set, so we check with config.yaml's value
-
-	configurationData := getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	viperValue := configurationData.GetKeycloakEndpointUserinfo()
-
-	// now check with the config yaml file.
-	testConfigFileMap, err := getConfigFileMap("")
-	require.Nil(t, err)
-	expectedValue := testConfigFileMap.KeycloakEndpointUserinfo
-
-	assert.Equal(t, expectedValue, viperValue)
-
-	// env variable will now be SET, so now we check with env variable and NOT With config.yaml
-	os.Setenv(envKey, tTestEnvString)
-
-	configurationData = getConfigurationDataHandler()
-	require.NotNil(t, configurationData)
-
-	require.Nil(t, err)
-
-	viperValue = configurationData.GetKeycloakEndpointUserinfo()
-	assert.Equal(t, tTestEnvString, viperValue)
-}
-
 /*
 TestMultipleConfigurations creates configuration objects using 2 different config files
 and checks whether one doesn't override the other.append
 */
-
 func TestMultipleConfigurations(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
@@ -758,25 +100,36 @@ func getConfigurationDataHandler() *configuration.ConfigurationData {
 	return nil
 }
 
+// getTestConfigMapValue accomplishes the same thing that testConfig.<PropertyName> does.
+func (tc testConfig) getTestConfigMapValue(key string) interface{} {
+	r := reflect.ValueOf(tc)
+	fmt.Println(key)
+	key = strings.Replace(strings.Title((strings.Replace(key, ".", " ", -1))), " ", "", -1)
+	fmt.Println(key)
+
+	f := reflect.Indirect(r).FieldByName(key)
+	return f.Interface()
+}
+
 type testConfig struct {
 	PostgresHost                 string `yaml:"postgres.host"`
 	PostgresPort                 int64  `yaml:"postgres.port"`
 	PostgresUser                 string `yaml:"postgres.user"`
 	PostgresDatabase             string `yaml:"postgres.database"`
 	PostgresPassword             string `yaml:"postgres.password"`
-	PostgresSSLMode              string `yaml:"postgres.sslmode"`
-	PostgresConnectionMaxRetries int    `yaml:"postgres.connection.maxretries"`
-	PostgresConnectionRetrySleep string `yaml:"postgres.connection.retrysleep"`
-	PopulateCommonTypes          bool   `yaml:"populate.commontypes"`
+	PostgresSslmode              string `yaml:"postgres.sslmode"`
+	PostgresConnectionMaxretries int    `yaml:"postgres.connection.maxretries"`
+	PostgresConnectionRetrysleep string `yaml:"postgres.connection.retrysleep"`
+	PopulateCommontypes          bool   `yaml:"populate.commontypes"`
 	HTTPAddress                  string `yaml:"http.address"`
 	DeveloperModeEnabled         bool   `yaml:"developer.mode.enabled"`
 	KeycloakSecret               string `yaml:"keycloak.secret"`
-	KeycloakClientID             string `yaml:"keycloak.client.id"`
+	KeycloakClientId             string `yaml:"keycloak.client.id"`
 	KeycloakEndpointAuth         string `yaml:"keycloak.endpoint.auth"`
 	KeycloakEndpointToken        string `yaml:"keycloak.endpoint.token"`
 	KeycloakEndpointUserinfo     string `yaml:"keycloak.endpoint.userinfo"`
-	TokenPublicKey               string `yaml:"token.publickey"`
-	TokenPrivateKey              string `yaml:"token.privatekey"`
+	TokenPublickey               string `yaml:"token.publickey"`
+	TokenPrivatekey              string `yaml:"token.privatekey"`
 }
 
 // Copy-pasted this from configuration package because they are inaccesible from
@@ -789,7 +142,7 @@ const (
 	varPostgresDatabase             = "postgres.database"
 	varPostgresPassword             = "postgres.password"
 	varPostgresSSLMode              = "postgres.sslmode"
-	varPostgresConnectionMaxRetries = "postgres.connection.maxretries"
+	varPostgresConnectionMaxretries = "postgres.connection.maxretries"
 	varPostgresConnectionRetrySleep = "postgres.connection.retrysleep"
 	varPopulateCommonTypes          = "populate.commontypes"
 	varHTTPAddress                  = "http.address"
@@ -813,6 +166,7 @@ func TestGenerateEnvKey(t *testing.T) {
 	assert.Equal(t, "ALMIGHTY_POSTGRES_HOST", generateEnvKey("postgres.host"))
 }
 
+// getConfigFileMap decodes config.yaml into a go struct
 func getConfigFileMap(configFilePath string) (testConfig, error) {
 	if configFilePath == "" {
 		//use default
@@ -831,7 +185,117 @@ func getConfigFileMap(configFilePath string) (testConfig, error) {
 		fmt.Println(err)
 		return testConfig{}, err
 	}
-	//fmt.Printf("Value: %#v\n", config)
-	//spew.Dump(config)
+
 	return config, nil
+}
+
+// configTestDescriptor.ConfigTestFunc is an interface which was assigned a method receiver.
+// This function types casts the interface to an actual callable method w.r.t to a ConfigurationData object
+func getConfigurationDataFunction(configurationDataFunc interface{}, configurationData *configuration.ConfigurationData) reflect.Value {
+	fn := reflect.ValueOf(configurationDataFunc)
+	function := fn.Call([]reflect.Value{reflect.ValueOf(configurationData)})
+	actualConfigurationDataFunction := function[0]
+	return actualConfigurationDataFunction
+}
+
+// Scenario 1: env variable NOT set, so we check with config.yaml's value
+
+func testSingleConfigReadFromConfigFile(t *testing.T, c configTestDescriptor) {
+	envKey := generateEnvKey(c.ConfigKey)
+
+	realEnvValue := os.Getenv(envKey) // could be "" as well.
+
+	os.Unsetenv(envKey)
+	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+
+	configurationData := getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	configurationDataFunction := getConfigurationDataFunction(c.ConfigValueFunc, configurationData)
+	viperValue := configurationDataFunction.Interface()
+
+	// now check with the config yaml file.
+	testConfigFileMap, err := getConfigFileMap("")
+	require.Nil(t, err)
+	expectedValue := testConfigFileMap.getTestConfigMapValue(c.ConfigKey)
+	if c.ConfigKey == varPostgresConnectionRetrySleep {
+		expectedValue = cast.ToDuration(fmt.Sprintf("%v", expectedValue))
+		viperValue = cast.ToDuration(fmt.Sprintf("%v", viperValue))
+	}
+	assert.Equal(t, reflect.TypeOf(expectedValue), reflect.TypeOf(viperValue), fmt.Sprintf("Type mismatches for %s", c.ConfigKey))
+	assert.Equal(t, expectedValue, viperValue, fmt.Sprintf("Mismatch for %s", c.ConfigKey))
+
+}
+
+// Scenario 2 : env variable will now be SET, so now we assert with env variable and NOT With config.yaml
+
+func testSingleConfigReadFromEnvVariable(t *testing.T, c configTestDescriptor) {
+	envKey := generateEnvKey(c.ConfigKey)
+
+	realEnvValue := os.Getenv(envKey) // could be "" as well.
+	os.Unsetenv(envKey)
+
+	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+
+	var testEnvValue interface{}
+	if c.ConfigValueDataType == reflect.String {
+		testEnvValue = tTestEnvString
+	} else if c.ConfigValueDataType == reflect.Int64 {
+		testEnvValue = tTestEnvInt64
+	} else if c.ConfigValueDataType == reflect.Int {
+		testEnvValue = tTestEnvInt
+	} else if c.ConfigValueDataType == reflect.Bool {
+		testEnvValue = tTestEnvBool
+	}
+	os.Setenv(envKey, fmt.Sprintf("%v", testEnvValue))
+
+	configurationData := getConfigurationDataHandler()
+	require.NotNil(t, configurationData)
+
+	configurationDataFunction := getConfigurationDataFunction(c.ConfigValueFunc, configurationData)
+	viperValue := configurationDataFunction.Interface()
+
+	if c.ConfigKey == varPostgresConnectionRetrySleep {
+		testEnvValue = cast.ToDuration(fmt.Sprintf("%v", testEnvValue))
+		viperValue = cast.ToDuration(fmt.Sprintf("%v", viperValue))
+	}
+
+	assert.Equal(t, testEnvValue, viperValue, fmt.Sprintf("Mismatch for %s", c.ConfigKey))
+
+}
+
+type configTestDescriptor struct {
+	ConfigKey           string       // the key(s) present in config.yaml
+	ConfigValueDataType reflect.Kind // will be used to decide the test string to be used for setting env variable.
+	TestValue           string       // to be set in the env variable
+
+	// ConfigValueFunc is to be invoked on ConfigurationData object.
+	// This is of type "interface{}" because the return types of every method differ.
+	// the method getConfigurationDataFunction(..) is used to convert the following
+	// into a callable method.
+	ConfigValueFunc interface{}
+}
+
+func TestAllConfigs(t *testing.T) {
+
+	testData := []configTestDescriptor{
+		configTestDescriptor{ConfigKey: varPostgresHost, ConfigValueDataType: reflect.String, ConfigValueFunc: (*configuration.ConfigurationData).GetPostgresHost},
+		configTestDescriptor{ConfigKey: varPostgresPort, ConfigValueDataType: reflect.Int64, ConfigValueFunc: (*configuration.ConfigurationData).GetPostgresPort},
+		configTestDescriptor{ConfigKey: varPostgresUser, ConfigValueDataType: reflect.String, ConfigValueFunc: (*configuration.ConfigurationData).GetPostgresUser},
+		configTestDescriptor{ConfigKey: varPostgresPassword, ConfigValueDataType: reflect.String, ConfigValueFunc: (*configuration.ConfigurationData).GetPostgresPassword},
+		configTestDescriptor{ConfigKey: varPostgresSSLMode, ConfigValueDataType: reflect.String, ConfigValueFunc: (*configuration.ConfigurationData).GetPostgresSSLMode},
+		configTestDescriptor{ConfigKey: varPostgresConnectionMaxretries, ConfigValueDataType: reflect.Int, ConfigValueFunc: (*configuration.ConfigurationData).GetPostgresConnectionMaxRetries},
+		configTestDescriptor{ConfigKey: varPostgresConnectionRetrySleep, ConfigValueDataType: reflect.String, ConfigValueFunc: (*configuration.ConfigurationData).GetPostgresConnectionRetrySleep},
+		configTestDescriptor{ConfigKey: varDeveloperModeEnabled, ConfigValueDataType: reflect.Bool, ConfigValueFunc: (*configuration.ConfigurationData).IsPostgresDeveloperModeEnabled},
+		configTestDescriptor{ConfigKey: varPopulateCommonTypes, ConfigValueDataType: reflect.Bool, ConfigValueFunc: (*configuration.ConfigurationData).GetPopulateCommonTypes},
+		configTestDescriptor{ConfigKey: varKeycloakClientID, ConfigValueDataType: reflect.String, ConfigValueFunc: (*configuration.ConfigurationData).GetKeycloakClientID},
+		configTestDescriptor{ConfigKey: varKeycloakEndpointAuth, ConfigValueDataType: reflect.String, ConfigValueFunc: (*configuration.ConfigurationData).GetKeycloakEndpointAuth},
+		configTestDescriptor{ConfigKey: varKeycloakEndpointToken, ConfigValueDataType: reflect.String, ConfigValueFunc: (*configuration.ConfigurationData).GetKeycloakEndpointToken},
+		configTestDescriptor{ConfigKey: varKeycloakEndpointUserinfo, ConfigValueDataType: reflect.String, ConfigValueFunc: (*configuration.ConfigurationData).GetKeycloakEndpointUserinfo},
+		configTestDescriptor{ConfigKey: varKeycloakSecret, ConfigValueDataType: reflect.String, ConfigValueFunc: (*configuration.ConfigurationData).GetKeycloakSecret},
+	}
+	for _, c := range testData {
+		testSingleConfigReadFromConfigFile(t, c)
+	}
+
 }

--- a/gormsupport/db_test_suite.go
+++ b/gormsupport/db_test_suite.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/jinzhu/gorm"
 	_ "github.com/lib/pq" // need to import postgres driver
@@ -29,7 +29,8 @@ type DBTestSuite struct {
 func (s *DBTestSuite) SetupSuite() {
 	resource.Require(s.T(), resource.Database)
 	var err error
-	if err = configuration.Setup(s.configFile); err != nil {
+	configuration, err := config.NewConfigurationData(s.configFile)
+	if err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
 

--- a/iteration/iteration_test.go
+++ b/iteration/iteration_test.go
@@ -8,10 +8,12 @@ import (
 
 	"strconv"
 
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/iteration"
 	"github.com/almighty/almighty-core/resource"
+
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,7 +27,7 @@ type TestIterationRepository struct {
 }
 
 func TestRunIterationRepository(t *testing.T) {
-	suite.Run(t, &TestIterationRepository{DBTestSuite: gormsupport.NewDBTestSuite("../config.yaml")})
+	suite.Run(t, &TestIterationRepository{DBTestSuite: gormsupport.NewDBTestSuite("../" + config.GetDefaultConfigurationFile())})
 }
 
 func (test *TestIterationRepository) SetupTest() {

--- a/iteration_test.go
+++ b/iteration_test.go
@@ -9,12 +9,14 @@ import (
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
 	"github.com/almighty/almighty-core/application"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/iteration"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/almighty/almighty-core/space"
+
 	testsupport "github.com/almighty/almighty-core/test"
 	almtoken "github.com/almighty/almighty-core/token"
 	"github.com/goadesign/goa"
@@ -33,7 +35,7 @@ type TestIterationREST struct {
 }
 
 func TestRunIterationREST(t *testing.T) {
-	suite.Run(t, &TestIterationREST{DBTestSuite: gormsupport.NewDBTestSuite("config.yaml")})
+	suite.Run(t, &TestIterationREST{DBTestSuite: gormsupport.NewDBTestSuite(config.GetDefaultConfigurationFile())})
 }
 
 func (rest *TestIterationREST) SetupTest() {

--- a/login.go
+++ b/login.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/login"
 	"github.com/almighty/almighty-core/token"
 	"github.com/goadesign/goa"
+	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -32,6 +33,10 @@ func (c *LoginController) Authorize(ctx *app.AuthorizeLoginContext) error {
 
 // Generate runs the authorize action.
 func (c *LoginController) Generate(ctx *app.GenerateLoginContext) error {
+	configuration, err := config.GetConfigurationData()
+	if err != nil {
+		return errors.Wrap(err, "Failed to setup configuration")
+	}
 	if !configuration.IsPostgresDeveloperModeEnabled() {
 		jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized("Postgres developer mode not enabled"))
 		return ctx.Unauthorized(jerrors)

--- a/login/service.go
+++ b/login/service.go
@@ -12,9 +12,10 @@ import (
 
 	errs "github.com/pkg/errors"
 
+	config "github.com/almighty/almighty-core/configuration"
+
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
-	"github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/rest"
 	"github.com/almighty/almighty-core/token"
@@ -147,6 +148,10 @@ func (keycloak *keycloakOAuthProvider) Perform(ctx *app.AuthorizeLoginContext) e
 
 func (keycloak keycloakOAuthProvider) getUser(ctx context.Context, token *oauth2.Token) (*openIDConnectUser, error) {
 	client := keycloak.config.Client(ctx, token)
+	configuration, err := config.GetConfigurationData()
+	if err != nil {
+		return nil, errs.Wrap(err, "Failed to setup the configuration")
+	}
 	resp, err := client.Get(configuration.GetKeycloakEndpointUserinfo())
 	if err != nil {
 		return nil, errs.WithStack(err)

--- a/login/service_blackbox_test.go
+++ b/login/service_blackbox_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	. "github.com/almighty/almighty-core/login"
 	"github.com/almighty/almighty-core/migration"
 	"github.com/almighty/almighty-core/resource"
@@ -28,11 +28,12 @@ var db *gorm.DB
 var loginService Service
 
 func TestMain(m *testing.M) {
+	configuration, err := config.NewConfigurationData("../" + config.GetDefaultConfigurationFile())
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+
 	if _, c := os.LookupEnv(resource.Database); c != false {
-		var err error
-		if err = configuration.Setup(""); err != nil {
-			panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
-		}
 
 		db, err = gorm.Open("postgres", configuration.GetPostgresConfigString())
 		if err != nil {
@@ -77,6 +78,12 @@ func TestMain(m *testing.M) {
 }
 
 func TestKeycloakAuthorizationRedirect(t *testing.T) {
+
+	configuration, err := config.NewConfigurationData("")
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+
 	resource.Require(t, resource.UnitTest)
 
 	rw := httptest.NewRecorder()

--- a/login/service_whitebox_test.go
+++ b/login/service_whitebox_test.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/almighty/almighty-core/account"
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/almighty/almighty-core/token"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 
@@ -18,11 +19,10 @@ var loginService *keycloakOAuthProvider
 
 func setup() {
 
-	var err error
-	if err = configuration.Setup(""); err != nil {
+	configuration, err := config.GetConfigurationData()
+	if err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
-
 	oauth := &oauth2.Config{
 		ClientID:     configuration.GetKeycloakClientID(),
 		ClientSecret: configuration.GetKeycloakSecret(),
@@ -33,12 +33,12 @@ func setup() {
 		},
 	}
 
-	publicKey, err := token.ParsePublicKey([]byte(configuration.GetTokenPublicKey()))
+	publicKey, err := token.ParsePublicKey(configuration.GetTokenPublicKey())
 	if err != nil {
 		panic(err)
 	}
 
-	privateKey, err := token.ParsePrivateKey([]byte(configuration.GetTokenPrivateKey()))
+	privateKey, err := token.ParsePrivateKey(configuration.GetTokenPrivateKey())
 	if err != nil {
 		panic(err)
 	}

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/resource"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
@@ -15,8 +15,8 @@ import (
 func TestConcurrentMigrations(t *testing.T) {
 	resource.Require(t, resource.Database)
 
-	var err error
-	if err = configuration.Setup(""); err != nil {
+	configuration, err := config.NewConfigurationData("../" + config.GetDefaultConfigurationFile())
+	if err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
 

--- a/remoteworkitem/github.go
+++ b/remoteworkitem/github.go
@@ -2,10 +2,12 @@ package remoteworkitem
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/google/go-github/github"
+	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
 )
 
@@ -32,6 +34,12 @@ func (f *githubIssueFetcher) listIssues(query string, opts *github.SearchOptions
 
 // Fetch tracker items from Github
 func (g *GithubTracker) Fetch() chan TrackerItemContent {
+	configuration, err := config.GetConfigurationData()
+	if err != nil {
+		fmt.Print(errors.Wrap(err, "Failed to setup the configuration"))
+		return nil
+	}
+
 	f := githubIssueFetcher{}
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: configuration.GetGithubAuthToken()},

--- a/remoteworkitem/scheduler_test.go
+++ b/remoteworkitem/scheduler_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/migration"
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/resource"
@@ -21,7 +21,8 @@ var db *gorm.DB
 func TestMain(m *testing.M) {
 	var err error
 
-	if err = configuration.Setup(""); err != nil {
+	configuration, err := config.NewConfigurationData("../" + config.GetDefaultConfigurationFile())
+	if err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
 

--- a/remoteworkitem/tracker_repository_blackbox_test.go
+++ b/remoteworkitem/tracker_repository_blackbox_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/almighty/almighty-core/application"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/remoteworkitem"
@@ -18,7 +19,7 @@ type trackerRepoBlackBoxTest struct {
 }
 
 func TestRunTrackerRepoBlackBoxTest(t *testing.T) {
-	suite.Run(t, &trackerRepoBlackBoxTest{DBTestSuite: gormsupport.NewDBTestSuite("../config.yaml")})
+	suite.Run(t, &trackerRepoBlackBoxTest{DBTestSuite: gormsupport.NewDBTestSuite("../" + config.GetDefaultConfigurationFile())})
 }
 
 func (s *trackerRepoBlackBoxTest) SetupTest() {

--- a/remoteworkitem/trackerquery_repository_blackbox_test.go
+++ b/remoteworkitem/trackerquery_repository_blackbox_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/almighty/almighty-core/application"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/remoteworkitem"
@@ -19,7 +20,7 @@ type trackerQueryRepoBlackBoxTest struct {
 }
 
 func TestRunTrackerQueryRepoBlackBoxTest(t *testing.T) {
-	suite.Run(t, &trackerQueryRepoBlackBoxTest{DBTestSuite: gormsupport.NewDBTestSuite("../config.yaml")})
+	suite.Run(t, &trackerQueryRepoBlackBoxTest{DBTestSuite: gormsupport.NewDBTestSuite("../" + config.GetDefaultConfigurationFile())})
 }
 
 func (s *trackerQueryRepoBlackBoxTest) SetupTest() {

--- a/search.go
+++ b/search.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/search"
@@ -31,6 +31,12 @@ func NewSearchController(service *goa.Service, db application.DB) *SearchControl
 
 // Show runs the show action.
 func (c *SearchController) Show(ctx *app.ShowSearchContext) error {
+
+	configuration, err := config.NewConfigurationData("")
+	if err != nil {
+		return errs.Wrap(err, "Failed to setup the configuration")
+	}
+
 	var offset int
 	var limit int
 

--- a/search/search_repository_blackbox_test.go
+++ b/search/search_repository_blackbox_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/almighty/almighty-core/app"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/migration"
 	"github.com/almighty/almighty-core/models"
@@ -38,7 +39,7 @@ func (s *searchRepositoryBlackboxTest) SetupSuite() {
 }
 
 func TestRunSearchRepositoryWhiteboxTest(t *testing.T) {
-	suite.Run(t, &searchRepositoryBlackboxTest{DBTestSuite: gormsupport.NewDBTestSuite("../config.yaml")})
+	suite.Run(t, &searchRepositoryBlackboxTest{DBTestSuite: gormsupport.NewDBTestSuite("../" + config.GetDefaultConfigurationFile())})
 }
 
 func (s *searchRepositoryBlackboxTest) TestRestrictByType() {

--- a/search/search_repository_whitebox_test.go
+++ b/search/search_repository_whitebox_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/almighty/almighty-core/app"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/migration"
 	"github.com/almighty/almighty-core/models"
@@ -42,7 +43,7 @@ func (s *searchRepositoryWhiteboxTest) SetupSuite() {
 }
 
 func TestRunSearchRepositoryWhiteboxTest(t *testing.T) {
-	suite.Run(t, &searchRepositoryWhiteboxTest{DBTestSuite: gormsupport.NewDBTestSuite("../config.yaml")})
+	suite.Run(t, &searchRepositoryWhiteboxTest{DBTestSuite: gormsupport.NewDBTestSuite("../" + config.GetDefaultConfigurationFile())})
 }
 
 type SearchTestDescriptor struct {

--- a/space-iterations_test.go
+++ b/space-iterations_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
 	"github.com/almighty/almighty-core/application"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
@@ -36,7 +37,7 @@ type TestSpaceIterationREST struct {
 }
 
 func TestRunSpaceIterationREST(t *testing.T) {
-	suite.Run(t, &TestSpaceIterationREST{DBTestSuite: gormsupport.NewDBTestSuite("config.yaml")})
+	suite.Run(t, &TestSpaceIterationREST{DBTestSuite: gormsupport.NewDBTestSuite(config.GetDefaultConfigurationFile())})
 }
 
 func (rest *TestSpaceIterationREST) SetupTest() {

--- a/space/space_test.go
+++ b/space/space_test.go
@@ -3,6 +3,7 @@ package space_test
 import (
 	"testing"
 
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
@@ -19,7 +20,7 @@ var testSpace string = satoriuuid.NewV4().String()
 var testSpace2 string = satoriuuid.NewV4().String()
 
 func TestRunRepoBBTest(t *testing.T) {
-	suite.Run(t, &repoBBTest{DBTestSuite: gormsupport.NewDBTestSuite("../config.yaml")})
+	suite.Run(t, &repoBBTest{DBTestSuite: gormsupport.NewDBTestSuite("../" + config.GetDefaultConfigurationFile())})
 }
 
 type repoBBTest struct {

--- a/space_test.go
+++ b/space_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/almighty/almighty-core"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
@@ -27,7 +28,7 @@ type TestSpaceREST struct {
 }
 
 func TestRunProjectREST(t *testing.T) {
-	suite.Run(t, &TestSpaceREST{DBTestSuite: gormsupport.NewDBTestSuite("config.yaml")})
+	suite.Run(t, &TestSpaceREST{DBTestSuite: gormsupport.NewDBTestSuite(config.GetDefaultConfigurationFile())})
 }
 
 func (rest *TestSpaceREST) SetupTest() {

--- a/test/data/multiple_config.yaml
+++ b/test/data/multiple_config.yaml
@@ -1,30 +1,30 @@
 #------------------------
-# Postgres configuration
+# Postgres configuration for testing the configuration framework
 #------------------------
 
-postgres.host: localhost
-postgres.port: 5432
-postgres.user: postgres
-postgres.password: mysecretpassword
-postgres.database: postgres
-postgres.sslmode: disable
+postgres.host: localhost2
+postgres.port: 54322
+postgres.user: postgres2
+postgres.password: mysecretpassword2
+postgres.database: postgres2
+postgres.sslmode: disable2
 # The number of times alm server will attempt to open a connection to the database before it gives up
-postgres.connection.maxretries: 50
+postgres.connection.maxretries: 502
 # Duration to wait before trying to connect again
-postgres.connection.retrysleep: 1s
+postgres.connection.retrysleep: 1s2
 
 #------------------------
 # HTTP configuration
 #------------------------
 
-http.address: 0.0.0.0:8080
+http.address: 0.0.0.0:80802
 
 #------------------------
 # Misc.
 #------------------------
 
 # Enable development related features, e.g. token generation endpoint
-developer.mode.enabled: false
+developer.mode.enabled: true
 
 # Whether you want to create the common work item types such as bug, feature, ...
 populate.commontypes: true

--- a/work-item-comments_test.go
+++ b/work-item-comments_test.go
@@ -4,13 +4,12 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
-
 	. "github.com/almighty/almighty-core"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
 	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/comment"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
@@ -23,6 +22,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/net/context"
 )
 
 type TestCommentREST struct {
@@ -33,7 +33,7 @@ type TestCommentREST struct {
 }
 
 func TestRunCommentREST(t *testing.T) {
-	suite.Run(t, &TestCommentREST{DBTestSuite: gormsupport.NewDBTestSuite("config.yaml")})
+	suite.Run(t, &TestCommentREST{DBTestSuite: gormsupport.NewDBTestSuite(config.GetDefaultConfigurationFile())})
 }
 
 func (rest *TestCommentREST) SetupTest() {

--- a/work-item-link-blackbox_test.go
+++ b/work-item-link-blackbox_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/almighty/almighty-core"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/migration"
@@ -63,9 +63,9 @@ type workItemLinkSuite struct {
 // The SetupSuite method will run before the tests in the suite are run.
 // It sets up a database connection for all the tests in this suite without polluting global space.
 func (s *workItemLinkSuite) SetupSuite() {
-	var err error
 
-	if err = configuration.Setup(""); err != nil {
+	configuration, err := config.NewConfigurationData(config.GetDefaultConfigurationFile())
+	if err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
 
@@ -621,6 +621,10 @@ func (s *workItemLinkSuite) TestListWorkItemRelationshipsLinksNotFoundDueToInval
 }
 
 func getWorkItemLinkTestData(t *testing.T) []testSecureAPI {
+	configuration, err := config.NewConfigurationData(config.GetDefaultConfigurationFile())
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
 	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((configuration.GetTokenPrivateKey()))
 	if err != nil {
 		t.Fatal("Could not parse Key ", err)
@@ -781,6 +785,10 @@ func (s *workItemLinkSuite) TestUnauthorizeWorkItemLinkCUD() {
 // The work item ID will be used to construct /api/workitems/:id/relationships/links endpoints
 func getWorkItemRelationshipLinksTestData(t *testing.T, wiID string) func(t *testing.T) []testSecureAPI {
 	return func(t *testing.T) []testSecureAPI {
+		configuration, err := config.NewConfigurationData(config.GetDefaultConfigurationFile())
+		if err != nil {
+			panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+		}
 		privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((configuration.GetTokenPrivateKey()))
 		if err != nil {
 			t.Fatal("Could not parse Key ", err)

--- a/work-item-link-category-blackbox_test.go
+++ b/work-item-link-category-blackbox_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/almighty/almighty-core"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/migration"
@@ -41,9 +41,8 @@ type workItemLinkCategorySuite struct {
 // The SetupSuite method will run before the tests in the suite are run.
 // It sets up a database connection for all the tests in this suite without polluting global space.
 func (s *workItemLinkCategorySuite) SetupSuite() {
-	var err error
-
-	if err = configuration.Setup(""); err != nil {
+	configuration, err := config.NewConfigurationData(config.GetDefaultConfigurationFile())
+	if err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
 
@@ -346,6 +345,11 @@ func TestSuiteWorkItemLinkCategory(t *testing.T) {
 }
 
 func getWorkItemLinkCategoryTestData(t *testing.T) []testSecureAPI {
+	configuration, err := config.NewConfigurationData(config.GetDefaultConfigurationFile())
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+
 	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((configuration.GetTokenPrivateKey()))
 	if err != nil {
 		t.Fatal("Could not parse Key ", err)

--- a/work-item-link-type-blackbox_test.go
+++ b/work-item-link-type-blackbox_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/almighty/almighty-core"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/migration"
@@ -43,9 +43,8 @@ type workItemLinkTypeSuite struct {
 // The SetupSuite method will run before the tests in the suite are run.
 // It sets up a database connection for all the tests in this suite without polluting global space.
 func (s *workItemLinkTypeSuite) SetupSuite() {
-	var err error
-
-	if err = configuration.Setup(""); err != nil {
+	configuration, err := config.NewConfigurationData(config.GetDefaultConfigurationFile())
+	if err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
 
@@ -301,6 +300,10 @@ func (s *workItemLinkTypeSuite) TestListWorkItemLinkTypeOK() {
 }
 
 func getWorkItemLinkTypeTestData(t *testing.T) []testSecureAPI {
+	configuration, err := config.NewConfigurationData(config.GetDefaultConfigurationFile())
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
 	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((configuration.GetTokenPrivateKey()))
 	if err != nil {
 		t.Fatal("Could not parse Key ", err)

--- a/workitem/workitem_repository_blackbox_test.go
+++ b/workitem/workitem_repository_blackbox_test.go
@@ -3,6 +3,7 @@ package workitem_test
 import (
 	"testing"
 
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
@@ -21,7 +22,7 @@ type workItemRepoBlackBoxTest struct {
 }
 
 func TestRunWorkTypeRepoBlackBoxTest(t *testing.T) {
-	suite.Run(t, &workItemRepoBlackBoxTest{DBTestSuite: gormsupport.NewDBTestSuite("../config.yaml")})
+	suite.Run(t, &workItemRepoBlackBoxTest{DBTestSuite: gormsupport.NewDBTestSuite("../" + config.GetDefaultConfigurationFile())})
 }
 
 func (s *workItemRepoBlackBoxTest) SetupTest() {

--- a/workitem/workitemtype_repository_blackbox_test.go
+++ b/workitem/workitemtype_repository_blackbox_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/almighty/almighty-core/app"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/errors"
+
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/workitem"
 	errs "github.com/pkg/errors"
@@ -22,7 +24,7 @@ type workItemTypeRepoBlackBoxTest struct {
 }
 
 func TestRunWorkItemTypeRepoBlackBoxTest(t *testing.T) {
-	suite.Run(t, &workItemTypeRepoBlackBoxTest{DBTestSuite: gormsupport.NewDBTestSuite("../config.yaml")})
+	suite.Run(t, &workItemTypeRepoBlackBoxTest{DBTestSuite: gormsupport.NewDBTestSuite("../" + config.GetDefaultConfigurationFile())})
 }
 
 func (s *workItemTypeRepoBlackBoxTest) SetupTest() {

--- a/workitem_blackbox_test.go
+++ b/workitem_blackbox_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/iteration"
@@ -168,6 +168,11 @@ func TestListByFields(t *testing.T) {
 }
 
 func getWorkItemTestData(t *testing.T) []testSecureAPI {
+	configuration, err := config.NewConfigurationData(config.GetDefaultConfigurationFile())
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+
 	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((configuration.GetTokenPrivateKey()))
 	if err != nil {
 		t.Fatal("Could not parse Key ", err)
@@ -573,7 +578,8 @@ type WorkItem2Suite struct {
 func (s *WorkItem2Suite) SetupSuite() {
 	var err error
 
-	if err = configuration.Setup(""); err != nil {
+	configuration, err := config.NewConfigurationData(config.GetDefaultConfigurationFile())
+	if err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
 

--- a/workitem_whitebox_test.go
+++ b/workitem_whitebox_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/migration"
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/remoteworkitem"
@@ -27,9 +27,9 @@ var DB *gorm.DB
 var RwiScheduler *remoteworkitem.Scheduler
 
 func TestMain(m *testing.M) {
-	var err error
 
-	if err = configuration.Setup(""); err != nil {
+	configuration, err := config.NewConfigurationData(config.GetDefaultConfigurationFile())
+	if err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
 

--- a/workitemtype_blackbox_test.go
+++ b/workitemtype_blackbox_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/almighty/almighty-core"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
@@ -291,6 +291,11 @@ func (s *workItemTypeSuite) TestListSourceAndTargetLinkTypesNotFound() {
 }
 
 func getWorkItemTypeTestData(t *testing.T) []testSecureAPI {
+	configuration, err := config.NewConfigurationData(config.GetDefaultConfigurationFile())
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+
 	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((configuration.GetTokenPrivateKey()))
 	if err != nil {
 		t.Fatal("Could not parse Key ", err)


### PR DESCRIPTION
The objective of this PR is to expose a way to create a dedicated configuration object, on which invocations can be made for fetching config values . Fixes #592  

```
configuration, err := config.GetConfigurationData()
configuration.GetPostgresConnectionMaxRetries()
```

The code refactoring involved the following  : 


**Exposed 2 methods in `configuration`**


(a) `NewConfigurationData(configFilePath)` : This takes the config file path as argument and is to be used for all test. 

```
configuration, err := config.NewConfigurationData("../config.yaml")
configuration.GetPostgresConnectionMaxRetries()
```

(b) `GetConfigurationData()` : This method internally consumes the env variable `ALMIGHTY_CONFIG_FILE_PATH` . This would either have been present in the environment from the start, Or would have been set using the `--config` flag. All methods except unit/integrations tests must be using this since the functional code should be config-file agnostic. 

```
configuration, err := config.GetConfigurationData()
configuration.GetPostgresConnectionMaxRetries()
```



~~Temporarily removed the keys from `config.yaml` because the format apparently is causing parsing errors.~~

**Use  _Literal style_ in config.yaml for rsa keys**

We were using [1] **>** for the multi-line RSA keys in config.yaml but **>** tends to eat up the newlines and eventually cause parsing errors. [2] So, that was replaced with **|** .


**Updated the alias for importing configuration package**

`github.com/almighty/almighty-core/configuration` is now using the alias `config` so that developers can continue using `configuration.GetPostgresConnectionMaxRetries()` in their code and also reduced the amount of refactoring needed.


[1] https://github.com/almighty/almighty-core/blob/master/config.yaml#L36
[2] http://stackoverflow.com/questions/3790454/in-yaml-how-do-i-break-a-string-over-multiple-lines/21699210#21699210

Thanks to @kwk for proposing the approach here : https://github.com/almighty/almighty-core/pull/632#discussion_r95592566

replaces old PR #632 
fixes #592
