### PR TITLE
Added a proxy API for token refresh

### DIFF
--- a/design/auth.go
+++ b/design/auth.go
@@ -29,6 +29,24 @@ var _ = a.Resource("login", func() {
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 	})
+
+	a.Action("refresh", func() {
+		a.Routing(
+			a.POST("refresh"),
+		)
+		a.Payload(refreshToken)
+		a.Description("Refreshes access token")
+		a.Response(d.OK, func() {
+			a.Media(AuthToken)
+		})
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+	})
+})
+
+var refreshToken = a.Type("RefreshToken", func() {
+	a.Attribute("refresh_token", d.String, "Refresh token")
 })
 
 // AuthToken represents an authentication JWT Token

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -26,8 +26,18 @@ func NewInternalError(msg string) InternalError {
 	return InternalError{simpleError{msg}}
 }
 
+// NewUnauthorizedError returns the custom defined error of type UnauthorizedError.
+func NewUnauthorizedError(msg string) UnauthorizedError {
+	return UnauthorizedError{simpleError{msg}}
+}
+
 // InternalError means that the operation failed for some internal, unexpected reason
 type InternalError struct {
+	simpleError
+}
+
+// UnauthorizedError means that the operation is unauthorized
+type UnauthorizedError struct {
 	simpleError
 }
 

--- a/errors/errors_blackbox_test.go
+++ b/errors/errors_blackbox_test.go
@@ -47,3 +47,12 @@ func TestNewNotFoundError(t *testing.T) {
 	err := errors.NewNotFoundError(param, value)
 	assert.Equal(t, fmt.Sprintf("%s with id '%s' not found", param, value), err.Error())
 }
+
+func TestNewUnauthorizedError(t *testing.T) {
+	t.Parallel()
+	resource.Require(t, resource.UnitTest)
+	msg := "Invalid token"
+	err := errors.NewUnauthorizedError(msg)
+
+	assert.Equal(t, msg, err.Error())
+}

--- a/login.go
+++ b/login.go
@@ -92,7 +92,7 @@ func readToken(res *http.Response, ctx jsonapi.InternalServerError) (*app.TokenD
 	var token app.TokenData
 	err := json.Unmarshal([]byte(jsonString), &token)
 	if err != nil {
-		return nil, jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(fmt.Sprintf("Error when unmarshal json with access token %s ", jsonString)+err.Error()))
+		return nil, jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(fmt.Sprintf("error when unmarshal json with access token %s ", jsonString)+err.Error()))
 	}
 	return &token, nil
 }
@@ -100,7 +100,7 @@ func readToken(res *http.Response, ctx jsonapi.InternalServerError) (*app.TokenD
 // Generate obtain the access token from Keycloak for the test user
 func (c *LoginController) Generate(ctx *app.GenerateLoginContext) error {
 	if !configuration.IsPostgresDeveloperModeEnabled() {
-		jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized("Postgres developer mode not enabled"))
+		jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized("postgres developer mode not enabled"))
 		return ctx.Unauthorized(jerrors)
 	}
 
@@ -119,7 +119,7 @@ func (c *LoginController) Generate(ctx *app.GenerateLoginContext) error {
 		"grant_type":    {"password"},
 	})
 	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("Error when obtaining token "+err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("error when obtaining token "+err.Error()))
 	}
 
 	token, err := readToken(res, ctx)

--- a/login.go
+++ b/login.go
@@ -65,7 +65,7 @@ func (c *LoginController) Refresh(ctx *app.RefreshLoginContext) error {
 	case 400:
 		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError(readBody(res.Body), nil))
 	default:
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(res.Status+""+readBody(res.Body)))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(res.Status+" "+readBody(res.Body)))
 	}
 
 	token, err := readToken(res, ctx)

--- a/login.go
+++ b/login.go
@@ -15,12 +15,12 @@ import (
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/configuration"
+	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/login"
 	"github.com/almighty/almighty-core/test"
 	"github.com/almighty/almighty-core/token"
 	"github.com/goadesign/goa"
-	"github.com/pkg/errors"
 )
 
 // LoginController implements the login resource.
@@ -38,6 +38,64 @@ func NewLoginController(service *goa.Service, auth *login.KeycloakOAuthProvider,
 // Authorize runs the authorize action.
 func (c *LoginController) Authorize(ctx *app.AuthorizeLoginContext) error {
 	return c.auth.Perform(ctx)
+}
+
+// Refresh obtain a new access token using the refresh token.
+func (c *LoginController) Refresh(ctx *app.RefreshLoginContext) error {
+	refreshToken := ctx.Payload.RefreshToken
+	if refreshToken == nil {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("refresh_token", nil).Expected("not nil"))
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	res, err := client.PostForm(configuration.GetKeycloakEndpointToken(), url.Values{
+		"client_id":     {configuration.GetKeycloakClientID()},
+		"client_secret": {configuration.GetKeycloakSecret()},
+		"refresh_token": {*refreshToken},
+		"grant_type":    {"refresh_token"},
+	})
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("Error when obtaining token "+err.Error()))
+	}
+	switch res.StatusCode {
+	case 200:
+		// OK
+	case 401:
+		jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(readBody(res.Body)))
+		return ctx.Unauthorized(jerrors)
+	case 400:
+		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError(readBody(res.Body), nil))
+	default:
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(res.Status+""+readBody(res.Body)))
+	}
+
+	token, err := readToken(res, ctx)
+	if err != nil {
+		return err
+	}
+
+	return ctx.OK(&app.AuthToken{Token: token})
+}
+
+func readBody(body io.ReadCloser) string {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(body)
+	return buf.String()
+}
+
+func readToken(res *http.Response, ctx jsonapi.InternalServerError) (*app.TokenData, error) {
+	// Read the json out of the response body
+	buf := new(bytes.Buffer)
+	io.Copy(buf, res.Body)
+	res.Body.Close()
+	jsonString := strings.TrimSpace(buf.String())
+
+	var token app.TokenData
+	err := json.Unmarshal([]byte(jsonString), &token)
+	if err != nil {
+		return nil, jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(fmt.Sprintf("Error when unmarshal json with access token %s ", jsonString)+err.Error()))
+	}
+	return &token, nil
 }
 
 // Generate obtain the access token from Keycloak for the test user
@@ -62,22 +120,16 @@ func (c *LoginController) Generate(ctx *app.GenerateLoginContext) error {
 		"grant_type":    {"password"},
 	})
 	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.Wrap(err, "Error when obtaining token"))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("Error when obtaining token "+err.Error()))
 	}
 
-	// Read the json out of the response body
-	buf := new(bytes.Buffer)
-	io.Copy(buf, res.Body)
-	res.Body.Close()
-	jsonString := strings.TrimSpace(buf.String())
-
-	var token app.TokenData
-	err = json.Unmarshal([]byte(jsonString), &token)
+	token, err := readToken(res, ctx)
 	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.Wrap(err, fmt.Sprintf("Error when unmarshal json with access token %s", jsonString)))
+		return err
 	}
+
 	var tokens app.AuthTokenCollection
-	tokens = append(tokens, &app.AuthToken{Token: &token})
+	tokens = append(tokens, &app.AuthToken{Token: token})
 	// Creates the testuser user and identity if they don't yet exist
 	c.auth.CreateKeycloakUser(*token.AccessToken, ctx)
 

--- a/login.go
+++ b/login.go
@@ -61,8 +61,7 @@ func (c *LoginController) Refresh(ctx *app.RefreshLoginContext) error {
 	case 200:
 		// OK
 	case 401:
-		jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(readBody(res.Body)))
-		return ctx.Unauthorized(jerrors)
+		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(res.Status+" "+readBody(res.Body)))
 	case 400:
 		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError(readBody(res.Body), nil))
 	default:

--- a/login/service.go
+++ b/login/service.go
@@ -146,12 +146,12 @@ func encodeToken(referal *url.URL, outhToken *oauth2.Token) error {
 	str := outhToken.Extra("expires_in")
 	expiresIn, err := strconv.Atoi(fmt.Sprintf("%v", str))
 	if err != nil {
-		return errs.WithStack(errors.New("Cant convert expires_in to integer " + err.Error()))
+		return errs.WithStack(errors.New("cant convert expires_in to integer " + err.Error()))
 	}
 	str = outhToken.Extra("refresh_expires_in")
 	refreshExpiresIn, err := strconv.Atoi(fmt.Sprintf("%v", str))
 	if err != nil {
-		return errs.WithStack(errors.New("Cant convert refresh_expires_in to integer " + err.Error()))
+		return errs.WithStack(errors.New("cant convert refresh_expires_in to integer " + err.Error()))
 	}
 	tokenData := &app.TokenData{
 		AccessToken:      &outhToken.AccessToken,
@@ -162,7 +162,7 @@ func encodeToken(referal *url.URL, outhToken *oauth2.Token) error {
 	}
 	b, err := json.Marshal(tokenData)
 	if err != nil {
-		return errs.WithStack(errors.New("Cant marshal token data struct " + err.Error()))
+		return errs.WithStack(errors.New("cant marshal token data struct " + err.Error()))
 	}
 
 	parameters := url.Values{}
@@ -180,13 +180,13 @@ func (keycloak *KeycloakOAuthProvider) CreateKeycloakUser(accessToken string, ct
 
 	claims, err := parseToken(accessToken, keycloak.TokenManager.PublicKey())
 	if err != nil || checkClaims(claims) != nil {
-		return nil, nil, errors.New("Error when parsing token " + err.Error())
+		return nil, nil, errors.New("error when parsing token " + err.Error())
 	}
 
 	keycloakIdentityID, _ := uuid.FromString(claims.Subject)
 	identities, err := keycloak.Identities.Query(account.IdentityFilterByID(keycloakIdentityID), account.IdentityWithUser())
 	if err != nil {
-		return nil, nil, errors.New("Error during querying for an identity " + err.Error())
+		return nil, nil, errors.New("error during querying for an identity " + err.Error())
 	}
 
 	if len(identities) == 0 {
@@ -218,7 +218,7 @@ func (keycloak *KeycloakOAuthProvider) CreateKeycloakUser(accessToken string, ct
 		fillUser(claims, user)
 		err = keycloak.Users.Save(ctx, user)
 		if err != nil {
-			return nil, nil, errors.New("Cant' update user " + err.Error())
+			return nil, nil, errors.New("cant' update user " + err.Error())
 		}
 	}
 	return identity, user, nil
@@ -240,7 +240,7 @@ func parseToken(tokenString string, publicKey *rsa.PublicKey) (*keycloakTokenCla
 	if token.Valid {
 		return claims, nil
 	}
-	return nil, errs.WithStack(errors.New("Token is not valid"))
+	return nil, errs.WithStack(errors.New("token is not valid"))
 }
 
 func generateGravatarURL(email string) (string, error) {
@@ -267,17 +267,17 @@ func generateGravatarURL(email string) (string, error) {
 
 func checkClaims(claims *keycloakTokenClaims) error {
 	if claims.Subject == "" {
-		return errors.New("Subject claim not found in token")
+		return errors.New("subject claim not found in token")
 	}
 	_, err := uuid.FromString(claims.Subject)
 	if err != nil {
-		return errors.New("Subject claim from token is not UUID " + err.Error())
+		return errors.New("subject claim from token is not UUID " + err.Error())
 	}
 	if claims.Username == "" {
-		return errors.New("Username claim not found in token")
+		return errors.New("username claim not found in token")
 	}
 	if claims.Email == "" {
-		return errors.New("Email claim not found in token")
+		return errors.New("email claim not found in token")
 	}
 	return nil
 }
@@ -287,7 +287,7 @@ func fillUser(claims *keycloakTokenClaims, user *account.User) error {
 	user.Email = claims.Email
 	image, err := generateGravatarURL(claims.Email)
 	if err != nil {
-		return errors.New("Error when generating gravatar " + err.Error())
+		return errors.New("error when generating gravatar " + err.Error())
 	}
 	user.ImageURL = image
 	return nil
@@ -298,7 +298,7 @@ func fillUser(claims *keycloakTokenClaims, user *account.User) error {
 func ContextIdentity(ctx context.Context) (string, error) {
 	tm := ReadTokenManagerFromContext(ctx)
 	if tm == nil {
-		return "", errs.New("Missing token manager")
+		return "", errs.New("missing token manager")
 	}
 	uuid, err := tm.Locate(ctx)
 	if err != nil {

--- a/login_test.go
+++ b/login_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/almighty/almighty-core/login"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/almighty/almighty-core/token"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
 	"github.com/stretchr/testify/assert"
 )
@@ -61,13 +62,58 @@ func TestTestUserTokenObtainedFromKeycloakOK(t *testing.T) {
 	_, result := test.GenerateLoginOK(t, nil, service, controller)
 	assert.Len(t, result, 1, "The size of token array is not 1")
 	for _, data := range result {
-		assert.NotEmpty(t, data.Token.AccessToken, "Access token is empty")
-		assert.NotEmpty(t, data.Token.RefreshToken, "Refresh token is empty")
-		assert.NotEmpty(t, data.Token.TokenType, "Token type is empty")
-		assert.NotNil(t, data.Token.ExpiresIn, "Expires-in is nil")
-		assert.NotNil(t, data.Token.RefreshExpiresIn, "Refresh-expires-in is nil")
-		assert.NotNil(t, data.Token.NotBeforePolicy, "Not-before-policy in is nil")
+		validateToken(t, data, controller)
 	}
+}
+
+func TestRefreshTokenUsingValidRefreshTokenOK(t *testing.T) {
+	resource.Require(t, resource.Database)
+	service, controller := createControler(t)
+	_, result := test.GenerateLoginOK(t, nil, service, controller)
+	if len(result) != 1 || result[0].Token.RefreshToken == nil {
+		t.Fatal("Can't get the test user token")
+	}
+	refreshToken := result[0].Token.RefreshToken
+
+	payload := &app.RefreshToken{RefreshToken: refreshToken}
+	_, newToken := test.RefreshLoginOK(t, nil, service, controller, payload)
+	validateToken(t, newToken, controller)
+}
+
+func TestRefreshTokenUsingNilTokenFails(t *testing.T) {
+	resource.Require(t, resource.Database)
+	service, controller := createControler(t)
+
+	payload := &app.RefreshToken{}
+	_, err := test.RefreshLoginBadRequest(t, nil, service, controller, payload)
+	assert.NotNil(t, err)
+}
+
+func TestRefreshTokenUsingInvalidTokenFails(t *testing.T) {
+	resource.Require(t, resource.Database)
+	service, controller := createControler(t)
+
+	refreshToken := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.S-vR8LZTQ92iqGCR3rNUG0MiGx2N5EBVq0frCHP_bJ8"
+	payload := &app.RefreshToken{RefreshToken: &refreshToken}
+	_, err := test.RefreshLoginBadRequest(t, nil, service, controller, payload)
+	assert.NotNil(t, err)
+}
+
+func validateToken(t *testing.T, token *app.AuthToken, controler *LoginController) {
+	assert.NotNil(t, token, "Token data is nil")
+	assert.NotEmpty(t, token.Token.AccessToken, "Access token is empty")
+	assert.NotEmpty(t, token.Token.RefreshToken, "Refresh token is empty")
+	assert.NotEmpty(t, token.Token.TokenType, "Token type is empty")
+	assert.NotNil(t, token.Token.ExpiresIn, "Expires-in is nil")
+	assert.NotNil(t, token.Token.RefreshExpiresIn, "Refresh-expires-in is nil")
+	assert.NotNil(t, token.Token.NotBeforePolicy, "Not-before-policy is nil")
+	keyFunc := func(t *jwt.Token) (interface{}, error) {
+		return controler.tokenManager.PublicKey(), nil
+	}
+	_, err := jwt.Parse(*token.Token.AccessToken, keyFunc)
+	assert.Nil(t, err, "Invalid access token")
+	_, err = jwt.Parse(*token.Token.RefreshToken, keyFunc)
+	assert.Nil(t, err, "Invalid refresh token")
 }
 
 type TestLoginService struct{}


### PR DESCRIPTION
This is a proxy API for token refresh in case we decide to go with a proxy instead of using a public Keycloak client.