### PR TITLE
Return a 403 Forbidden response when trying to update a comment from …

### DIFF
--- a/comments.go
+++ b/comments.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"errors"
-
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/comment"
@@ -57,7 +55,9 @@ func (c *CommentsController) Update(ctx *app.UpdateCommentsContext) error {
 		}
 
 		if identity != cm.CreatedBy.String() {
-			return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(errors.New("Not same user")))
+			// need to use the goa.NewErrorClass() func as there is no native support for 403 in goa
+			// and it is not planned to be supported yet: https://github.com/goadesign/goa/pull/1030
+			return jsonapi.JSONErrorResponse(ctx, goa.NewErrorClass("forbidden", 403)("User is not the comment author"))
 		}
 
 		cm.Body = *ctx.Payload.Data.Attributes.Body

--- a/comments_blackbox_test.go
+++ b/comments_blackbox_test.go
@@ -215,7 +215,7 @@ func (s *CommentsSuite) TestUpdateCommentWithOtherUser() {
 	commentId := s.createWorkItemComment(testsupport.TestIdentity, workitemId, "body", &plaintextMarkup)
 	// when
 	updatedCommentBody := "An updated comment"
-	updateCommentPayload := app.UpdateCommentsPayload{
+	updateCommentPayload := &app.UpdateCommentsPayload{
 		Data: &app.Comment{
 			Type: "comments",
 			Attributes: &app.CommentAttributes{
@@ -223,6 +223,7 @@ func (s *CommentsSuite) TestUpdateCommentWithOtherUser() {
 			},
 		},
 	}
+	// when/then
 	userSvc, _, _, commentsCtrl := s.securedControllers(testsupport.TestIdentity2)
-	test.UpdateCommentsUnauthorized(s.T(), userSvc.Context, userSvc, commentsCtrl, commentId, &updateCommentPayload)
+	test.UpdateCommentsForbidden(s.T(), userSvc.Context, userSvc, commentsCtrl, commentId, updateCommentPayload)
 }

--- a/design/comments.go
+++ b/design/comments.go
@@ -136,6 +136,7 @@ var _ = a.Resource("comments", func() {
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.Forbidden, JSONAPIErrors)
 	})
 
 })

--- a/jsonapi/jsonapi_utility.go
+++ b/jsonapi/jsonapi_utility.go
@@ -110,6 +110,11 @@ type Unauthorized interface {
 	Unauthorized(*app.JSONAPIErrors) error
 }
 
+// Forbidden represent a Context that can return a Unauthorized HTTP status
+type Forbidden interface {
+	Forbidden(*app.JSONAPIErrors) error
+}
+
 // JSONErrorResponse auto maps the provided error to the correct response type
 // If all else fails, InternalServerError is returned
 func JSONErrorResponse(x InternalServerError, err error) error {
@@ -126,6 +131,10 @@ func JSONErrorResponse(x InternalServerError, err error) error {
 	case http.StatusUnauthorized:
 		if ctx, ok := x.(Unauthorized); ok {
 			return errs.WithStack(ctx.Unauthorized(jsonErr))
+		}
+	case http.StatusForbidden:
+		if ctx, ok := x.(Forbidden); ok {
+			return errs.WithStack(ctx.Forbidden(jsonErr))
 		}
 	default:
 		return errs.WithStack(x.InternalServerError(jsonErr))


### PR DESCRIPTION
…another user (#715)

Added support for 403/Forbidden responses in `json_utility` and returning
this type of error when the user who tries to update a comment is not
the original author of the comment.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

* Please describe what your change is about.
* What issues does it solve? (Use [autoreferencing for this](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests))
* If you are still working on the change please prefix the pull request title with "WIP"
