### PR TITLE
Don't run coverage tests with coverage when deploying master

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -4,6 +4,6 @@
 
 cico_setup;
 
-run_tests_with_coverage;
+run_tests_without_coverage;
 
 deploy;


### PR DESCRIPTION
This runs tests without coverage when building master for deployment. (Fixes #759)

This PR will run the existing coverage script `cico_run_coverage.sh` for master:  https://github.com/almighty/almighty-jobs/pull/76