### PR TITLE
Rename 'id' parameter into 'commentId' for the /comments endpoint (#739)

### DIFF
--- a/comments.go
+++ b/comments.go
@@ -26,7 +26,7 @@ func NewCommentsController(service *goa.Service, db application.DB) *CommentsCon
 // Show runs the show action.
 func (c *CommentsController) Show(ctx *app.ShowCommentsContext) error {
 	return application.Transactional(c.db, func(appl application.Application) error {
-		c, err := appl.Comments().Load(ctx, ctx.ID)
+		c, err := appl.Comments().Load(ctx, ctx.CommentID)
 		if err != nil {
 			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(err.Error()))
 			return ctx.NotFound(jerrors)
@@ -50,7 +50,7 @@ func (c *CommentsController) Update(ctx *app.UpdateCommentsContext) error {
 	}
 
 	return application.Transactional(c.db, func(appl application.Application) error {
-		cm, err := appl.Comments().Load(ctx.Context, ctx.ID)
+		cm, err := appl.Comments().Load(ctx.Context, ctx.CommentID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}

--- a/design/comments.go
+++ b/design/comments.go
@@ -100,12 +100,12 @@ var _ = a.Resource("comments", func() {
 
 	a.Action("show", func() {
 		a.Routing(
-			a.GET("/:id"),
+			a.GET("/:commentId"),
 		)
 		a.Params(func() {
-			a.Param("id", d.UUID, "id")
+			a.Param("commentId", d.UUID, "commentId")
 		})
-		a.Description("Retrieve comment with given id.")
+		a.Description("Retrieve comment with given commentId.")
 		a.Response(d.OK, func() {
 			a.Media(commentSingle)
 		})
@@ -116,11 +116,11 @@ var _ = a.Resource("comments", func() {
 	a.Action("update", func() {
 		a.Security("jwt")
 		a.Routing(
-			a.PATCH("/:id"),
+			a.PATCH("/:commentId"),
 		)
-		a.Description("update the comment with the given id.")
+		a.Description("update the comment with the given commentId.")
 		a.Params(func() {
-			a.Param("id", d.UUID, "id")
+			a.Param("commentId", d.UUID, "commentId")
 		})
 		a.Payload(commentSingle)
 		a.Response(d.OK, func() {


### PR DESCRIPTION
Fixes #739
