### PR TITLE
Use an updated payload for the creation of the work item

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -338,7 +338,7 @@ To override configuration values using environment variables, use the prefix
 
 For example to override `postgres.password`, set the environment variable `ALMIGHTY_POSTGRES_PASSWORD` to the value of you liking.
 
-NOTE: Environment variables override the default values and the ones you've set in your config file. 
+NOTE: Environment variables override the default values and the ones you've set in your config file.
 
 ==== Development
 
@@ -373,7 +373,7 @@ Generate a token for future use.
 ./bin/alm-cli generate login -H localhost:8080 --pp
 ----
 
-You should get Token in response, save this token in your favourite editor as you need to use this token for POST API calls  
+You should get Token in response, save this token in your favourite editor as you need to use this token for POST API calls
 
 Create a work item type (using above token).
 ----
@@ -420,7 +420,7 @@ System defined Work Item Types are
 Use any one of above to create Work Item based on that type.
 Following example creates a Work Item of type `userstory`
 ----
-$ ./bin/alm-cli create workitem --key "<GENERATED TOKEN>" --payload '{"type": "userstory", "fields": { "system.title": "A catchy Title", "system.owner": "tmaeder", "system.state": "open" }}' -H localhost:8080
+$ ./bin/alm-cli create workitem --key "<GENERATED TOKEN>" --payload '{ "data": { "attributes": { "system.owner": "tmaeder", "system.state": "open", "system.title": "Example of an Epic", "version": "1" }, "relationships": { "baseType": { "data": { "id": "Epic", "type": "workitemtypes" } } }, "type": "workitems" } }' -H localhost:8080
 ----
 
 In response you should get ID of created item, using that you can retrieve the work item.


### PR DESCRIPTION
I experienced an error while testing the almighty commands. In particular, I found that the workitem creation command doesn't work with the mentioned example:
```
./bin/alm-cli create workitem --key "<TOKEN>" --payload '{"type": "Epic", "fields": { "system.owner": "tmaeder", "system.state": "open" }}' -H localhost:8080`
2017/02/02 15:33:19 [INFO] started id=hrK3JTIf POST=http://localhost:8080/api/workitems
2017/02/02 15:33:19 [INFO] completed id=hrK3JTIf status=400 time=14.057174ms
error: 400: {"errors":[{"code":"bad_request","detail":"[v4y23h48] 400 invalid_request: attribute \"data\" of raw is missing and required, attribute: data, parent: raw","id":"IDXykbYw","status":"400","title":"Bad Request"}]}
```

If you check the payload example of the workitem creation cmd, there are new elements and `data` is one of them:

```json
{
    "data": {
        "attributes": {
            "system.owner": "tmaeder",
            "system.state": "open",
            "version": 0
        },
        "id": "780",
        "links": {
            "self": "http://localhost:8080/api/workitems/780",
            "sourceLinkTypes": "http://localhost:8080/api/workitemtypes/Epic/source-link-types",
            "targetLinkTypes": "http://localhost:8080/api/workitemtypes/Epic/target-link-types"
        },
        "relationships": {
```

I decided to replace the current payload that doesn't work by the following one `{ "data": { "attributes": { "system.owner": "tmaeder", "system.state": "open", "system.title": "Example of an Epic", "version": "1" }, "relationships": { "baseType": { "data": { "id": "Epic", "type": "workitemtypes" } } }, "type": "workitems" } }`

```
$ ./bin/alm-cli create workitem --key "<TOKEN>" --payload '{ "data": { "attributes": { "system.owner": "tmaeder", "system.state": "open", "system.title": "Example of an Epic", "version": "1" }, "relationships": { "baseType": { "data": { "id": "Epic", "type": "workitemtypes" } } }, "type": "workitems" } }' -H localhost:8080
2017/02/02 16:56:23 [INFO] started id=37DDCF6i POST=http://localhost:8080/api/workitems
2017/02/02 16:56:23 [INFO] completed id=37DDCF6i status=201 time=21.372247ms
{"data":{"attributes":{"system.owner":"tmaeder","system.state":"open","version":0},"id":"780","links":{"self":"http://localhost:8080/api/workitems/780","sourceLinkTypes":"http://localhost:8080/api/workitemtypes/Epic/source-link-types","targetLinkTypes":"http://localhost:8080/api/workitemtypes/Epic/target-link-types"},"relationships":{"assignees":{},"baseType":{"data":{"id":"Epic","type":"workitemtypes"}},"comments":{"links":{"related":"http://localhost:8080/api/workitems/780/comments","self":"http://localhost:8080/api/workitems/780/relationships/comments"}},"iteration":{}},"type":"workitems"},"links":{"self":"http://localhost:8080/api/workitems"}}
```

Consequently, I can find it afterwards by using its ID.

```
$ ./bin/alm-cli show workitem --id 780 -H localhost:8080 --pp
2017/02/02 16:56:36 [INFO] started id=kx0LZApG GET=http://localhost:8080/api/workitems/780
2017/02/02 16:56:36 [INFO] completed id=kx0LZApG status=200 time=15.261339ms
{
    "data": {
        "attributes": {
            "system.owner": "tmaeder",
            "system.state": "open",
            "version": 0
        },
        "id": "780",
        "links": {
            "self": "http://localhost:8080/api/workitems/780",
            "sourceLinkTypes": "http://localhost:8080/api/workitemtypes/Epic/source-link-types",
            "targetLinkTypes": "http://localhost:8080/api/workitemtypes/Epic/target-link-types"
        },
        "relationships": {
            "assignees": {},
            "baseType": {
                "data": {
                    "id": "Epic",
                    "type": "workitemtypes"
                }
            },
            "comments": {
                "links": {
                    "related": "http://localhost:8080/api/workitems/780/comments",
                    "self": "http://localhost:8080/api/workitems/780/relationships/comments"
                },
                "meta": {
                    "totalCount": 0
                }
            },
            "iteration": {}
        },
        "type": "workitems"
    }
```
