### PR TITLE
Add health check for the docker backend container

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -17,3 +17,7 @@ WORKDIR ${ALMIGHTY_INSTALL_PREFIX}
 ENTRYPOINT [ "bin/alm" ]
 
 EXPOSE 8080
+
+# Check every 5 minutes if the container is still "healthy"
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl -f localhost:8080/api/status || exit 1


### PR DESCRIPTION
This allows any monitoring to see what the state of the core container is.

Just run `docker inspect CONTAINERNAME` and look for the `State.Health.Status` value. Once the container is started the state is `starting` and after that it can become `healthy` or `unhealthy` depending on the outcome of the curl request to `/api/status`.

You can read more on the HEALTHCHECK Dockerfile here: https://docs.docker.com/engine/reference/builder/#/healthcheck

@kbsingh @aslakknutsen what do you think about this?