### PR TITLE
Add refresh tokens to /api/login/authorize and /api/login/generate responses

### DIFF
--- a/design/auth.go
+++ b/design/auth.go
@@ -1,0 +1,54 @@
+package design
+
+import (
+	d "github.com/goadesign/goa/design"
+	a "github.com/goadesign/goa/design/apidsl"
+)
+
+var _ = a.Resource("login", func() {
+
+	a.BasePath("/login")
+
+	a.Action("authorize", func() {
+		a.Routing(
+			a.GET("authorize"),
+		)
+		a.Description("Authorize with the ALM")
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.TemporaryRedirect)
+	})
+
+	a.Action("generate", func() {
+		a.Routing(
+			a.GET("generate"),
+		)
+		a.Description("Generates a set of Tokens for different Auth levels. NOT FOR PRODUCTION. Only available if server is running in dev mode")
+		a.Response(d.OK, func() {
+			a.Media(a.CollectionOf(AuthToken))
+		})
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+	})
+})
+
+// AuthToken represents an authentication JWT Token
+var AuthToken = a.MediaType("application/vnd.authtoken+json", func() {
+	a.TypeName("AuthToken")
+	a.Description("JWT Token")
+	a.Attributes(func() {
+		a.Attribute("token", tokenData)
+		a.Required("token")
+	})
+	a.View("default", func() {
+		a.Attribute("token")
+	})
+})
+
+var tokenData = a.Type("TokenData", func() {
+	a.Attribute("access_token", d.String, "Access token")
+	a.Attribute("expires_in", d.Integer, "Access token expires in seconds")
+	a.Attribute("refresh_expires_in", d.Integer, "Refresh token expires in seconds")
+	a.Attribute("refresh_token", d.String, "Refresh token")
+	a.Attribute("token_type", d.String, "Token type")
+	a.Attribute("not-before-policy", d.Integer, "Token is not valid if issued before this date")
+})

--- a/design/media_types.go
+++ b/design/media_types.go
@@ -23,19 +23,6 @@ var ALMStatus = a.MediaType("application/vnd.status+json", func() {
 	})
 })
 
-// AuthToken represents an authentication JWT Token
-var AuthToken = a.MediaType("application/vnd.authtoken+json", func() {
-	a.TypeName("AuthToken")
-	a.Description("JWT Token")
-	a.Attributes(func() {
-		a.Attribute("token", d.String, "JWT Token")
-		a.Required("token")
-	})
-	a.View("default", func() {
-		a.Attribute("token")
-	})
-})
-
 // workItem is the media type for work items
 // Deprecated, but kept around as internal model for now.
 var workItem = a.MediaType("application/vnd.workitem+json", func() {

--- a/design/resources.go
+++ b/design/resources.go
@@ -103,32 +103,6 @@ var _ = a.Resource("status", func() {
 	})
 })
 
-var _ = a.Resource("login", func() {
-
-	a.BasePath("/login")
-
-	a.Action("authorize", func() {
-		a.Routing(
-			a.GET("authorize"),
-		)
-		a.Description("Authorize with the ALM")
-		a.Response(d.Unauthorized, JSONAPIErrors)
-		a.Response(d.TemporaryRedirect)
-	})
-
-	a.Action("generate", func() {
-		a.Routing(
-			a.GET("generate"),
-		)
-		a.Description("Generates a set of Tokens for different Auth levels. NOT FOR PRODUCTION. Only available if server is running in dev mode")
-		a.Response(d.OK, func() {
-			a.Media(a.CollectionOf(AuthToken))
-		})
-		a.Response(d.Unauthorized, JSONAPIErrors)
-		a.Response(d.InternalServerError, JSONAPIErrors)
-	})
-})
-
 var _ = a.Resource("tracker", func() {
 	a.BasePath("/trackers")
 

--- a/login_test.go
+++ b/login_test.go
@@ -61,9 +61,12 @@ func TestTestUserTokenObtainedFromKeycloakOK(t *testing.T) {
 	_, result := test.GenerateLoginOK(t, nil, service, controller)
 	assert.Len(t, result, 1, "The size of token array is not 1")
 	for _, data := range result {
-		if data.Token == "" {
-			t.Errorf("token is empty")
-		}
+		assert.NotEmpty(t, data.Token.AccessToken, "Access token is empty")
+		assert.NotEmpty(t, data.Token.RefreshToken, "Refresh token is empty")
+		assert.NotEmpty(t, data.Token.TokenType, "Token type is empty")
+		assert.NotNil(t, data.Token.ExpiresIn, "Expires-in is nil")
+		assert.NotNil(t, data.Token.RefreshExpiresIn, "Refresh-expires-in is nil")
+		assert.NotNil(t, data.Token.NotBeforePolicy, "Not-before-policy in is nil")
 	}
 }
 


### PR DESCRIPTION
This PR fixes the following parts of the #774 issue:

1. /api/login/generate now returns a payload with both refresh and access tokens:

```
[
  {
    "token": {
      "access_token": "<ACCESS-TOKEN>",
      "expires_in": 1800,
      "not-before-policy": 0,
      "refresh_expires_in": 1800,
      "refresh_token": "<REFRESH-TOKEN>",
      "token_type": "bearer"
    }
  }
]
```
2. /api/login/authorize when doing the final redirect now includes an encoded JSON with both refresh and access tokens in "token_json" param:

```
Location: http://localhost:8088/login?token=ACCESS_TOKEN&token_json=ENCODED_TOKEN_JSON
```

Here is an example of token_json:

```
{
      "access_token": "<ACCESS-TOKEN>",
      "expires_in": 1800,
      "not-before-policy": 0,
      "refresh_expires_in": 1800,
      "refresh_token": "<REFRESH-TOKEN>",
      "token_type": "bearer"
}
```

The "token" param is still in place not to break the current UI clients. As soon as UI switches to token_json we can drop the token param.

Fixes #774

