### PR TITLE
Inconsistency in comment id when creating vs showing (#714)

### DIFF
--- a/comments.go
+++ b/comments.go
@@ -10,7 +10,6 @@ import (
 	"github.com/almighty/almighty-core/login"
 	"github.com/almighty/almighty-core/rest"
 	"github.com/goadesign/goa"
-	uuid "github.com/satori/go.uuid"
 )
 
 // CommentsController implements the comments resource.
@@ -26,14 +25,8 @@ func NewCommentsController(service *goa.Service, db application.DB) *CommentsCon
 
 // Show runs the show action.
 func (c *CommentsController) Show(ctx *app.ShowCommentsContext) error {
-	id, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(err.Error()))
-		return ctx.BadRequest(jerrors)
-	}
-
 	return application.Transactional(c.db, func(appl application.Application) error {
-		c, err := appl.Comments().Load(ctx, id)
+		c, err := appl.Comments().Load(ctx, ctx.ID)
 		if err != nil {
 			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(err.Error()))
 			return ctx.NotFound(jerrors)
@@ -51,17 +44,13 @@ func (c *CommentsController) Show(ctx *app.ShowCommentsContext) error {
 
 // Update does PATCH comment
 func (c *CommentsController) Update(ctx *app.UpdateCommentsContext) error {
-	id, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
-	}
 	identity, err := login.ContextIdentity(ctx)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(err.Error()))
 	}
 
 	return application.Transactional(c.db, func(appl application.Application) error {
-		cm, err := appl.Comments().Load(ctx.Context, id)
+		cm, err := appl.Comments().Load(ctx.Context, ctx.ID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}

--- a/comments_blackbox_test.go
+++ b/comments_blackbox_test.go
@@ -15,6 +15,7 @@ import (
 	testsupport "github.com/almighty/almighty-core/test"
 	almtoken "github.com/almighty/almighty-core/token"
 	"github.com/almighty/almighty-core/workitem"
+
 	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
@@ -111,12 +112,7 @@ func (s *CommentsSuite) TestShowCommentWithoutAuth() {
 	userSvc, commentsCtrl := s.unsecuredController()
 	_, result := test.ShowCommentsOK(s.T(), userSvc.Context, userSvc, commentsCtrl, commentId)
 	// then
-	require.NotNil(s.T(), result)
-	require.NotNil(s.T(), result.Data)
-	assert.NotNil(s.T(), result.Data.ID)
-	assert.NotNil(s.T(), result.Data.Type)
-	assert.Equal(s.T(), "a comment", *result.Data.Attributes.Body)
-	assert.Equal(s.T(), testsupport.TestIdentity.ID, *result.Data.Relationships.CreatedBy.Data.ID)
+	validateComment(s.T(), result)
 }
 
 func (s *CommentsSuite) TestShowCommentWithAuth() {
@@ -127,12 +123,22 @@ func (s *CommentsSuite) TestShowCommentWithAuth() {
 	userSvc, _, _, commentsCtrl := s.securedControllers(testsupport.TestIdentity)
 	_, result := test.ShowCommentsOK(s.T(), userSvc.Context, userSvc, commentsCtrl, commentId)
 	// then
-	require.NotNil(s.T(), result)
-	require.NotNil(s.T(), result.Data)
-	assert.NotNil(s.T(), result.Data.ID)
-	assert.NotNil(s.T(), result.Data.Type)
-	assert.Equal(s.T(), "a comment", *result.Data.Attributes.Body)
-	assert.Equal(s.T(), testsupport.TestIdentity.ID, *result.Data.Relationships.CreatedBy.Data.ID)
+	validateComment(s.T(), result)
+}
+
+func validateComment(t *testing.T, result *app.CommentSingle) {
+	require.NotNil(t, result)
+	require.NotNil(t, result.Data)
+	assert.NotNil(t, result.Data.ID)
+	assert.NotNil(t, result.Data.Type)
+	require.NotNil(t, result.Data.Attributes)
+	require.NotNil(t, result.Data.Attributes.Body)
+	assert.Equal(t, "a comment", *result.Data.Attributes.Body)
+	require.NotNil(t, result.Data.Relationships)
+	require.NotNil(t, result.Data.Relationships.CreatedBy)
+	require.NotNil(t, result.Data.Relationships.CreatedBy.Data)
+	require.NotNil(t, result.Data.Relationships.CreatedBy.Data.ID)
+	assert.Equal(t, testsupport.TestIdentity.ID, *result.Data.Relationships.CreatedBy.Data.ID)
 }
 
 func (s *CommentsSuite) TestUpdateCommentWithoutAuth() {

--- a/comments_blackbox_test.go
+++ b/comments_blackbox_test.go
@@ -1,0 +1,201 @@
+package main_test
+
+import (
+	"crypto/rsa"
+	"fmt"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	. "github.com/almighty/almighty-core"
+	"github.com/almighty/almighty-core/account"
+	"github.com/almighty/almighty-core/app"
+	"github.com/almighty/almighty-core/app/test"
+	"github.com/almighty/almighty-core/configuration"
+	"github.com/almighty/almighty-core/gormapplication"
+	"github.com/almighty/almighty-core/gormsupport/cleaner"
+	"github.com/almighty/almighty-core/migration"
+	"github.com/almighty/almighty-core/models"
+	"github.com/almighty/almighty-core/resource"
+	testsupport "github.com/almighty/almighty-core/test"
+	almtoken "github.com/almighty/almighty-core/token"
+	"github.com/almighty/almighty-core/workitem"
+	"github.com/goadesign/goa"
+	"github.com/jinzhu/gorm"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// a normal test function that will kick off TestSuiteComments
+func TestSuiteComments(t *testing.T) {
+	resource.Require(t, resource.Database)
+	suite.Run(t, new(CommentsSuite))
+}
+
+// ========== TestSuiteComments struct that implements SetupSuite, TearDownSuite, SetupTest, TearDownTest ==========
+type CommentsSuite struct {
+	suite.Suite
+	workitemCommentsCtrl app.WorkItemCommentsController
+	workitemCtrl         app.WorkitemController
+	defaultSvc           *goa.Service
+	userSvc              *goa.Service
+	userSvc2             *goa.Service
+	db                   *gorm.DB
+	pubKey               *rsa.PublicKey
+	priKey               *rsa.PrivateKey
+	clean                func()
+	commentId            uuid.UUID
+}
+
+func (s *CommentsSuite) SetupSuite() {
+	var err error
+	if err = configuration.Setup(""); err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+	s.db, err = gorm.Open("postgres", configuration.GetPostgresConfigString())
+	if err != nil {
+		panic("Failed to connect database: " + err.Error())
+	}
+	// default service (without auth)
+	s.defaultSvc = goa.New("Comments-service-test")
+	// user service (with auth)
+	s.pubKey, _ = almtoken.ParsePublicKey([]byte(almtoken.RSAPublicKey))
+	s.priKey, _ = almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
+	s.userSvc = testsupport.ServiceAsUser("CommentsSuite-Service", almtoken.NewManager(s.pubKey, s.priKey), account.TestIdentity)
+	s.userSvc2 = testsupport.ServiceAsUser("CommentsSuite-Service", almtoken.NewManager(s.pubKey, s.priKey), account.TestIdentity2)
+	// Make sure the database is populated with the correct types (e.g. bug etc.)
+	if configuration.GetPopulateCommonTypes() {
+		if err := models.Transactional(s.db, func(tx *gorm.DB) error {
+			return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))
+		}); err != nil {
+			panic(err.Error())
+		}
+	}
+	s.clean = cleaner.DeleteCreatedEntities(s.db)
+	s.workitemCtrl = NewWorkitemController(s.userSvc, gormapplication.NewGormDB(s.db))
+	s.workitemCommentsCtrl = NewWorkItemCommentsController(s.userSvc, gormapplication.NewGormDB(s.db))
+}
+
+func (s *CommentsSuite) TearDownSuite() {
+	s.clean()
+	if s.db != nil {
+		s.db.Close()
+	}
+}
+
+func (s *CommentsSuite) SetupTest() {
+	// create the workitem that will be used to perform the comment operations during the tests.
+	// given
+	createWorkitemPayload := app.CreateWorkitemPayload{
+		Data: &app.WorkItem2{
+			Type: APIStringTypeWorkItem,
+			Attributes: map[string]interface{}{
+				workitem.SystemTitle: "Title",
+				workitem.SystemState: workitem.SystemStateNew},
+			Relationships: &app.WorkItemRelationships{
+				BaseType: &app.RelationBaseType{
+					Data: &app.BaseTypeData{
+						Type: "workitemtypes",
+						ID:   workitem.SystemBug,
+					},
+				},
+			},
+		},
+	}
+	_, wi := test.CreateWorkitemCreated(s.T(), s.userSvc.Context, s.userSvc, s.workitemCtrl, &createWorkitemPayload)
+	workitemId := *wi.Data.ID
+	// now, create a comment for the workitem
+	createWorkItemCommentPayload := app.CreateWorkItemCommentsPayload{
+		Data: &app.CreateComment{
+			Type: "comments",
+			Attributes: &app.CreateCommentAttributes{
+				Body: "a comment",
+			},
+		},
+	}
+	_, comment := test.CreateWorkItemCommentsOK(s.T(), s.userSvc.Context, s.userSvc, s.workitemCommentsCtrl, workitemId,
+		&createWorkItemCommentPayload)
+	s.commentId = *comment.Data.ID
+	s.T().Log(fmt.Sprintf("Created comment with id %v", s.commentId))
+}
+
+func (s *CommentsSuite) TearDownTest() {
+}
+
+func (s *CommentsSuite) TestShowCommentWithoutAuth() {
+	// given
+	commentsCtrl := NewCommentsController(s.defaultSvc, gormapplication.NewGormDB(s.db))
+	// when
+	_, result := test.ShowCommentsOK(s.T(), s.defaultSvc.Context, s.defaultSvc, commentsCtrl, s.commentId)
+	// then
+	require.NotNil(s.T(), result)
+	require.NotNil(s.T(), result.Data)
+	assert.NotNil(s.T(), result.Data.ID)
+	assert.NotNil(s.T(), result.Data.Type)
+	assert.Equal(s.T(), "a comment", *result.Data.Attributes.Body)
+	assert.Equal(s.T(), account.TestIdentity.ID, *result.Data.Relationships.CreatedBy.Data.ID)
+}
+
+func (s *CommentsSuite) TestShowCommentWithAuth() {
+	// given
+	commentsCtrl := NewCommentsController(s.userSvc, gormapplication.NewGormDB(s.db))
+	// when
+	_, result := test.ShowCommentsOK(s.T(), s.userSvc.Context, s.userSvc, commentsCtrl, s.commentId)
+	// then
+	require.NotNil(s.T(), result)
+	require.NotNil(s.T(), result.Data)
+	assert.NotNil(s.T(), result.Data.ID)
+	assert.NotNil(s.T(), result.Data.Type)
+	assert.Equal(s.T(), "a comment", *result.Data.Attributes.Body)
+	assert.Equal(s.T(), account.TestIdentity.ID, *result.Data.Relationships.CreatedBy.Data.ID)
+}
+
+func (s *CommentsSuite) TestUpdateCommentWithoutAuth() {
+	// given
+	commentsCtrl := NewCommentsController(s.defaultSvc, gormapplication.NewGormDB(s.db))
+	updatedCommentBody := "An updated comment"
+	updateCommentPayload := app.UpdateCommentsPayload{
+		Data: &app.Comment{
+			Type: "comments",
+			Attributes: &app.CommentAttributes{
+				Body: &updatedCommentBody,
+			},
+		},
+	}
+	// when/then
+	test.UpdateCommentsUnauthorized(s.T(), s.defaultSvc.Context, s.defaultSvc, commentsCtrl, s.commentId, &updateCommentPayload)
+}
+
+func (s *CommentsSuite) TestUpdateCommentWithSameAuthenticatedUser() {
+	// given
+	commentsCtrl := NewCommentsController(s.userSvc, gormapplication.NewGormDB(s.db))
+	updatedCommentBody := "An updated comment"
+	updateCommentPayload := app.UpdateCommentsPayload{
+		Data: &app.Comment{
+			Type: "comments",
+			Attributes: &app.CommentAttributes{
+				Body: &updatedCommentBody,
+			},
+		},
+	}
+	// when/then
+	test.UpdateCommentsOK(s.T(), s.userSvc.Context, s.userSvc, commentsCtrl, s.commentId, &updateCommentPayload)
+}
+
+func (s *CommentsSuite) TestUpdateCommentWithOtherAuthenticatedUser() {
+	// given
+	commentsCtrl := NewCommentsController(s.userSvc2, gormapplication.NewGormDB(s.db))
+	updatedCommentBody := "An updated comment"
+	updateCommentPayload := app.UpdateCommentsPayload{
+		Data: &app.Comment{
+			Type: "comments",
+			Attributes: &app.CommentAttributes{
+				Body: &updatedCommentBody,
+			},
+		},
+	}
+	// when/then
+	test.UpdateCommentsUnauthorized(s.T(), s.userSvc2.Context, s.userSvc2, commentsCtrl, s.commentId, &updateCommentPayload)
+}

--- a/design/comments.go
+++ b/design/comments.go
@@ -103,7 +103,7 @@ var _ = a.Resource("comments", func() {
 			a.GET("/:id"),
 		)
 		a.Params(func() {
-			a.Param("id", d.String, "id")
+			a.Param("id", d.UUID, "id")
 		})
 		a.Description("Retrieve comment with given id.")
 		a.Response(d.OK, func() {
@@ -120,7 +120,7 @@ var _ = a.Resource("comments", func() {
 		)
 		a.Description("update the comment with the given id.")
 		a.Params(func() {
-			a.Param("id", d.String, "id")
+			a.Param("id", d.UUID, "id")
 		})
 		a.Payload(commentSingle)
 		a.Response(d.OK, func() {

--- a/test/account.go
+++ b/test/account.go
@@ -17,3 +17,18 @@ var TestUser = account.User{
 	Email:    "testdeveloper@testalm.io",
 	Identity: TestIdentity,
 }
+
+// TestIdentity2 only creates in memory obj for testing purposes
+var TestIdentity2 = account.Identity{
+	ID:       uuid.NewV4(),
+	FullName: "Test Developer Identity 2",
+}
+
+// TestUser2 only creates in memory obj for testing purposes.
+// This TestUser2 can be used to verify that some entity created by TestUser
+// can be later updated or deleted (or not) by another user.
+var TestUser2 = account.User{
+	ID:       uuid.NewV4(),
+	Email:    "testdeveloper2@testalm.io",
+	Identity: TestIdentity2,
+}


### PR DESCRIPTION
Replaced the `string` type with `UUID` for the `ID` parameter
in the `show` and `update` operations.

Added a `comments_backbox_test.go` to verify that comments can
be shown with and without auth, but cannot be updated without auth
or when the user was not the comment author.

Fixes #714 

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
