### PR TITLE
Set default comment markup to 'PlainText' in the database (#741)

### DIFF
--- a/comment/comment.go
+++ b/comment/comment.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"
+	"github.com/almighty/almighty-core/rendering"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
@@ -50,13 +51,14 @@ func (m *GormCommentRepository) TableName() string {
 }
 
 // Create creates a new record.
-func (m *GormCommentRepository) Create(ctx context.Context, u *Comment) error {
+func (m *GormCommentRepository) Create(ctx context.Context, comment *Comment) error {
 	defer goa.MeasureSince([]string{"goa", "db", "comment", "create"}, time.Now())
-
-	u.ID = uuid.NewV4()
-
-	err := m.db.Create(u).Error
-	if err != nil {
+	comment.ID = uuid.NewV4()
+	// make sure no comment is created with an empty 'markup' value
+	if comment.Markup == "" {
+		comment.Markup = rendering.SystemMarkupDefault
+	}
+	if err := m.db.Create(comment).Error; err != nil {
 		goa.LogError(ctx, "error adding Comment", "error", err.Error())
 		return errs.WithStack(err)
 	}
@@ -74,6 +76,10 @@ func (m *GormCommentRepository) Save(ctx context.Context, comment *Comment) (*Co
 	}
 	if err := tx.Error; err != nil {
 		return nil, errors.NewInternalError(err.Error())
+	}
+	// make sure no comment is created with an empty 'markup' value
+	if comment.Markup == "" {
+		comment.Markup = rendering.SystemMarkupDefault
 	}
 	tx = tx.Save(comment)
 	if err := tx.Error; err != nil {

--- a/comment/comment_test.go
+++ b/comment/comment_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/almighty/almighty-core/rendering"
 	"github.com/almighty/almighty-core/resource"
 	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -34,237 +36,164 @@ func (test *TestCommentRepository) TearDownTest() {
 	test.clean()
 }
 
-func (test *TestCommentRepository) TestCreateComment() {
-	t := test.T()
-	resource.Require(t, resource.Database)
-	repo := comment.NewCommentRepository(test.DB)
-	c := &comment.Comment{
-		ParentID:  "A",
-		Body:      "Test A",
-		Markup:    rendering.SystemMarkupMarkdown,
+func newComment(parentID, body, markup string) *comment.Comment {
+	return &comment.Comment{
+		ParentID:  parentID,
+		Body:      body,
+		Markup:    markup,
 		CreatedBy: uuid.NewV4(),
-	}
-	repo.Create(context.Background(), c)
-	if c.ID == uuid.Nil {
-		t.Errorf("Comment was not created, ID nil")
-	}
-	if c.CreatedAt.After(time.Now()) {
-		t.Errorf("Comment was not created, CreatedAt after Now()?")
 	}
 }
 
-func (test *TestCommentRepository) TestSaveComment() {
-	t := test.T()
-	resource.Require(t, resource.Database)
+func (test *TestCommentRepository) createComment(c *comment.Comment) {
 	repo := comment.NewCommentRepository(test.DB)
-	parentID := "AA"
-	c := &comment.Comment{
-		ParentID:  parentID,
-		Body:      "Test AA",
-		Markup:    rendering.SystemMarkupPlainText,
-		CreatedBy: uuid.NewV4(),
-	}
-	repo.Create(context.Background(), c)
-	if c.ID == uuid.Nil {
-		t.Errorf("Comment was not created, ID nil")
-	}
-	c.Body = "Test AB"
-	c.Markup = rendering.SystemMarkupMarkdown
-	repo.Save(context.Background(), c)
+	err := repo.Create(context.Background(), c)
+	require.Nil(test.T(), err)
+}
 
+func (test *TestCommentRepository) createComments(comments []*comment.Comment) {
+	repo := comment.NewCommentRepository(test.DB)
+	for _, comment := range comments {
+		err := repo.Create(context.Background(), comment)
+		require.Nil(test.T(), err)
+	}
+}
+
+func (test *TestCommentRepository) TestCreateCommentWithMarkup() {
+	// given
+	repo := comment.NewCommentRepository(test.DB)
+	comment := newComment("A", "Test A", rendering.SystemMarkupMarkdown)
+	// when
+	repo.Create(context.Background(), comment)
+	// then
+	assert.NotNil(test.T(), comment.ID, "Comment was not created, ID nil")
+	require.NotNil(test.T(), comment.CreatedAt, "Comment was not created?")
+	assert.False(test.T(), comment.CreatedAt.After(time.Now()), "Comment was not created, CreatedAt after Now()?")
+}
+
+func (test *TestCommentRepository) TestCreateCommentWithoutMarkup() {
+	// given
+	repo := comment.NewCommentRepository(test.DB)
+	comment := newComment("A", "Test A", "")
+	// when
+	repo.Create(context.Background(), comment)
+	// then
+	assert.NotNil(test.T(), comment.ID, "Comment was not created, ID nil")
+	require.NotNil(test.T(), comment.CreatedAt, "Comment was not created?")
+	assert.False(test.T(), comment.CreatedAt.After(time.Now()), "CreatedAt after Now()?")
+	assert.Equal(test.T(), rendering.SystemMarkupDefault, comment.Markup)
+}
+
+func (test *TestCommentRepository) TestSaveCommentWithMarkup() {
+	// given
+	repo := comment.NewCommentRepository(test.DB)
+	comment := newComment("A", "Test A", rendering.SystemMarkupPlainText)
+	test.createComment(comment)
+	assert.NotNil(test.T(), comment.ID, "Comment was not created, ID nil")
+	// when
+	comment.Body = "Test AB"
+	comment.Markup = rendering.SystemMarkupMarkdown
+	repo.Save(context.Background(), comment)
 	offset := 0
 	limit := 1
-	cl, _, err := repo.List(context.Background(), parentID, &offset, &limit)
-	if err != nil {
-		t.Error("Failed to List", err.Error())
-	}
+	comments, _, err := repo.List(context.Background(), comment.ParentID, &offset, &limit)
+	// then
+	require.Nil(test.T(), err)
+	require.Equal(test.T(), 1, len(comments), "List returned more then expected based on parentID")
+	assert.Equal(test.T(), "Test AB", comments[0].Body)
+	assert.Equal(test.T(), rendering.SystemMarkupMarkdown, comments[0].Markup)
+}
 
-	if len(cl) != 1 {
-		t.Error("List returned more then expected based on parentID")
-	}
-
-	c1 := cl[0]
-	if c1.Body != "Test AB" || c1.Markup != rendering.SystemMarkupMarkdown {
-		t.Error("List returned unexpected comment")
-	}
-
+func (test *TestCommentRepository) TestSaveCommentWithoutMarkup() {
+	// given
+	repo := comment.NewCommentRepository(test.DB)
+	comment := newComment("A", "Test A", rendering.SystemMarkupMarkdown)
+	test.createComment(comment)
+	assert.NotNil(test.T(), comment.ID, "Comment was not created, ID nil")
+	// when
+	comment.Body = "Test AB"
+	comment.Markup = ""
+	repo.Save(context.Background(), comment)
+	offset := 0
+	limit := 1
+	comments, _, err := repo.List(context.Background(), comment.ParentID, &offset, &limit)
+	// then
+	require.Nil(test.T(), err)
+	require.Equal(test.T(), 1, len(comments), "List returned more then expected based on parentID")
+	assert.Equal(test.T(), "Test AB", comments[0].Body)
+	assert.Equal(test.T(), rendering.SystemMarkupPlainText, comments[0].Markup)
 }
 
 func (test *TestCommentRepository) TestCountComments() {
-	t := test.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	repo := comment.NewCommentRepository(test.DB)
-
 	parentID := "A"
-	body := "Test A"
-
-	cs := []*comment.Comment{
-		&comment.Comment{
-			ParentID:  parentID,
-			Body:      body,
-			CreatedBy: uuid.NewV4(),
-		},
-		&comment.Comment{
-			ParentID:  "B",
-			Body:      "Test B",
-			CreatedBy: uuid.NewV4(),
-		},
-	}
-
-	for _, c := range cs {
-		err := repo.Create(context.Background(), c)
-		if err != nil {
-			t.Error("Failed to Create", err.Error())
-		}
-
-	}
-
+	comment1 := newComment("A", "Test A", rendering.SystemMarkupMarkdown)
+	comment2 := newComment("B", "Test B", rendering.SystemMarkupMarkdown)
+	comments := []*comment.Comment{comment1, comment2}
+	test.createComments(comments)
+	// when
 	count, err := repo.Count(context.Background(), parentID)
-	if err != nil {
-		t.Error("Failed to Count", err.Error())
-	}
-
-	if count != 1 {
-		t.Error("expected count is 1 but got:", count)
-	}
+	// then
+	require.Nil(test.T(), err)
+	assert.Equal(test.T(), 1, count)
 }
 
 func (test *TestCommentRepository) TestListComments() {
-	t := test.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	repo := comment.NewCommentRepository(test.DB)
-
-	parentID := "A"
-	body := "Test A"
-
-	cs := []*comment.Comment{
-		&comment.Comment{
-			ParentID:  parentID,
-			Body:      body,
-			CreatedBy: uuid.NewV4(),
-		},
-		&comment.Comment{
-			ParentID:  "B",
-			Body:      "Test B",
-			CreatedBy: uuid.NewV4(),
-		},
-	}
-
-	for _, c := range cs {
-		repo.Create(context.Background(), c)
-	}
-
+	comment1 := newComment("A", "Test A", rendering.SystemMarkupMarkdown)
+	comment2 := newComment("B", "Test B", rendering.SystemMarkupMarkdown)
+	comments := []*comment.Comment{comment1, comment2}
+	test.createComments(comments)
+	// when
 	offset := 0
 	limit := 1
-	cl, _, err := repo.List(context.Background(), parentID, &offset, &limit)
-	if err != nil {
-		t.Error("Failed to List", err.Error())
-	}
-
-	if len(cl) != 1 {
-		t.Error("List returned more then expected based on parentID")
-	}
-
-	c := cl[0]
-	if c.Body != body {
-		t.Error("List returned unexpected comment")
-	}
+	comments, _, err := repo.List(context.Background(), comment1.ParentID, &offset, &limit)
+	// then
+	require.Nil(test.T(), err)
+	require.Equal(test.T(), 1, len(comments))
+	assert.Equal(test.T(), comment1.Body, comments[0].Body)
 }
 
 func (test *TestCommentRepository) TestListCommentsWrongOffset() {
-	t := test.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	repo := comment.NewCommentRepository(test.DB)
-
-	parentID := "A"
-	body := "Test A"
-
-	cs := []*comment.Comment{
-		&comment.Comment{
-			ParentID:  parentID,
-			Body:      body,
-			CreatedBy: uuid.NewV4(),
-		},
-		&comment.Comment{
-			ParentID:  "B",
-			Body:      "Test B",
-			CreatedBy: uuid.NewV4(),
-		},
-	}
-
-	for _, c := range cs {
-		repo.Create(context.Background(), c)
-	}
-
+	comment1 := newComment("A", "Test A", rendering.SystemMarkupMarkdown)
+	comment2 := newComment("B", "Test B", rendering.SystemMarkupMarkdown)
+	comments := []*comment.Comment{comment1, comment2}
+	test.createComments(comments)
+	// when
 	offset := -1
 	limit := 1
-	_, _, err := repo.List(context.Background(), parentID, &offset, &limit)
-	if err == nil {
-		t.Error("Expected an error to List")
-	}
-
+	_, _, err := repo.List(context.Background(), comment1.ParentID, &offset, &limit)
+	// then
+	assert.NotNil(test.T(), err)
 }
 
 func (test *TestCommentRepository) TestListCommentsWrongLimit() {
-	t := test.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	repo := comment.NewCommentRepository(test.DB)
-
-	parentID := "A"
-	body := "Test A"
-
-	cs := []*comment.Comment{
-		&comment.Comment{
-			ParentID:  parentID,
-			Body:      body,
-			CreatedBy: uuid.NewV4(),
-		},
-		&comment.Comment{
-			ParentID:  "B",
-			Body:      "Test B",
-			CreatedBy: uuid.NewV4(),
-		},
-	}
-
-	for _, c := range cs {
-		repo.Create(context.Background(), c)
-	}
-
+	comment1 := newComment("A", "Test A", rendering.SystemMarkupMarkdown)
+	comment2 := newComment("B", "Test B", rendering.SystemMarkupMarkdown)
+	comments := []*comment.Comment{comment1, comment2}
+	test.createComments(comments)
+	// when
 	offset := 0
 	limit := -1
-	_, _, err := repo.List(context.Background(), parentID, &offset, &limit)
-	if err == nil {
-		t.Error("Expected an error to List")
-	}
-
+	_, _, err := repo.List(context.Background(), comment1.ParentID, &offset, &limit)
+	// then
+	assert.NotNil(test.T(), err)
 }
 
 func (test *TestCommentRepository) TestLoadComment() {
-	t := test.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	repo := comment.NewCommentRepository(test.DB)
-
-	c := &comment.Comment{
-		ParentID:  "A",
-		Body:      "Test A",
-		CreatedBy: uuid.NewV4(),
-	}
-
-	repo.Create(context.Background(), c)
-
-	l, err := repo.Load(context.Background(), c.ID)
-	if err != nil {
-		t.Error("Error loading comment")
-	}
-	if l.ID != c.ID {
-		t.Errorf("Loaded comment was not same as requested")
-	}
-	if l.Body != c.Body {
-		t.Error("Loaded comment has different body")
-	}
+	comment := newComment("A", "Test A", rendering.SystemMarkupMarkdown)
+	test.createComment(comment)
+	// when
+	loadedComment, err := repo.Load(context.Background(), comment.ID)
+	require.Nil(test.T(), err)
+	assert.Equal(test.T(), comment.ID, loadedComment.ID)
+	assert.Equal(test.T(), comment.Body, loadedComment.Body)
 }

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -148,6 +148,9 @@ func getMigrations() migrations {
 	// Version 23
 	m = append(m, steps{executeSQLFile("023-comment-markup.sql")})
 
+	// Version 23
+	m = append(m, steps{executeSQLFile("024-comment-markup-default.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -148,7 +148,7 @@ func getMigrations() migrations {
 	// Version 23
 	m = append(m, steps{executeSQLFile("023-comment-markup.sql")})
 
-	// Version 23
+	// Version 24
 	m = append(m, steps{executeSQLFile("024-comment-markup-default.sql")})
 
 	// Version N

--- a/migration/sql-files/024-comment-markup-default.sql
+++ b/migration/sql-files/024-comment-markup-default.sql
@@ -1,0 +1,2 @@
+-- add a 'markup' column in the 'comments' table
+update comments set markup = 'PlainText' where markup = NULL; 


### PR DESCRIPTION
Forcing the markup value to 'PlainText' (the default value) when
creating or updating a comment.
Setting this value in the existing DB records

Refactoring the `comment/comment_test.go` test to make them more
compact yet more readable (IMO)

Fixes #741 
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
