### PR TITLE
Support system.description as type map[string]interface{}

### DIFF
--- a/rendering/markup_content.go
+++ b/rendering/markup_content.go
@@ -51,7 +51,7 @@ func NewMarkupContent(content, markup string) MarkupContent {
 }
 
 // NewMarkupContentFromValue creates a MarkupContent from the given value,
-// by converting a 'string' or casting a 'MarkupContent'. Otherwise, it returns nil.
+// by converting a 'string', a 'map[string]interface{}' or casting a 'MarkupContent'. Otherwise, it returns nil.
 func NewMarkupContentFromValue(value interface{}) *MarkupContent {
 	if value == nil {
 		return nil
@@ -62,6 +62,9 @@ func NewMarkupContentFromValue(value interface{}) *MarkupContent {
 		return &result
 	case MarkupContent:
 		result := value.(MarkupContent)
+		return &result
+	case map[string]interface{}:
+		result := NewMarkupContentFromMap(value.(map[string]interface{}))
 		return &result
 	default:
 		return nil

--- a/workitem.go
+++ b/workitem.go
@@ -7,8 +7,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	"reflect"
-
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/criteria"
@@ -260,8 +258,10 @@ func ConvertJSONAPIToWorkItem(appl application.Application, source app.WorkItem2
 
 	for key, val := range source.Attributes {
 		// convert legacy description to markup content
-		if key == workitem.SystemDescription && reflect.TypeOf(val).Kind() == reflect.String {
-			target.Fields[key] = rendering.NewMarkupContentFromLegacy(val.(string))
+		if key == workitem.SystemDescription {
+			if m := rendering.NewMarkupContentFromValue(val); m != nil {
+				target.Fields[key] = *m
+			}
 		} else {
 			target.Fields[key] = val
 		}

--- a/workitem_blackbox_test.go
+++ b/workitem_blackbox_test.go
@@ -721,7 +721,7 @@ func (s *WorkItem2Suite) TestWI2UpdateOnlyMarkupDescriptionWithoutMarkup() {
 	modifiedDescription := rendering.NewMarkupContentFromLegacy("Only Description is modified")
 	expectedDescription := "Only Description is modified"
 	expectedRenderedDescription := "Only Description is modified"
-	s.minimumPayload.Data.Attributes[workitem.SystemDescription] = modifiedDescription
+	s.minimumPayload.Data.Attributes[workitem.SystemDescription] = modifiedDescription.ToMap()
 	_, updatedWI := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.ID, s.minimumPayload)
 	require.NotNil(s.T(), updatedWI)
 	assert.Equal(s.T(), expectedDescription, updatedWI.Data.Attributes[workitem.SystemDescription])
@@ -734,7 +734,7 @@ func (s *WorkItem2Suite) TestWI2UpdateOnlyMarkupDescriptionWithMarkup() {
 	modifiedDescription := rendering.NewMarkupContent("Only Description is modified", rendering.SystemMarkupMarkdown)
 	expectedDescription := "Only Description is modified"
 	expectedRenderedDescription := "<p>Only Description is modified</p>\n"
-	s.minimumPayload.Data.Attributes[workitem.SystemDescription] = modifiedDescription
+	s.minimumPayload.Data.Attributes[workitem.SystemDescription] = modifiedDescription.ToMap()
 
 	_, updatedWI := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.ID, s.minimumPayload)
 	require.NotNil(s.T(), updatedWI)


### PR DESCRIPTION
When a description is sent in the new format and deserialized
from json it has the type map[string]interface{} and not the
internal type rendering.MarkupContent

Related #835
