### PR TITLE
Use paging modular methods in Search controller

### DIFF
--- a/search.go
+++ b/search.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"strconv"
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
@@ -35,27 +34,7 @@ func (c *SearchController) Show(ctx *app.ShowSearchContext) error {
 	var offset int
 	var limit int
 
-	if ctx.PageOffset == nil {
-		offset = 0
-	} else {
-		offsetValue, err := strconv.Atoi(*ctx.PageOffset)
-		if err != nil {
-			offset = 0
-		} else {
-			offset = offsetValue
-		}
-	}
-
-	if ctx.PageLimit == nil {
-		limit = 100
-	} else {
-		limit = *ctx.PageLimit
-	}
-	if offset < 0 {
-		//jerrors, _ := jsonapi.ErrorToJSONAPIErrors(models.NewBadParameterError(fmt.Sprintf("offset must be >= 0, but is: %d", offset)))
-		jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(fmt.Sprintf("offset must be >= 0, but is: %d", offset)))
-		return ctx.BadRequest(jerrors)
-	}
+	offset, limit = computePagingLimts(ctx.PageOffset, ctx.PageLimit)
 
 	// ToDo : Keep URL registeration central somehow.
 	hostString := ctx.RequestData.Host
@@ -90,68 +69,12 @@ func (c *SearchController) Show(ctx *app.ShowSearchContext) error {
 			Data:  ConvertWorkItems(ctx.RequestData, result),
 		}
 
-		// prev link
-		if offset > 0 && count > 0 {
-			var prevStart int
-			// we do have a prev link
-			if offset <= count {
-				prevStart = offset - limit
-			} else {
-				// the first range that intersects the end of the useful range
-				prevStart = offset - (((offset-count)/limit)+1)*limit
-			}
-			realLimit := limit
-			if prevStart < 0 {
-				// need to cut the range to start at 0
-				realLimit = limit + prevStart
-				prevStart = 0
-			}
-			prev := fmt.Sprintf("%s?q=%s&page[offset]=%d&page[limit]=%d", buildAbsoluteURL(ctx.RequestData), ctx.Q, prevStart, realLimit)
-			response.Links.Prev = &prev
-		}
-
-		// next link
-		nextStart := offset + len(result)
-		if nextStart < count {
-			// we have a next link
-			next := fmt.Sprintf("%s?q=%s&page[offset]=%d&page[limit]=%d", buildAbsoluteURL(ctx.RequestData), ctx.Q, nextStart, limit)
-			response.Links.Next = &next
-		}
-
-		// first link
-		var firstEnd int
-		if offset > 0 {
-			firstEnd = offset % limit // this is where the second page starts
-		} else {
-			// offset == 0, first == current
-			firstEnd = limit
-		}
-		first := fmt.Sprintf("%s?q=%s&page[offset]=%d&page[limit]=%d", buildAbsoluteURL(ctx.RequestData), ctx.Q, 0, firstEnd)
-		response.Links.First = &first
-
-		// last link
-		var lastStart int
-		if offset < count {
-			// advance some pages until touching the end of the range
-			lastStart = offset + (((count - offset - 1) / limit) * limit)
-		} else {
-			// retreat at least one page until covering the range
-			lastStart = offset - ((((offset - count) / limit) + 1) * limit)
-		}
-		realLimit := limit
-		if lastStart < 0 {
-			// need to cut the range to start at 0
-			realLimit = limit + lastStart
-			lastStart = 0
-		}
-		last := fmt.Sprintf("%s?q=%s&page[offset]=%d&page[limit]=%d", buildAbsoluteURL(ctx.RequestData), ctx.Q, lastStart, realLimit)
-		response.Links.Last = &last
-
+		setPagingLinks(response.Links, buildAbsoluteURL(ctx.RequestData), len(result), offset, limit, count, "q="+ctx.Q)
 		return ctx.OK(&response)
 	})
 }
 
-// Users runs the user search action.
+// Spaces runs the space search action.
 func (c *SearchController) Spaces(ctx *app.SpacesSearchContext) error {
 	q := ctx.Q
 	if q == "" {

--- a/search_blackbox_test.go
+++ b/search_blackbox_test.go
@@ -81,8 +81,10 @@ func TestSearchPagination(t *testing.T) {
 	controller := NewSearchController(service, gormapplication.NewGormDB(DB))
 	q := "specialwordforsearch2"
 	_, sr := test.ShowSearchOK(t, nil, nil, controller, nil, nil, q)
-	assert.Equal(t, "http:///api/search?q=specialwordforsearch2&page[offset]=0&page[limit]=100", *sr.Links.First)
-	assert.Equal(t, "http:///api/search?q=specialwordforsearch2&page[offset]=0&page[limit]=100", *sr.Links.Last)
+
+	// defaults in paging.go is 'pageSizeDefault = 20'
+	assert.Equal(t, "http:///api/search?page[offset]=0&page[limit]=20&q=specialwordforsearch2", *sr.Links.First)
+	assert.Equal(t, "http:///api/search?page[offset]=0&page[limit]=20&q=specialwordforsearch2", *sr.Links.Last)
 	require.NotEmpty(t, sr.Data)
 	r := sr.Data[0]
 	assert.Equal(t, "specialwordforsearch2", r.Attributes[workitem.SystemTitle])


### PR DESCRIPTION
This is code cleanup PR where I've removed repetitive code for generating paging boundaries for the paging link, inside the Search controller.