### PR TITLE
`make build` fails on `glide --verbose`  (#764)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ clean-glide-cache:
 	-rm -rf ./.glide
 
 $(VENDOR_DIR): glide.lock glide.yaml
-	$(GLIDE_BIN) --verbose install
+	$(GLIDE_BIN) install
 	touch $(VENDOR_DIR)
 
 .PHONY: deps


### PR DESCRIPTION
removed the `--verbose` flag that is not supported
on glide 0.13.0

Fixes #764 

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
