### PR TITLE
Require simplified golang code on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ help:/
 .PHONY: check-go-format
 ## Exists with an error if there are files whose formatting differs from gofmt's
 check-go-format: prebuild-check
-	@gofmt -l ${SOURCES} 2>&1 \
+	@gofmt -s -l ${SOURCES} 2>&1 \
 		| tee /tmp/gofmt-errors \
 		| read \
 	&& echo "ERROR: These files differ from gofmt's style (run 'make format-go-code' to fix this):" \
@@ -98,7 +98,7 @@ check-go-format: prebuild-check
 .PHONY: format-go-code
 ## Formats any go file that differs from gofmt's style
 format-go-code: prebuild-check
-	@gofmt -l -w ${SOURCES}
+	@gofmt -s -l -w ${SOURCES}
 
 .PHONY: build
 ## Build server and client.

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -369,20 +369,20 @@ func createOrUpdateSystemPlannerItemType(ctx context.Context, witr *workitem.Gor
 	stString := "string"
 	stUser := "user"
 	workItemTypeFields := map[string]app.FieldDefinition{
-		workitem.SystemTitle:        app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: true},
-		workitem.SystemDescription:  app.FieldDefinition{Type: &app.FieldType{Kind: "markup"}, Required: false},
-		workitem.SystemCreator:      app.FieldDefinition{Type: &app.FieldType{Kind: "user"}, Required: true},
-		workitem.SystemRemoteItemID: app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: false},
-		workitem.SystemCreatedAt:    app.FieldDefinition{Type: &app.FieldType{Kind: "instant"}, Required: false},
-		workitem.SystemIteration:    app.FieldDefinition{Type: &app.FieldType{Kind: "iteration"}, Required: false},
-		workitem.SystemAssignees: app.FieldDefinition{
+		workitem.SystemTitle:        {Type: &app.FieldType{Kind: "string"}, Required: true},
+		workitem.SystemDescription:  {Type: &app.FieldType{Kind: "markup"}, Required: false},
+		workitem.SystemCreator:      {Type: &app.FieldType{Kind: "user"}, Required: true},
+		workitem.SystemRemoteItemID: {Type: &app.FieldType{Kind: "string"}, Required: false},
+		workitem.SystemCreatedAt:    {Type: &app.FieldType{Kind: "instant"}, Required: false},
+		workitem.SystemIteration:    {Type: &app.FieldType{Kind: "iteration"}, Required: false},
+		workitem.SystemAssignees: {
 			Type: &app.FieldType{
 				ComponentType: &stUser,
 				Kind:          "list",
 			},
 			Required: false,
 		},
-		workitem.SystemState: app.FieldDefinition{
+		workitem.SystemState: {
 			Type: &app.FieldType{
 				BaseType: &stString,
 				Kind:     "enum",

--- a/remoteworkitem/remoteworkitem.go
+++ b/remoteworkitem/remoteworkitem.go
@@ -35,7 +35,7 @@ const (
 
 // WorkItemKeyMaps relate remote attribute keys to internal representation
 var WorkItemKeyMaps = map[string]WorkItemMap{
-	ProviderGithub: WorkItemMap{
+	ProviderGithub: {
 		AttributeMapper{AttributeExpression(GithubTitle), StringConverter{}}:                                             workitem.SystemTitle,
 		AttributeMapper{AttributeExpression(GithubDescription), MarkupConverter{markup: rendering.SystemMarkupMarkdown}}: workitem.SystemDescription,
 		AttributeMapper{AttributeExpression(GithubState), GithubStateConverter{}}:                                        workitem.SystemState,
@@ -43,7 +43,7 @@ var WorkItemKeyMaps = map[string]WorkItemMap{
 		AttributeMapper{AttributeExpression(GithubCreator), StringConverter{}}:                                           workitem.SystemCreator,
 		AttributeMapper{AttributeExpression(GithubAssignee), ListStringConverter{}}:                                      workitem.SystemAssignees,
 	},
-	ProviderJira: WorkItemMap{
+	ProviderJira: {
 		AttributeMapper{AttributeExpression(JiraTitle), StringConverter{}}:                                      workitem.SystemTitle,
 		AttributeMapper{AttributeExpression(JiraBody), StringConverter{}}:                                       workitem.SystemDescription,
 		AttributeMapper{AttributeExpression(JiraBody), MarkupConverter{markup: rendering.SystemMarkupJiraWiki}}: workitem.SystemDescription,

--- a/search/search_repository_whitebox_test.go
+++ b/search/search_repository_whitebox_test.go
@@ -335,13 +335,13 @@ type searchTestData struct {
 func TestParseSearchStringURL(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
-	inputSet := []searchTestData{searchTestData{
+	inputSet := []searchTestData{{
 		query: "http://demo.almighty.io/work-item/list/detail/100",
 		expected: searchKeyword{
 			id:    nil,
 			words: []string{"(100:* | demo.almighty.io/work-item/list/detail/100:*)"},
 		},
-	}, searchTestData{
+	}, {
 		query: "http://demo.almighty.io/work-item/board/detail/100",
 		expected: searchKeyword{
 			id:    nil,
@@ -358,13 +358,13 @@ func TestParseSearchStringURL(t *testing.T) {
 func TestParseSearchStringURLWithouID(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
-	inputSet := []searchTestData{searchTestData{
+	inputSet := []searchTestData{{
 		query: "http://demo.almighty.io/work-item/list/detail/",
 		expected: searchKeyword{
 			id:    nil,
 			words: []string{"demo.almighty.io/work-item/list/detail:*"},
 		},
-	}, searchTestData{
+	}, {
 		query: "http://demo.almighty.io/work-item/board/detail/",
 		expected: searchKeyword{
 			id:    nil,

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -26,7 +26,7 @@ func TestGenerateToken(t *testing.T) {
 		ID:       uuid.NewV4(),
 		FullName: fullName,
 		ImageURL: "http://some.com/image",
-		Emails:   []account.User{account.User{Email: "mr@test.com"}},
+		Emails:   []account.User{{Email: "mr@test.com"}},
 	})
 
 	ident, err := manager.Extract(tokenString)

--- a/workitem/workitemtype_blackbox_test.go
+++ b/workitem/workitemtype_blackbox_test.go
@@ -142,7 +142,7 @@ func TestWorkItemType_Equal(t *testing.T) {
 	i := workitem.WorkItemType{
 		Name: "foo",
 		Fields: map[string]workitem.FieldDefinition{
-			"aListType": workitem.FieldDefinition{
+			"aListType": {
 				Type: workitem.EnumType{
 					SimpleType: workitem.SimpleType{Kind: workitem.KindEnum},
 					Values:     []interface{}{"open", "done", "closed"},

--- a/workitem/workitemtype_repository_blackbox_test.go
+++ b/workitem/workitemtype_repository_blackbox_test.go
@@ -47,7 +47,7 @@ func (s *workItemTypeRepoBlackBoxTest) TearDownTest() {
 func (s *workItemTypeRepoBlackBoxTest) TestCreateLoadWIT() {
 
 	wit, err := s.repo.Create(context.Background(), nil, "foo_bar", map[string]app.FieldDefinition{
-		"foo": app.FieldDefinition{
+		"foo": {
 			Required: true,
 			Type:     &app.FieldType{Kind: string(workitem.KindFloat)},
 		},
@@ -74,7 +74,7 @@ func (s *workItemTypeRepoBlackBoxTest) TestCreateLoadWIT() {
 func (s *workItemTypeRepoBlackBoxTest) TestCreateLoadWITWithList() {
 	bt := "string"
 	wit, err := s.repo.Create(context.Background(), nil, "foo_bar", map[string]app.FieldDefinition{
-		"foo": app.FieldDefinition{
+		"foo": {
 			Required: true,
 			Type: &app.FieldType{
 				ComponentType: &bt,
@@ -104,7 +104,7 @@ func (s *workItemTypeRepoBlackBoxTest) TestCreateWITWithBaseType() {
 	bt := "string"
 	basetype := "foo.bar"
 	baseWit, err := s.repo.Create(context.Background(), nil, basetype, map[string]app.FieldDefinition{
-		"foo": app.FieldDefinition{
+		"foo": {
 			Required: true,
 			Type: &app.FieldType{
 				ComponentType: &bt,

--- a/workitem/workitemtype_repository_whitebox_test.go
+++ b/workitem/workitemtype_repository_whitebox_test.go
@@ -42,7 +42,7 @@ func TestConvertTypeFromModels(t *testing.T) {
 		Version: 42,
 		Path:    "something",
 		Fields: map[string]FieldDefinition{
-			"aListType": FieldDefinition{
+			"aListType": {
 				Type: EnumType{
 					BaseType:   SimpleType{KindString},
 					SimpleType: SimpleType{KindEnum},
@@ -72,7 +72,7 @@ func TestConvertTypeFromModels(t *testing.T) {
 		Name:    "foo",
 		Version: 42,
 		Fields: map[string]*app.FieldDefinition{
-			"aListType": &app.FieldDefinition{
+			"aListType": {
 				Required: true,
 				Type: &app.FieldType{
 					BaseType: &stString,
@@ -141,11 +141,11 @@ func TestTempConvertFieldsToModels(t *testing.T) {
 	stString := "string"
 
 	newFields := map[string]app.FieldDefinition{
-		SystemTitle:        app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: true},
-		SystemDescription:  app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: false},
-		SystemCreator:      app.FieldDefinition{Type: &app.FieldType{Kind: "user"}, Required: true},
-		SystemRemoteItemID: app.FieldDefinition{Type: &app.FieldType{Kind: "string"}, Required: false},
-		SystemState: app.FieldDefinition{
+		SystemTitle:        {Type: &app.FieldType{Kind: "string"}, Required: true},
+		SystemDescription:  {Type: &app.FieldType{Kind: "string"}, Required: false},
+		SystemCreator:      {Type: &app.FieldType{Kind: "user"}, Required: true},
+		SystemRemoteItemID: {Type: &app.FieldType{Kind: "string"}, Required: false},
+		SystemState: {
 			Type: &app.FieldType{
 				BaseType: &stString,
 				Kind:     "enum",

--- a/workitem_blackbox_test.go
+++ b/workitem_blackbox_test.go
@@ -756,7 +756,7 @@ func (s *WorkItem2Suite) TestWI2UpdateMultipleScenarios() {
 	maliciousUUID := "non UUID string"
 	s.minimumPayload.Data.Relationships.Assignees = &app.RelationGenericList{
 		Data: []*app.GenericData{
-			&app.GenericData{
+			{
 				ID:   &maliciousUUID,
 				Type: &userType,
 			}},
@@ -765,7 +765,7 @@ func (s *WorkItem2Suite) TestWI2UpdateMultipleScenarios() {
 
 	s.minimumPayload.Data.Relationships.Assignees = &app.RelationGenericList{
 		Data: []*app.GenericData{
-			&app.GenericData{
+			{
 				ID:   &newUserUUID,
 				Type: &userType,
 			}},
@@ -1027,7 +1027,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWithAssigneeRelation() {
 		},
 		Assignees: &app.RelationGenericList{
 			Data: []*app.GenericData{
-				&app.GenericData{
+				{
 					Type: &userType,
 					ID:   &newUserId,
 				}},


### PR DESCRIPTION
To accomplish this, I've modified the `make format-go-code` target in order to to simplify the code.