### PR TITLE
Prevent script injection in workitem content #708

### DIFF
--- a/rendering/markup_render.go
+++ b/rendering/markup_render.go
@@ -29,7 +29,5 @@ func RenderMarkupToHTML(content, markup string) string {
 		return html
 	default:
 		return ""
-
 	}
-
 }

--- a/workitem.go
+++ b/workitem.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"html"
 	"strconv"
 
 	"golang.org/x/net/context"
@@ -324,15 +325,17 @@ func ConvertWorkItem(request *goa.RequestData, wi *app.WorkItem, additional ...W
 					Data: ConvertIterationSimple(request, valStr),
 				}
 			}
-
+		case workitem.SystemTitle:
+			// 'HTML escape' the title to prevent script injection
+			op.Attributes[name] = html.EscapeString(val.(string))
 		case workitem.SystemDescription:
 			description := rendering.NewMarkupContentFromValue(val)
 			if description != nil {
 				op.Attributes[name] = (*description).Content
 				op.Attributes[workitem.SystemDescriptionMarkup] = (*description).Markup
-				// let's include the rendered description
+				// let's include the rendered description while 'HTML escaping' it to prevent script injection
 				op.Attributes[workitem.SystemDescriptionRendered] =
-					rendering.RenderMarkupToHTML((*description).Content, (*description).Markup)
+					rendering.RenderMarkupToHTML(html.EscapeString((*description).Content), (*description).Markup)
 			}
 
 		default:


### PR DESCRIPTION
using the `html.EscapeString()` function to escape the
title and rendered description content (not the raw content
that remains editable as it was input by the user).

Fixes #708

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
