### PR TITLE
WIP Makefile: check-go-format, format-go-code + CI check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,22 @@ help:/
           } \
         }' $(MAKEFILE_LIST)
 
+.PHONY: check-go-format
+## Exists with an error if there are files whose formatting differs from gofmt's
+check-go-format: prebuild-check
+	@gofmt -l ${SOURCES} 2>&1 \
+		| tee /tmp/gofmt-errors \
+		| read \
+	&& echo "ERROR: These files differ from gofmt's style (run 'make format-go-code' to fix this):" \
+	&& cat /tmp/gofmt-errors \
+	&& exit 1 \
+	|| true
+
+.PHONY: format-go-code
+## Formats any go file that differs from gofmt's style
+format-go-code: prebuild-check
+	@gofmt -l -w ${SOURCES}
+
 .PHONY: build
 ## Build server and client.
 build: prebuild-check deps generate $(BINARY_SERVER_BIN) $(BINARY_CLIENT_BIN) # do the build

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -44,6 +44,7 @@ function cleanup_env {
 function prepare() {
   # Let's test
   make docker-start
+  make docker-check-go-format
   make docker-deps
   make docker-generate
   make docker-build

--- a/space.go
+++ b/space.go
@@ -214,11 +214,11 @@ func ConvertSpace(request *goa.RequestData, p *space.Space, additional ...SpaceC
 		ID:   &p.ID,
 		Type: "spaces",
 		Attributes: &app.SpaceAttributes{
-			Name:      &p.Name,
+			Name:        &p.Name,
 			Description: &p.Description,
-			CreatedAt: &p.CreatedAt,
-			UpdatedAt: &p.UpdatedAt,
-			Version:   &p.Version,
+			CreatedAt:   &p.CreatedAt,
+			UpdatedAt:   &p.UpdatedAt,
+			Version:     &p.Version,
 		},
 		Links: &app.GenericLinks{
 			Self: &selfURL,

--- a/space/space.go
+++ b/space/space.go
@@ -15,9 +15,9 @@ import (
 // Space represents a Space on the domain and db layer
 type Space struct {
 	gormsupport.Lifecycle
-	ID      satoriuuid.UUID
-	Version int
-	Name    string
+	ID          satoriuuid.UUID
+	Version     int
+	Name        string
 	Description string
 }
 


### PR DESCRIPTION
check-go-format:
  - Exists with an error if there are files whose formatting differs
    from gofmt's

format-go-code:
  - Formats any go file that differs from gofmt's style

From this point onwards, the CI will check that GO code is correctly
formatted and if it is not, it will print an error that lists the files
that need to be changed.

In order to satisfy this CI check you can run "make format-go-code" to
have your code in proper shape. Then add those changes made to your
files and commit them.

This commit for example is based on a state of master where not all code
is correctly formatted, so it will not pass CI. I will make a second
commit that fixes this. This commit and the CI run are meant to be seen
as a demonstration that it works.

Try "make help" to find out more about the new make targets.

Thanks to @hectorj2f for coming up with this idea.
