### PR TITLE
Replace userspace POST with PUT and GET support

### DIFF
--- a/design/userspace.go
+++ b/design/userspace.go
@@ -10,11 +10,20 @@ var _ = a.Resource("userspace", func() {
 
 	a.Action("create", func() {
 		a.Routing(
-			a.POST("/*"),
+			a.PUT("/*"),
 		)
 		a.Description("Data dump endpoint ")
 		a.Payload(a.HashOf(d.String, d.Any))
-		a.Response(d.Created)
+		a.Response(d.NoContent)
 		a.Response(d.InternalServerError)
+	})
+	a.Action("show", func() {
+		a.Routing(
+			a.GET("/*"),
+		)
+		a.Description("Data dump endpoint ")
+		a.Response(d.OK, a.HashOf(d.String, d.Any))
+		a.Response(d.InternalServerError)
+		a.Response(d.NotFound)
 	})
 })


### PR DESCRIPTION
Temp endpoint for data dump from 'userspace'

Path is a unique ID for a resource that exists in userspace
that need data synced down to saas. PUT Path stores the data and
GET Path fetch the data back.
