### PR TITLE
Go code quality checks

### DIFF
--- a/.golint_exclude
+++ b/.golint_exclude
@@ -1,0 +1,5 @@
+bindata_assetfs.go
+sqlbindata
+/design/.*
+.*exported
+EOF

--- a/.make/Makefile.lnx
+++ b/.make/Makefile.lnx
@@ -12,8 +12,11 @@ GOCOVMERGE_BIN=$(VENDOR_DIR)/github.com/wadey/gocovmerge/gocovmerge
 DOCKER_BIN_NAME=docker
 DOCKER_COMPOSE_BIN_NAME=docker-compose
 
-GOLINT_BIN=$(VENDOR_DIR)/github.com/golang/lint/golint/golint
-GOCYCLO_BIN=$(VENDOR_DIR)/github.com/fzipp/gocyclo/gocyclo
+GOLINT_DIR=$(VENDOR_DIR)/github.com/golang/lint/golint
+GOLINT_BIN=$(GOLINT_DIR)/golint
+GOCYCLO_DIR=$(VENDOR_DIR)/github.com/fzipp/gocyclo
+GOCYCLO_BIN=$(GOCYCLO_DIR)/gocyclo
+
 
 GIT_BIN_NAME := git
 GLIDE_BIN_NAME := glide

--- a/.make/Makefile.lnx
+++ b/.make/Makefile.lnx
@@ -12,6 +12,10 @@ GOCOVMERGE_BIN=$(VENDOR_DIR)/github.com/wadey/gocovmerge/gocovmerge
 DOCKER_BIN_NAME=docker
 DOCKER_COMPOSE_BIN_NAME=docker-compose
 
+GOIMPORTS_BIN=$(VENDOR_DIR)/golang.org/x/tools/cmd/goimports/goimports
+GOLINT_BIN=$(VENDOR_DIR)/github.com/golang/lint/golint/golint
+GOCYCLO_BIN=$(VENDOR_DIR)/github.com/fzipp/gocyclo/gocyclo
+
 GIT_BIN_NAME := git
 GLIDE_BIN_NAME := glide
 GO_BIN_NAME := go

--- a/.make/Makefile.lnx
+++ b/.make/Makefile.lnx
@@ -12,7 +12,6 @@ GOCOVMERGE_BIN=$(VENDOR_DIR)/github.com/wadey/gocovmerge/gocovmerge
 DOCKER_BIN_NAME=docker
 DOCKER_COMPOSE_BIN_NAME=docker-compose
 
-GOIMPORTS_BIN=$(VENDOR_DIR)/golang.org/x/tools/cmd/goimports/goimports
 GOLINT_BIN=$(VENDOR_DIR)/github.com/golang/lint/golint/golint
 GOCYCLO_BIN=$(VENDOR_DIR)/github.com/fzipp/gocyclo/gocyclo
 

--- a/.make/Makefile.win
+++ b/.make/Makefile.win
@@ -12,6 +12,11 @@ GOCOVMERGE_BIN=$(VENDOR_DIR)/github.com/wadey/gocovmerge/gocovmerge.exe
 DOCKER_BIN_NAME=docker.exe
 DOCKER_COMPOSE_BIN_NAME=docker-compose.exe
 
+GOLINT_DIR=$(VENDOR_DIR)/github.com/golang/lint/golint
+GOLINT_BIN=$(GOLINT_DIR)/golint.exe
+GOCYCLO_DIR=$(VENDOR_DIR)/github.com/fzipp/gocyclo
+GOCYCLO_BIN=$(GOCYCLO_DIR)/gocyclo.exe
+
 GIT_BIN_NAME := git.exe
 GLIDE_BIN_NAME := glide.exe
 GO_BIN_NAME := go.exe

--- a/.make/docker.mk
+++ b/.make/docker.mk
@@ -120,10 +120,3 @@ ifeq ($(strip $(shell docker ps -qa --filter "name=$(DOCKER_CONTAINER_NAME)" 2>/
 	$(error No container name "$(DOCKER_CONTAINER_NAME)" exists to run the command "make $(makecommand)")
 endif
 	docker exec -t $(DOCKER_RUN_INTERACTIVE_SWITCH) "$(DOCKER_CONTAINER_NAME)" bash -ec 'make $(makecommand)'
-
-## Runs "make golint" inside the already started docker check container (see "make docker-start").
-docker-golint:
-ifeq ($(strip $(shell docker ps -qa --filter "name=$(DOCKER_CONTAINER_NAME)" 2>/dev/null)),)
-	$(error No container name "$(DOCKER_CONTAINER_NAME)" exists to run the check. Try running "make docker-start && make docker-deps && make docker-generate && make docker-check")
-endif
-	docker exec -t $(DOCKER_RUN_INTERACTIVE_SWITCH) "$(DOCKER_CONTAINER_NAME)" make golint

--- a/.make/docker.mk
+++ b/.make/docker.mk
@@ -121,7 +121,6 @@ ifeq ($(strip $(shell docker ps -qa --filter "name=$(DOCKER_CONTAINER_NAME)" 2>/
 endif
 	docker exec -t $(DOCKER_RUN_INTERACTIVE_SWITCH) "$(DOCKER_CONTAINER_NAME)" bash -ec 'make $(makecommand)'
 
-.PHONY: docker-golint
 ## Runs "make golint" inside the already started docker check container (see "make docker-start").
 docker-golint:
 ifeq ($(strip $(shell docker ps -qa --filter "name=$(DOCKER_CONTAINER_NAME)" 2>/dev/null)),)

--- a/.make/docker.mk
+++ b/.make/docker.mk
@@ -67,7 +67,7 @@ clean-docker-build-dir:
 ## After calling this command you can invoke all the make targets from the
 ## normal Makefile (e.g. deps, generate, build) inside the build container
 ## by prefixing them with "docker-". For example to execute "make deps"
-## inside the build container, just run "make docker-deps".  
+## inside the build container, just run "make docker-deps".
 ## To remove the container when no longer needed, call "make docker-rm".
 docker-start: docker-build-dir docker-image-builder
 ifneq ($(strip $(shell docker ps -qa --filter "name=$(DOCKER_CONTAINER_NAME)" 2>/dev/null)),)
@@ -113,10 +113,18 @@ endif
 # This is a wildcard target to let you call any make target from the normal makefile
 # but it will run inside the docker container. This target will only get executed if
 # there's no specialized form available. For example if you call "make docker-start"
-# not this target gets executed but the "docker-start" target. 
+# not this target gets executed but the "docker-start" target.
 docker-%:
 	$(eval makecommand:=$(subst docker-,,$@))
 ifeq ($(strip $(shell docker ps -qa --filter "name=$(DOCKER_CONTAINER_NAME)" 2>/dev/null)),)
 	$(error No container name "$(DOCKER_CONTAINER_NAME)" exists to run the command "make $(makecommand)")
 endif
 	docker exec -t $(DOCKER_RUN_INTERACTIVE_SWITCH) "$(DOCKER_CONTAINER_NAME)" bash -ec 'make $(makecommand)'
+
+.PHONY: docker-golint
+## Runs "make golint" inside the already started docker check container (see "make docker-start").
+docker-golint:
+ifeq ($(strip $(shell docker ps -qa --filter "name=$(DOCKER_CONTAINER_NAME)" 2>/dev/null)),)
+	$(error No container name "$(DOCKER_CONTAINER_NAME)" exists to run the check. Try running "make docker-start && make docker-deps && make docker-generate && make docker-check")
+endif
+	docker exec -t $(DOCKER_RUN_INTERACTIVE_SWITCH) "$(DOCKER_CONTAINER_NAME)" make golint

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -102,6 +102,10 @@ DOCKER_COMPOSE_FILE = $(CUR_DIR)/.make/docker-compose.integration-test.yaml
 # This pattern excludes some folders from the coverage calculation (see grep -v)
 ALL_PKGS_EXCLUDE_PATTERN = 'vendor\|app\|tool\/cli\|design\|client\|test'
 
+# This pattern excludes some folders from the go code analysis
+GOANALYSIS_PKGS_EXCLUDE_PATTERN="vendor|app|client|tool/cli"
+GOANALYSIS_DIRS=$(shell go list -f {{.Dir}} ./... | grep -v -E $(GOANALYSIS_PKGS_EXCLUDE_PATTERN))
+
 #-------------------------------------------------------------------------------
 # Normal test targets
 #
@@ -247,7 +251,7 @@ $(COV_PATH_OVERALL): $(GOCOVMERGE_BIN)
 # Console coverage output:
 
 # First parameter: file to do in-place replacement with.
-# Delete the lines containing /bindata_assetfs.go 
+# Delete the lines containing /bindata_assetfs.go
 define cleanup-coverage-file
 @sed -i '/.*\/bindata_assetfs\.go.*/d' $(1)
 @sed -i '/.*\/sqlbindata\.go.*/d' $(1)

--- a/Makefile
+++ b/Makefile
@@ -102,16 +102,13 @@ check-go-format: prebuild-check
  ## Run different static code analysis for go
 golint: clean-golint $(GOIMPORTS_BIN) $(GOLINT_BIN) $(GOCYCLO_BIN)
 	@echo "--- GoCYCLO CODE ANALYSIS ----" >> $(GOLINT_TMP_FILE);
-	@$(foreach d,$(CHECK_DIRS),$(GOCYCLO_BIN) -over 15 $d | grep -vEf .golint_exclude >> $(GOLINT_TMP_FILE);)
+	@$(foreach d,$(GOLINT_DIRS),$(GOCYCLO_BIN) -over 15 $d | grep -vEf .golint_exclude >> $(GOLINT_TMP_FILE);)
 
-	@echo "--- Go VET CODE ANALYSIS ----" >> $(CHECK_TMP_FILE);
-	@$(foreach d,$(CHECK_DIRS),go tool vet --all $d/*.go 2>&1 >> $(GOLINT_TMP_FILE);)
+	@echo "--- Go VET CODE ANALYSIS ----" >> $(GOLINT_TMP_FILE);
+	@$(foreach d,$(GOLINT_DIRS),go tool vet --all $d/*.go 2>&1 >> $(GOLINT_TMP_FILE);)
 
 	@echo "--- Go LINT CODE ANALYSIS ----" >> $(GOLINT_TMP_FILE);
-	@$(foreach d,$(CHECK_DIRS),$(GOLINT_BIN) $d 2>&1 | grep -vEf .golint_exclude >> $(GOLINT_TMP_FILE);)
-
-	@echo "--- Go IMPORTS CODE ANALYSIS ----" >> $(GOLINT_TMP_FILE);
-	@$(foreach d,$(CHECK_DIRS),$(GOIMPORTS_BIN) -l $d/*.go | grep -vEf .golint_exclude >> $(GOLINT_TMP_FILE);)
+	@$(foreach d,$(GOLINT_DIRS),$(GOLINT_BIN) $d 2>&1 | grep -vEf .golint_exclude >> $(GOLINT_TMP_FILE);)
 
 .PHONY: format-go-code
 ## Formats any go file that differs from gofmt's style
@@ -136,8 +133,7 @@ else
 	cd ${CLIENT_DIR}/ && go build -v -o ${BINARY_CLIENT_BIN}
 endif
 
-$(GOIMPORTS_BIN):
-	cd $(VENDOR_DIR)/golang.org/x/tools/cmd/goimports && go build -v
+# Build go tool to analysis the code
 $(GOLINT_BIN):
 	cd $(VENDOR_DIR)/github.com/golang/lint/golint && go build -v
 $(GOCYCLO_BIN):

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,6 @@ SOURCES := $(shell find $(SOURCE_DIR) -path $(SOURCE_DIR)/vendor -prune -o -name
 DESIGN_DIR=design
 DESIGNS := $(shell find $(SOURCE_DIR)/$(DESIGN_DIR) -path $(SOURCE_DIR)/vendor -prune -o -name '*.go' -print)
 
-GOLINT_DIRS=$(shell go list -f {{.Dir}} ./... | grep -v -E "vendor|app|client|tool/cli")
-
 # Find all required tools:
 GIT_BIN := $(shell command -v $(GIT_BIN_NAME) 2> /dev/null)
 GLIDE_BIN := $(shell command -v $(GLIDE_BIN_NAME) 2> /dev/null)
@@ -96,22 +94,25 @@ check-go-format: prebuild-check
 	&& exit 1 \
 	|| true
 
-.PHONY: golint
-.ONESHELL: golint
+.PHONY: analyze-go-code
+.ONESHELL: analyze-go-code
 ## Run a complete static code analysis using the following tools: golint, gocyclo and go-vet.
-golint: $(GOLINT_BIN) gocyclo govet
+analyze-go-code: golint gocyclo govet
+
+## Run gocyclo analysis over the code.
+golint: $(GOLINT_BIN)
 	$(info >>--- RESULTS: GOLINT CODE ANALYSIS ---<<)
-	@$(foreach d,$(GOLINT_DIRS),$(GOLINT_BIN) $d 2>&1 | grep -vEf .golint_exclude;)
+	@$(foreach d,$(GOANALYSIS_DIRS),$(GOLINT_BIN) $d 2>&1 | grep -vEf .golint_exclude;)
 
 ## Run gocyclo analysis over the code.
 gocyclo: $(GOCYCLO_BIN)
 	$(info >>--- RESULTS: GOCYCLO CODE ANALYSIS ---<<)
-	@$(foreach d,$(GOLINT_DIRS),$(GOCYCLO_BIN) -over 15 $d | grep -vEf .golint_exclude;)
+	@$(foreach d,$(GOANALYSIS_DIRS),$(GOCYCLO_BIN) -over 15 $d | grep -vEf .golint_exclude;)
 
 ## Run go vet analysis over the code.
 govet:
 	$(info >>--- RESULTS: GO VET CODE ANALYSIS ---<<)
-	@$(foreach d,$(GOLINT_DIRS),go tool vet --all $d/*.go 2>&1;)
+	@$(foreach d,$(GOANALYSIS_DIRS),go tool vet --all $d/*.go 2>&1;)
 
 .PHONY: format-go-code
 ## Formats any go file that differs from gofmt's style

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,6 @@ check-go-format: prebuild-check
 	|| true
 
 .PHONY: analyze-go-code
-.ONESHELL: analyze-go-code
 ## Run a complete static code analysis using the following tools: golint, gocyclo and go-vet.
 analyze-go-code: golint gocyclo govet
 

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -46,6 +46,7 @@ function prepare() {
   make docker-start
   make docker-check-go-format
   make docker-deps
+  make docker-golint
   make docker-generate
   make docker-build
   echo 'CICO: Preparation complete'
@@ -63,7 +64,7 @@ function run_tests_without_coverage() {
 function run_tests_with_coverage() {
   # Run the unit tests that generate coverage information
   make docker-test-unit
-  
+
   make integration-test-env-prepare
   trap cleanup_env EXIT
 
@@ -84,7 +85,7 @@ function run_tests_with_coverage() {
 function deploy() {
   # Let's deploy
   make docker-image-deploy
-  docker tag almighty-core-deploy registry.ci.centos.org:5000/almighty/almighty-core:latest 
+  docker tag almighty-core-deploy registry.ci.centos.org:5000/almighty/almighty-core:latest
   docker push registry.ci.centos.org:5000/almighty/almighty-core:latest
   echo 'CICO: Image pushed, ready to update deployed app'
 }

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -46,7 +46,7 @@ function prepare() {
   make docker-start
   make docker-check-go-format
   make docker-deps
-  make docker-golint
+  make docker-analyze-go-code
   make docker-generate
   make docker-build
   echo 'CICO: Preparation complete'

--- a/glide.lock
+++ b/glide.lock
@@ -184,6 +184,7 @@ imports:
   version: a888bfdffa4526cc6987572bca9a2c6b7758290f
   subpackages:
   - go/ast/astutil
+  - cmd/goimports
 - name: google.golang.org/appengine
   version: ca59ef35f409df61fa4a5f8290ff289b37eccfb8
   subpackages:
@@ -198,4 +199,10 @@ imports:
   version: 7664702784775e51966f0885f5cd27435916517b
 - name: gopkg.in/yaml.v2
   version: a5b47d31c556af34a302ce5d659e6fea44d90de0
+- name: github.com/golang/lint
+  version: c7bacac2b21ca01afa1dee0acf64df3ce047c28f
+  subpackages:
+  - golint
+- name: github.com/fzipp/gocyclo
+  version: 6acd4345c835499920e8426c7e4e8d7a34f1bb83
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -184,7 +184,6 @@ imports:
   version: a888bfdffa4526cc6987572bca9a2c6b7758290f
   subpackages:
   - go/ast/astutil
-  - cmd/goimports
 - name: google.golang.org/appengine
   version: ca59ef35f409df61fa4a5f8290ff289b37eccfb8
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -36,7 +36,6 @@ import:
 - package: golang.org/x/tools
   subpackages:
   - go/ast/astutil
-  - cmd/goimports
 - package: gopkg.in/yaml.v2
 - package: bitbucket.org/pkg/inflect
 - package: github.com/kr/pretty

--- a/glide.yaml
+++ b/glide.yaml
@@ -36,6 +36,7 @@ import:
 - package: golang.org/x/tools
   subpackages:
   - go/ast/astutil
+  - cmd/goimports
 - package: gopkg.in/yaml.v2
 - package: bitbucket.org/pkg/inflect
 - package: github.com/kr/pretty
@@ -90,3 +91,5 @@ import:
 - package: github.com/russross/blackfriday
 - package: github.com/microcosm-cc/bluemonday
 - package: github.com/shurcooL/sanitized_anchor_name
+- package: github.com/golang/lint/golint
+- package: github.com/golang/fzipp/gocyclo


### PR DESCRIPTION
I'd like to point it out several things:
- These checks don't aim to be blockers for the PR, in other words, not to fail our jenkins tests.
- These checks could help us to enforce a good quality for our code
- I selected three of the most common tools to analysis the go code: `gofmt`, `go vet`, `golint`, `gocyclo`... We already had `gofmt` in our Makefile,
- The results of these checks are included into a log file (as proposed in https://github.com/almighty/almighty-core/pull/45) but we could print them into the stdout. I think that makes more sense but I wanted to know your opinion.

If we want to add more tools maybe we could consider using  https://github.com/alecthomas/gometalinter