### PR TITLE
Put 'edit-codebase' URL for WorkItem (to unblock UI team).

### DIFF
--- a/design/workitems.go
+++ b/design/workitems.go
@@ -40,7 +40,7 @@ var workItemRelationships = a.Type("WorkItemRelationships", func() {
 	a.Attribute("comments", relationGeneric, "This defines comments on the Work Item")
 	a.Attribute("iteration", relationGeneric, "This defines the iteration this work item belong to")
 	a.Attribute("area", relationGeneric, "This defines the area this work item belongs to")
-
+	a.Attribute("codebase", relationGeneric, "ToDo :- Final version of this relationship is yet to come, this is added in order to unblock UI for a short term.")
 })
 
 // relationBaseType is top level block for WorkItemType relationship

--- a/workitem.go
+++ b/workitem.go
@@ -304,6 +304,10 @@ func ConvertWorkItem(request *goa.RequestData, wi *app.WorkItem, additional ...W
 	selfURL := rest.AbsoluteURL(request, app.WorkitemHref(wi.ID))
 	sourceLinkTypesURL := rest.AbsoluteURL(request, app.WorkitemtypeHref(wi.Type)+sourceLinkTypesRouteEnd)
 	targetLinkTypesURL := rest.AbsoluteURL(request, app.WorkitemtypeHref(wi.Type)+targetLinkTypesRouteEnd)
+	// ToDo: Need to define edit-codebase URL for given WI
+	// This value depends on other parameters like repo,branch,fileName,lineNumber
+	// Following URL will be defined once other modules are ready for integration
+	editCodebaseURL := rest.AbsoluteURL(request, "/ToBeDecided")
 	op := &app.WorkItem2{
 		ID:   &wi.ID,
 		Type: APIStringTypeWorkItem,
@@ -315,6 +319,16 @@ func ConvertWorkItem(request *goa.RequestData, wi *app.WorkItem, additional ...W
 				Data: &app.BaseTypeData{
 					ID:   wi.Type,
 					Type: APIStringTypeWorkItemType,
+				},
+			},
+			// ToDo: Values for codebase relationship are not finalised yet.
+			// Reason behind using `Map` is that it is "EDIT" URL for codebase.
+			// There can be more related URLs in future.
+			Codebase: &app.RelationGeneric{
+				Links: &app.GenericLinks{
+					Meta: map[string]interface{}{
+						"edit": editCodebaseURL,
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Temporarily fixes https://github.com/fabric8io/fabric8-planner/issues/889

Added relationships->codebase->links->meta["edit"] for every WI that will hold a URL.
This URL is not finalised yet hence it will show -> http://localhost:8080/ToBeDecided for all WIs.
Added this to unblock UI team.

**ToDo:**
Define strategy to construct Che editor's URL that will take user to respective repo/branch/file/line.

