### PR TITLE
developer mode is manadatory for this test

### DIFF
--- a/login_test.go
+++ b/login_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -56,6 +57,7 @@ func createControler(t *testing.T) (*goa.Service, *LoginController) {
 }
 
 func TestTestUserTokenObtainedFromKeycloakOK(t *testing.T) {
+	os.Setenv("ALMIGHTY_DEVELOPER_MODE_ENABLED", "true")
 	resource.Require(t, resource.Database)
 	service, controller := createControler(t)
 	_, result := test.GenerateLoginOK(t, nil, service, controller)


### PR DESCRIPTION
Without enabling developer mode, the temporary token cannot be
generated.  This is the only test that fails without developer
mode enabled globally.