### PR TITLE
Return the HTML rendering of comments #744

### DIFF
--- a/comments.go
+++ b/comments.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"html"
+
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/comment"
@@ -112,13 +114,15 @@ func ConvertCommentResourceID(request *goa.RequestData, comment *comment.Comment
 func ConvertComment(request *goa.RequestData, comment *comment.Comment, additional ...CommentConvertFunc) *app.Comment {
 	selfURL := rest.AbsoluteURL(request, app.CommentsHref(comment.ID))
 	markup := rendering.NilSafeGetMarkup(&comment.Markup)
+	bodyRendered := rendering.RenderMarkupToHTML(html.EscapeString(comment.Body), comment.Markup)
 	c := &app.Comment{
 		Type: "comments",
 		ID:   &comment.ID,
 		Attributes: &app.CommentAttributes{
-			Body:      &comment.Body,
-			Markup:    &markup,
-			CreatedAt: &comment.CreatedAt,
+			Body:         &comment.Body,
+			BodyRendered: &bodyRendered,
+			Markup:       &markup,
+			CreatedAt:    &comment.CreatedAt,
 		},
 		Relationships: &app.CommentRelations{
 			CreatedBy: &app.CommentCreatedBy{

--- a/comments_blackbox_test.go
+++ b/comments_blackbox_test.go
@@ -2,6 +2,7 @@ package main_test
 
 import (
 	"fmt"
+	"html"
 	"testing"
 
 	. "github.com/almighty/almighty-core"
@@ -93,7 +94,7 @@ func (s *CommentsSuite) createWorkItem(identity account.Identity) string {
 	return workitemId
 }
 
-func newCreateWorkItemCommentsPayload(body string, markup *string) *app.CreateWorkItemCommentsPayload {
+func (s *CommentsSuite) newCreateWorkItemCommentsPayload(body string, markup *string) *app.CreateWorkItemCommentsPayload {
 	return &app.CreateWorkItemCommentsPayload{
 		Data: &app.CreateComment{
 			Type: "comments",
@@ -105,7 +106,7 @@ func newCreateWorkItemCommentsPayload(body string, markup *string) *app.CreateWo
 	}
 }
 
-func newUpdateCommentsPayload(body string, markup *string) *app.UpdateCommentsPayload {
+func (s *CommentsSuite) newUpdateCommentsPayload(body string, markup *string) *app.UpdateCommentsPayload {
 	return &app.UpdateCommentsPayload{
 		Data: &app.Comment{
 			Type: "comments",
@@ -119,7 +120,7 @@ func newUpdateCommentsPayload(body string, markup *string) *app.UpdateCommentsPa
 
 // createWorkItemComment creates a workitem comment that will be used to perform the comment operations during the tests.
 func (s *CommentsSuite) createWorkItemComment(identity account.Identity, workitemId string, body string, markup *string) uuid.UUID {
-	createWorkItemCommentPayload := newCreateWorkItemCommentsPayload(body, markup)
+	createWorkItemCommentPayload := s.newCreateWorkItemCommentsPayload(body, markup)
 	userSvc, _, workitemCommentsCtrl, _ := s.securedControllers(identity)
 	_, comment := test.CreateWorkItemCommentsOK(s.T(), userSvc.Context, userSvc, workitemCommentsCtrl, workitemId, createWorkItemCommentPayload)
 	commentId := *comment.Data.ID
@@ -127,21 +128,22 @@ func (s *CommentsSuite) createWorkItemComment(identity account.Identity, workite
 	return commentId
 }
 
-func validateComment(t *testing.T, result *app.CommentSingle, expectedBody string, expectedMarkup string) {
-	require.NotNil(t, result)
-	require.NotNil(t, result.Data)
-	assert.NotNil(t, result.Data.ID)
-	assert.NotNil(t, result.Data.Type)
-	require.NotNil(t, result.Data.Attributes)
-	require.NotNil(t, result.Data.Attributes.Body)
-	assert.Equal(t, expectedBody, *result.Data.Attributes.Body)
-	require.NotNil(t, result.Data.Attributes.Markup)
-	assert.Equal(t, expectedMarkup, *result.Data.Attributes.Markup)
-	require.NotNil(t, result.Data.Relationships)
-	require.NotNil(t, result.Data.Relationships.CreatedBy)
-	require.NotNil(t, result.Data.Relationships.CreatedBy.Data)
-	require.NotNil(t, result.Data.Relationships.CreatedBy.Data.ID)
-	assert.Equal(t, testsupport.TestIdentity.ID, *result.Data.Relationships.CreatedBy.Data.ID)
+func (s *CommentsSuite) validateComment(result *app.CommentSingle, expectedBody string, expectedMarkup string) {
+	require.NotNil(s.T(), result)
+	require.NotNil(s.T(), result.Data)
+	assert.NotNil(s.T(), result.Data.ID)
+	assert.NotNil(s.T(), result.Data.Type)
+	require.NotNil(s.T(), result.Data.Attributes)
+	require.NotNil(s.T(), result.Data.Attributes.Body)
+	assert.Equal(s.T(), expectedBody, *result.Data.Attributes.Body)
+	require.NotNil(s.T(), result.Data.Attributes.Markup)
+	assert.Equal(s.T(), expectedMarkup, *result.Data.Attributes.Markup)
+	assert.Equal(s.T(), rendering.RenderMarkupToHTML(html.EscapeString(expectedBody), expectedMarkup), *result.Data.Attributes.BodyRendered)
+	require.NotNil(s.T(), result.Data.Relationships)
+	require.NotNil(s.T(), result.Data.Relationships.CreatedBy)
+	require.NotNil(s.T(), result.Data.Relationships.CreatedBy.Data)
+	require.NotNil(s.T(), result.Data.Relationships.CreatedBy.Data.ID)
+	assert.Equal(s.T(), testsupport.TestIdentity.ID, *result.Data.Relationships.CreatedBy.Data.ID)
 }
 
 func (s *CommentsSuite) TestShowCommentWithoutAuth() {
@@ -152,7 +154,7 @@ func (s *CommentsSuite) TestShowCommentWithoutAuth() {
 	userSvc, commentsCtrl := s.unsecuredController()
 	_, result := test.ShowCommentsOK(s.T(), userSvc.Context, userSvc, commentsCtrl, commentId)
 	// then
-	validateComment(s.T(), result, "body", rendering.SystemMarkupMarkdown)
+	s.validateComment(result, "body", rendering.SystemMarkupMarkdown)
 }
 
 func (s *CommentsSuite) TestShowCommentWithoutAuthWithMarkup() {
@@ -163,7 +165,7 @@ func (s *CommentsSuite) TestShowCommentWithoutAuthWithMarkup() {
 	userSvc, commentsCtrl := s.unsecuredController()
 	_, result := test.ShowCommentsOK(s.T(), userSvc.Context, userSvc, commentsCtrl, commentId)
 	// then
-	validateComment(s.T(), result, "body", rendering.SystemMarkupPlainText)
+	s.validateComment(result, "body", rendering.SystemMarkupPlainText)
 }
 
 func (s *CommentsSuite) TestShowCommentWithAuth() {
@@ -174,7 +176,18 @@ func (s *CommentsSuite) TestShowCommentWithAuth() {
 	userSvc, _, _, commentsCtrl := s.securedControllers(testsupport.TestIdentity)
 	_, result := test.ShowCommentsOK(s.T(), userSvc.Context, userSvc, commentsCtrl, commentId)
 	// then
-	validateComment(s.T(), result, "body", rendering.SystemMarkupPlainText)
+	s.validateComment(result, "body", rendering.SystemMarkupPlainText)
+}
+
+func (s *CommentsSuite) TestShowCommentWithEscapedScriptInjection() {
+	// given
+	workitemId := s.createWorkItem(testsupport.TestIdentity)
+	commentId := s.createWorkItemComment(testsupport.TestIdentity, workitemId, "<img src=x onerror=alert('body') />", &plaintextMarkup)
+	// when
+	userSvc, _, _, commentsCtrl := s.securedControllers(testsupport.TestIdentity)
+	_, result := test.ShowCommentsOK(s.T(), userSvc.Context, userSvc, commentsCtrl, commentId)
+	// then
+	s.validateComment(result, "<img src=x onerror=alert('body') />", rendering.SystemMarkupPlainText)
 }
 
 func (s *CommentsSuite) TestUpdateCommentWithoutAuth() {
@@ -182,7 +195,7 @@ func (s *CommentsSuite) TestUpdateCommentWithoutAuth() {
 	workitemId := s.createWorkItem(testsupport.TestIdentity)
 	commentId := s.createWorkItemComment(testsupport.TestIdentity, workitemId, "body", &plaintextMarkup)
 	// when
-	updateCommentPayload := newUpdateCommentsPayload("updated body", &markdownMarkup)
+	updateCommentPayload := s.newUpdateCommentsPayload("updated body", &markdownMarkup)
 	userSvc, commentsCtrl := s.unsecuredController()
 	test.UpdateCommentsUnauthorized(s.T(), userSvc.Context, userSvc, commentsCtrl, commentId, updateCommentPayload)
 }
@@ -192,10 +205,10 @@ func (s *CommentsSuite) TestUpdateCommentWithSameUserWithOtherMarkup() {
 	workitemId := s.createWorkItem(testsupport.TestIdentity)
 	commentId := s.createWorkItemComment(testsupport.TestIdentity, workitemId, "body", &plaintextMarkup)
 	// when
-	updateCommentPayload := newUpdateCommentsPayload("updated body", &markdownMarkup)
+	updateCommentPayload := s.newUpdateCommentsPayload("updated body", &markdownMarkup)
 	userSvc, _, _, commentsCtrl := s.securedControllers(testsupport.TestIdentity)
 	_, result := test.UpdateCommentsOK(s.T(), userSvc.Context, userSvc, commentsCtrl, commentId, updateCommentPayload)
-	validateComment(s.T(), result, "updated body", rendering.SystemMarkupMarkdown)
+	s.validateComment(result, "updated body", rendering.SystemMarkupMarkdown)
 }
 
 func (s *CommentsSuite) TestUpdateCommentWithSameUserWithNilMarkup() {
@@ -203,10 +216,10 @@ func (s *CommentsSuite) TestUpdateCommentWithSameUserWithNilMarkup() {
 	workitemId := s.createWorkItem(testsupport.TestIdentity)
 	commentId := s.createWorkItemComment(testsupport.TestIdentity, workitemId, "body", &plaintextMarkup)
 	// when
-	updateCommentPayload := newUpdateCommentsPayload("updated body", nil)
+	updateCommentPayload := s.newUpdateCommentsPayload("updated body", nil)
 	userSvc, _, _, commentsCtrl := s.securedControllers(testsupport.TestIdentity)
 	_, result := test.UpdateCommentsOK(s.T(), userSvc.Context, userSvc, commentsCtrl, commentId, updateCommentPayload)
-	validateComment(s.T(), result, "updated body", rendering.SystemMarkupDefault)
+	s.validateComment(result, "updated body", rendering.SystemMarkupDefault)
 }
 
 func (s *CommentsSuite) TestUpdateCommentWithOtherUser() {

--- a/design/comments.go
+++ b/design/comments.go
@@ -36,6 +36,9 @@ var commentAttributes = a.Type("CommentAttributes", func() {
 	a.Attribute("body", d.String, "The comment body", func() {
 		a.Example("This is really interesting")
 	})
+	a.Attribute("body.rendered", d.String, "The comment body rendered in HTML", func() {
+		a.Example("<p>This is really interesting</p>\n")
+	})
 	a.Attribute("markup", d.String, "The comment markup associated with the body", func() {
 		a.Example("Markdown")
 	})

--- a/work-item-comments_test.go
+++ b/work-item-comments_test.go
@@ -1,6 +1,7 @@
 package main_test
 
 import (
+	"html"
 	"testing"
 	"time"
 
@@ -39,6 +40,7 @@ func TestRunCommentREST(t *testing.T) {
 }
 
 func (rest *TestCommentREST) SetupTest() {
+	resource.Require(rest.T(), resource.Database)
 	rest.db = gormapplication.NewGormDB(rest.DB)
 	rest.clean = cleaner.DeleteCreatedEntities(rest.DB)
 }
@@ -60,151 +62,7 @@ func (rest *TestCommentREST) UnSecuredController() (*goa.Service, *WorkItemComme
 	return svc, NewWorkItemCommentsController(svc, rest.db)
 }
 
-func (rest *TestCommentREST) TestSuccessCreateSingleCommentWithMarkup() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-	wiid, err := createWorkItem(rest.db)
-	if err != nil {
-		t.Error(err)
-	}
-	markup := rendering.SystemMarkupMarkdown
-	p := createComment("Test", &markup)
-	svc, ctrl := rest.SecuredController()
-	_, c := test.CreateWorkItemCommentsOK(t, svc.Context, svc, ctrl, wiid, p)
-	assertComment(t, c.Data)
-}
-
-func (rest *TestCommentREST) TestSuccessCreateSingleCommentWithDefaultMarkup() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-	wiid, err := createWorkItem(rest.db)
-	if err != nil {
-		t.Error(err)
-	}
-	p := createComment("Test", nil)
-	svc, ctrl := rest.SecuredController()
-	_, c := test.CreateWorkItemCommentsOK(t, svc.Context, svc, ctrl, wiid, p)
-	assertComment(t, c.Data)
-}
-
-func (rest *TestCommentREST) TestListCommentsByParentWorkItem() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
-	wiid, err := createWorkItem(rest.db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	application.Transactional(rest.db, func(app application.Application) error {
-		repo := app.Comments()
-		repo.Create(context.Background(), &comment.Comment{ParentID: wiid, Body: "Test 1", CreatedBy: uuid.NewV4()})
-		repo.Create(context.Background(), &comment.Comment{ParentID: wiid, Body: "Test 2", CreatedBy: uuid.NewV4()})
-		repo.Create(context.Background(), &comment.Comment{ParentID: wiid, Body: "Test 3", CreatedBy: uuid.NewV4()})
-		repo.Create(context.Background(), &comment.Comment{ParentID: wiid + "_other", Body: "Test 1", CreatedBy: uuid.NewV4()})
-		return nil
-	})
-
-	svc, ctrl := rest.UnSecuredController()
-	offset := "0"
-	limit := 3
-	_, cs := test.ListWorkItemCommentsOK(t, svc.Context, svc, ctrl, wiid, &limit, &offset)
-	if len(cs.Data) != 3 {
-		t.Fatal("Listed comments of wrong length")
-	}
-	assertComment(t, cs.Data[0])
-
-	wiid2, err := createWorkItem(rest.db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, cs2 := test.ListWorkItemCommentsOK(t, svc.Context, svc, ctrl, wiid2, &limit, &offset)
-	if len(cs2.Data) != 0 {
-		t.Fatal("Listed comments of wrong length")
-	}
-}
-
-func (rest *TestCommentREST) TestEmptyListCommentsByParentWorkItem() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
-	wiid, err := createWorkItem(rest.db)
-	if err != nil {
-		t.Error(err)
-	}
-
-	svc, ctrl := rest.UnSecuredController()
-	offset := "0"
-	limit := 1
-	_, cs := test.ListWorkItemCommentsOK(t, svc.Context, svc, ctrl, wiid, &limit, &offset)
-	if len(cs.Data) != 0 {
-		t.Error("Listed comments of wrong length")
-	}
-}
-
-func (rest *TestCommentREST) TestCreateSingleCommentMissingWorkItem() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
-	p := createComment("Test", nil)
-
-	svc, ctrl := rest.SecuredController()
-	test.CreateWorkItemCommentsNotFound(t, svc.Context, svc, ctrl, "0000000", p)
-}
-
-func (rest *TestCommentREST) TestCreateSingleNoAuthorized() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
-	wiid, err := createWorkItem(rest.db)
-	if err != nil {
-		t.Error(err)
-	}
-
-	p := createComment("Test", nil)
-
-	svc, ctrl := rest.UnSecuredController()
-	test.CreateWorkItemCommentsUnauthorized(t, svc.Context, svc, ctrl, wiid, p)
-}
-
-// Can not be tested via normal Goa testing framework as setting empty body on CreateCommentAttributes is
-// validated before Request to service is made. Validate model and assume it will be validated before hitting
-// service when mounted. Test to show intent.
-func (rest *TestCommentREST) TestShouldNotCreateEmptyBody() {
-	t := rest.T()
-
-	p := createComment("", nil)
-	err := p.Validate()
-	if err == nil {
-		t.Error("Should not allow empty body", err)
-	}
-}
-
-func (rest *TestCommentREST) TestListCommentsByMissingParentWorkItem() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
-	svc, ctrl := rest.SecuredController()
-	offset := "0"
-	limit := 1
-	test.ListWorkItemCommentsNotFound(t, svc.Context, svc, ctrl, "0000000", &limit, &offset)
-}
-
-func assertComment(t *testing.T, c *app.Comment) {
-	assert.NotNil(t, c)
-	assert.Equal(t, "comments", c.Type)
-	assert.NotNil(t, c.ID)
-	assert.NotNil(t, c.Attributes.Body)
-	assert.NotNil(t, c.Attributes.Markup)
-	require.NotNil(t, c.Attributes.CreatedAt)
-	assert.WithinDuration(t, time.Now(), *c.Attributes.CreatedAt, 2*time.Second)
-	require.NotNil(t, c.Relationships)
-	require.NotNil(t, c.Relationships.CreatedBy)
-	require.NotNil(t, c.Relationships.CreatedBy.Data)
-	assert.Equal(t, "identities", c.Relationships.CreatedBy.Data.Type)
-	assert.NotNil(t, c.Relationships.CreatedBy.Data.ID)
-}
-
-func createComment(body string, markup *string) *app.CreateWorkItemCommentsPayload {
+func (rest *TestCommentREST) newCreateWorkItemCommentsPayload(body string, markup *string) *app.CreateWorkItemCommentsPayload {
 	return &app.CreateWorkItemCommentsPayload{
 		Data: &app.CreateComment{
 			Type: "comments",
@@ -216,9 +74,9 @@ func createComment(body string, markup *string) *app.CreateWorkItemCommentsPaylo
 	}
 }
 
-func createWorkItem(db *gormapplication.GormDB) (string, error) {
+func (rest *TestCommentREST) createDefaultWorkItem() string {
 	var wiid string
-	err := application.Transactional(db, func(appl application.Application) error {
+	err := application.Transactional(rest.db, func(appl application.Application) error {
 		repo := appl.WorkItems()
 		wi, err := repo.Create(
 			context.Background(),
@@ -234,8 +92,123 @@ func createWorkItem(db *gormapplication.GormDB) (string, error) {
 		wiid = wi.ID
 		return nil
 	})
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-	return wiid, nil
+	require.Nil(rest.T(), err)
+	return wiid
+}
+
+func (rest *TestCommentREST) assertComment(c *app.Comment, expectedBody string, expectedMarkup string) {
+	assert.NotNil(rest.T(), c)
+	assert.Equal(rest.T(), "comments", c.Type)
+	assert.NotNil(rest.T(), c.ID)
+	require.NotNil(rest.T(), c.Attributes)
+	assert.Equal(rest.T(), expectedBody, *c.Attributes.Body)
+	assert.Equal(rest.T(), expectedMarkup, *c.Attributes.Markup)
+	assert.Equal(rest.T(), rendering.RenderMarkupToHTML(html.EscapeString(expectedBody), expectedMarkup), *c.Attributes.BodyRendered)
+	require.NotNil(rest.T(), c.Attributes.CreatedAt)
+	assert.WithinDuration(rest.T(), time.Now(), *c.Attributes.CreatedAt, 2*time.Second)
+	require.NotNil(rest.T(), c.Relationships)
+	require.NotNil(rest.T(), c.Relationships.CreatedBy)
+	require.NotNil(rest.T(), c.Relationships.CreatedBy.Data)
+	assert.Equal(rest.T(), "identities", c.Relationships.CreatedBy.Data.Type)
+	assert.NotNil(rest.T(), c.Relationships.CreatedBy.Data.ID)
+}
+
+func (rest *TestCommentREST) TestSuccessCreateSingleCommentWithMarkup() {
+	// given
+	wiid := rest.createDefaultWorkItem()
+	// when
+	markup := rendering.SystemMarkupMarkdown
+	p := rest.newCreateWorkItemCommentsPayload("Test", &markup)
+	svc, ctrl := rest.SecuredController()
+	_, c := test.CreateWorkItemCommentsOK(rest.T(), svc.Context, svc, ctrl, wiid, p)
+	// then
+	rest.assertComment(c.Data, "Test", markup)
+}
+
+func (rest *TestCommentREST) TestSuccessCreateSingleCommentWithDefaultMarkup() {
+	// given
+	wiid := rest.createDefaultWorkItem()
+	// when
+	p := rest.newCreateWorkItemCommentsPayload("Test", nil)
+	svc, ctrl := rest.SecuredController()
+	_, c := test.CreateWorkItemCommentsOK(rest.T(), svc.Context, svc, ctrl, wiid, p)
+	// then
+	rest.assertComment(c.Data, "Test", rendering.SystemMarkupDefault)
+}
+
+func (rest *TestCommentREST) TestListCommentsByParentWorkItem() {
+	// given
+	wiid := rest.createDefaultWorkItem()
+	application.Transactional(rest.db, func(app application.Application) error {
+		repo := app.Comments()
+		repo.Create(context.Background(), &comment.Comment{ParentID: wiid, Body: "Test 1", CreatedBy: uuid.NewV4()})
+		repo.Create(context.Background(), &comment.Comment{ParentID: wiid, Body: "Test 2", CreatedBy: uuid.NewV4()})
+		repo.Create(context.Background(), &comment.Comment{ParentID: wiid, Body: "Test 3", CreatedBy: uuid.NewV4()})
+		repo.Create(context.Background(), &comment.Comment{ParentID: wiid + "_other", Body: "Test 1", CreatedBy: uuid.NewV4()})
+		return nil
+	})
+	// when
+	svc, ctrl := rest.UnSecuredController()
+	offset := "0"
+	limit := 3
+	_, cs := test.ListWorkItemCommentsOK(rest.T(), svc.Context, svc, ctrl, wiid, &limit, &offset)
+	// then
+	require.Equal(rest.T(), 3, len(cs.Data))
+	rest.assertComment(cs.Data[0], "Test 3", rendering.SystemMarkupDefault) // items are returned in reverse order or creation
+	// given
+	wiid2 := rest.createDefaultWorkItem()
+	// when
+	_, cs2 := test.ListWorkItemCommentsOK(rest.T(), svc.Context, svc, ctrl, wiid2, &limit, &offset)
+	// then
+	assert.Equal(rest.T(), 0, len(cs2.Data))
+}
+
+func (rest *TestCommentREST) TestEmptyListCommentsByParentWorkItem() {
+	// given
+	wiid := rest.createDefaultWorkItem()
+	// when
+	svc, ctrl := rest.UnSecuredController()
+	offset := "0"
+	limit := 1
+	_, cs := test.ListWorkItemCommentsOK(rest.T(), svc.Context, svc, ctrl, wiid, &limit, &offset)
+	// then
+	assert.Equal(rest.T(), 0, len(cs.Data))
+}
+
+func (rest *TestCommentREST) TestCreateSingleCommentMissingWorkItem() {
+	// given
+	p := rest.newCreateWorkItemCommentsPayload("Test", nil)
+	// when/then
+	svc, ctrl := rest.SecuredController()
+	test.CreateWorkItemCommentsNotFound(rest.T(), svc.Context, svc, ctrl, "0000000", p)
+}
+
+func (rest *TestCommentREST) TestCreateSingleNoAuthorized() {
+	// given
+	wiid := rest.createDefaultWorkItem()
+	// when/then
+	p := rest.newCreateWorkItemCommentsPayload("Test", nil)
+	svc, ctrl := rest.UnSecuredController()
+	test.CreateWorkItemCommentsUnauthorized(rest.T(), svc.Context, svc, ctrl, wiid, p)
+}
+
+// Can not be tested via normal Goa testing framework as setting empty body on CreateCommentAttributes is
+// validated before Request to service is made. Validate model and assume it will be validated before hitting
+// service when mounted. Test to show intent.
+func (rest *TestCommentREST) TestShouldNotCreateEmptyBody() {
+	// given
+	p := rest.newCreateWorkItemCommentsPayload("", nil)
+	// when
+	err := p.Validate()
+	// then
+	require.NotNil(rest.T(), err)
+}
+
+func (rest *TestCommentREST) TestListCommentsByMissingParentWorkItem() {
+	// given
+	svc, ctrl := rest.SecuredController()
+	// when/then
+	offset := "0"
+	limit := 1
+	test.ListWorkItemCommentsNotFound(rest.T(), svc.Context, svc, ctrl, "0000000", &limit, &offset)
 }


### PR DESCRIPTION
Added an extra field in the comment response to hold
the HTML rendered value based on the `body` and `markup`
of the comment.
Also, the generated HTML is escaped, preventing script
injection.

Refactored significantly the `work-item-comments_test.go`
file to make it more readable. Using methods instead of pure
functions allows for the same names in different TestSuite
in the same package.

Fixes #744
Fixes #724

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

