### PR TITLE
Auto-delete links on a WI when WI gets deleted

### DIFF
--- a/workitem.go
+++ b/workitem.go
@@ -191,6 +191,8 @@ func (c *WorkitemController) Delete(ctx *app.DeleteWorkitemContext) error {
 		// work item is a part of.
 		wilList, err := appl.WorkItemLinks().ListByWorkItemID(ctx, ctx.ID)
 		if err != nil {
+			// Ignore not found errors only. We just leave the links alone if
+			// there aren't any.
 			_, ok := errs.Cause(err).(errors.NotFoundError)
 			if !ok {
 				return jsonapi.JSONErrorResponse(ctx, errs.Wrapf(err, "error fetching work item links associated to %s", ctx.ID))

--- a/workitem_blackbox_test.go
+++ b/workitem_blackbox_test.go
@@ -573,6 +573,9 @@ type WorkItem2Suite struct {
 	clean          func()
 	wiCtrl         app.WorkitemController
 	wi2Ctrl        app.WorkitemController
+	linkCtrl       app.WorkItemLinkController
+	linkCatCtrl    app.WorkItemLinkCategoryController
+	linkTypeCtrl   app.WorkItemLinkTypeController
 	pubKey         *rsa.PublicKey
 	priKey         *rsa.PrivateKey
 	svc            *goa.Service
@@ -601,6 +604,15 @@ func (s *WorkItem2Suite) SetupSuite() {
 
 	s.wi2Ctrl = NewWorkitemController(s.svc, gormapplication.NewGormDB(s.db))
 	require.NotNil(s.T(), s.wi2Ctrl)
+
+	s.linkCatCtrl = NewWorkItemLinkCategoryController(s.svc, gormapplication.NewGormDB(DB))
+	require.NotNil(s.T(), s.linkCatCtrl)
+
+	s.linkTypeCtrl = NewWorkItemLinkTypeController(s.svc, gormapplication.NewGormDB(DB))
+	require.NotNil(s.T(), s.linkTypeCtrl)
+
+	s.linkCtrl = NewWorkItemLinkController(s.svc, gormapplication.NewGormDB(DB))
+	require.NotNil(s.T(), s.linkCtrl)
 
 	// Make sure the database is populated with the correct types (e.g. bug etc.)
 	if configuration.GetPopulateCommonTypes() {
@@ -1364,6 +1376,57 @@ func (s *WorkItem2Suite) TestWI2SuccessDelete() {
 	test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWi.Data.ID)
 	test.DeleteWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWi.Data.ID)
 	test.ShowWorkitemNotFound(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWi.Data.ID)
+}
+
+// TestWI2DeleteLinksOnWIDeletionOK creates two work items (WI1 and WI2) and
+// creates a link between them. When one of the work items is deleted, the
+// link shall be gone as well.
+func (s *WorkItem2Suite) TestWI2DeleteLinksOnWIDeletionOK() {
+	// Create two work items (wi1 and wi2)
+	c := minimumRequiredCreatePayload()
+	c.Data.Attributes[workitem.SystemTitle] = "WI1"
+	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
+	c.Data.Relationships = &app.WorkItemRelationships{
+		BaseType: &app.RelationBaseType{
+			Data: &app.BaseTypeData{
+				Type: "workitemtypes",
+				ID:   workitem.SystemBug,
+			},
+		},
+	}
+	_, wi1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	require.NotNil(s.T(), wi1)
+	c.Data.Attributes[workitem.SystemTitle] = "WI2"
+	_, wi2 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	require.NotNil(s.T(), wi2)
+
+	// Create link category
+	linkCatPayload := CreateWorkItemLinkCategory("test-user")
+	_, linkCat := test.CreateWorkItemLinkCategoryCreated(s.T(), nil, nil, s.linkCatCtrl, linkCatPayload)
+	require.NotNil(s.T(), linkCat)
+
+	// Create work item link type payload
+	linkTypePayload := CreateWorkItemLinkType("MyLinkType", workitem.SystemBug, workitem.SystemBug, *linkCat.Data.ID)
+	_, linkType := test.CreateWorkItemLinkTypeCreated(s.T(), nil, nil, s.linkTypeCtrl, linkTypePayload)
+	require.NotNil(s.T(), linkType)
+
+	// Create link between wi1 and wi2
+	id1, err := strconv.ParseUint(*wi1.Data.ID, 10, 64)
+	require.Nil(s.T(), err)
+	id2, err := strconv.ParseUint(*wi2.Data.ID, 10, 64)
+	require.Nil(s.T(), err)
+	linkPayload := CreateWorkItemLink(id1, id2, *linkType.Data.ID)
+	_, workItemLink := test.CreateWorkItemLinkCreated(s.T(), nil, nil, s.linkCtrl, linkPayload)
+	require.NotNil(s.T(), workItemLink)
+
+	// Delete work item wi1
+	test.DeleteWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *wi1.Data.ID)
+
+	// Check that the link was deleted by deleting wi1
+	test.ShowWorkItemLinkNotFound(s.T(), s.svc.Context, s.svc, s.linkCtrl, *workItemLink.Data.ID)
+
+	// Check that we can query for wi2 without problems
+	test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *wi2.Data.ID)
 }
 
 func (s *WorkItem2Suite) TestWI2FailMissingDelete() {


### PR DESCRIPTION
If we don't auto-delete the links, then we get a 404 when we query for
the links on the still existing end of a link. This is because we try to
resolve both ends of the link and the one that has been deleted
obviously cannot be found.

For now we auto-delete the links associated to a WI in the WI
controller explicitly. Later we might want to have some registration
mechanism where different systems can hook into. For now this is
overkill.

Fixes #768