### PR TITLE
Add index for searching parent path of Areas

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -157,6 +157,9 @@ func getMigrations() migrations {
 	// version 26
 	m = append(m, steps{executeSQLFile("026-areas.sql")})
 
+	// version 27
+	m = append(m, steps{executeSQLFile("027-areas-index.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/027-areas-index.sql
+++ b/migration/sql-files/027-areas-index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX area_path_btree_index ON areas USING BTREE (path);
+CREATE INDEX area_path_gist_index ON areas USING GIST (path);

--- a/migration/sql-files/027-areas-index.sql
+++ b/migration/sql-files/027-areas-index.sql
@@ -1,2 +1,1 @@
-CREATE INDEX area_path_btree_index ON areas USING BTREE (path);
 CREATE INDEX area_path_gist_index ON areas USING GIST (path);


### PR DESCRIPTION
The parent path column in the database in Area table is an
ltree field which stores the path to the parent.
Searching the ltree field can be made efficient by using
either the btree or gist index.
https://www.postgresql.org/docs/current/static/ltree.html

How to check if index is being hit:
- create a large test data  set in areas table ( tested with about 1000 )
- Fire the query similar to " explain analyze select path from areas where path ~ 'e9a6afc1_e51e_4a35_b16a_97e673b914f1.*'; "
- The output should mention which is the index that was used.
