### PR TITLE
Have distinguishable forward and reverse names for link types

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -278,7 +278,7 @@ func BootstrapWorkItemLinking(ctx context.Context, linkCatRepo *link.GormWorkIte
 	if err := createOrUpdateWorkItemLinkType(ctx, linkCatRepo, linkTypeRepo, link.SystemWorkItemLinkTypeBugBlocker, "One bug blocks a planner item.", link.TopologyNetwork, "blocks", "blocked by", workitem.SystemBug, workitem.SystemPlannerItem, link.SystemWorkItemLinkCategorySystem); err != nil {
 		return errs.WithStack(err)
 	}
-	if err := createOrUpdateWorkItemLinkType(ctx, linkCatRepo, linkTypeRepo, link.SystemWorkItemLinkPlannerItemRelated, "One planner item or a subtype of it relates to another one.", link.TopologyNetwork, "relates to", "relates to", workitem.SystemPlannerItem, workitem.SystemPlannerItem, link.SystemWorkItemLinkCategorySystem); err != nil {
+	if err := createOrUpdateWorkItemLinkType(ctx, linkCatRepo, linkTypeRepo, link.SystemWorkItemLinkPlannerItemRelated, "One planner item or a subtype of it relates to another one.", link.TopologyNetwork, "relates to", "is related to", workitem.SystemPlannerItem, workitem.SystemPlannerItem, link.SystemWorkItemLinkCategorySystem); err != nil {
 		return errs.WithStack(err)
 	}
 	return nil


### PR DESCRIPTION
Replace reverse name of "Related planner item" link type: `relates to` becomes `is related to`. This distinguishes it from the forward name which also used to be `relates to`.

As soon as the UI shows correct forward and reverse names, we need to make this change in order to distinguish "link types" or forward and reverse names in the UI.

@sanbornsen's  commit on UI side is going to fix this: https://github.com/sanbornsen/fabric8-planner/commit/18f6c0c6ea6b9de7ecaaea78bcfb855eed302e12
