### PR TITLE
Propagate the ctx over the repository operations

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/goadesign/goa/client"
 	"github.com/goadesign/goa/middleware"
 	"golang.org/x/net/context"
 )
@@ -91,10 +92,7 @@ func Error(ctx context.Context, fields map[string]interface{}, format string, ar
 		}
 
 		if ctx != nil {
-			reqID := middleware.ContextRequestID(ctx)
-			if reqID != "" {
-				entry = entry.WithField("requestID", reqID)
-			}
+			entry = entry.WithField("req_id", extractRequestID(ctx))
 		}
 
 		if len(args) > 0 {
@@ -115,11 +113,9 @@ func Warn(ctx context.Context, fields map[string]interface{}, format string, arg
 		}
 
 		if ctx != nil {
-			reqID := middleware.ContextRequestID(ctx)
-			if reqID != "" {
-				entry = entry.WithField("requestID", reqID)
-			}
+			entry = entry.WithField("req_id", extractRequestID(ctx))
 		}
+
 		if len(args) > 0 {
 			entry.WithFields(fields).Warnf(format, args...)
 		} else {
@@ -133,10 +129,7 @@ func Info(ctx context.Context, fields map[string]interface{}, format string, arg
 		entry := log.NewEntry(logger)
 
 		if ctx != nil {
-			reqID := middleware.ContextRequestID(ctx)
-			if reqID != "" {
-				entry = entry.WithField("requestID", reqID)
-			}
+			entry = entry.WithField("req_id", extractRequestID(ctx))
 		}
 
 		if len(args) > 0 {
@@ -152,10 +145,7 @@ func Panic(ctx context.Context, fields map[string]interface{}, format string, ar
 		entry := log.WithField("pid", os.Getpid())
 
 		if ctx != nil {
-			reqID := middleware.ContextRequestID(ctx)
-			if reqID != "" {
-				entry = entry.WithField("requestID", reqID)
-			}
+			entry = entry.WithField("req_id", extractRequestID(ctx))
 		}
 
 		if len(args) > 0 {
@@ -171,10 +161,7 @@ func Debug(ctx context.Context, fields map[string]interface{}, format string, ar
 		entry := log.NewEntry(logger)
 
 		if ctx != nil {
-			reqID := middleware.ContextRequestID(ctx)
-			if reqID != "" {
-				entry = entry.WithField("requestID", reqID)
-			}
+			entry = entry.WithField("req_id", extractRequestID(ctx))
 		}
 
 		if len(args) > 0 {
@@ -183,6 +170,16 @@ func Debug(ctx context.Context, fields map[string]interface{}, format string, ar
 			entry.WithFields(fields).Debugln(format)
 		}
 	}
+}
+
+// extractRequestID obtains the request ID either from a goa client or middleware
+func extractRequestID(ctx context.Context) string {
+	reqID := middleware.ContextRequestID(ctx)
+	if reqID == "" {
+		return client.ContextRequestID(ctx)
+	}
+
+	return reqID
 }
 
 func extractCallerDetails() (string, int, string, error) {

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -348,7 +348,7 @@ func createOrUpdateWorkItemLinkType(ctx context.Context, linkCatRepo *link.GormW
 		return errs.WithStack(err)
 	}
 
-	linkType, err := linkTypeRepo.LoadTypeFromDBByNameAndCategory(name, cat.ID)
+	linkType, err := linkTypeRepo.LoadTypeFromDBByNameAndCategory(ctx, name, cat.ID)
 	lt := link.WorkItemLinkType{
 		Name:           name,
 		Description:    &description,
@@ -459,7 +459,7 @@ func createOrUpdatePlannerItemExtension(typeName string, ctx context.Context, wi
 }
 
 func createOrUpdateType(typeName string, extendedTypeName *string, fields map[string]app.FieldDefinition, ctx context.Context, witr *workitem.GormWorkItemTypeRepository, db *gorm.DB) error {
-	wit, err := witr.LoadTypeFromDB(typeName)
+	wit, err := witr.LoadTypeFromDB(ctx, typeName)
 	cause := errs.Cause(err)
 	switch cause.(type) {
 	case errors.NotFoundError:
@@ -482,7 +482,7 @@ func createOrUpdateType(typeName string, extendedTypeName *string, fields map[st
 				"extendedTypeName": *extendedTypeName,
 			}, "Work item type %s extends another type %v will copy fields from the extended type", typeName, *extendedTypeName)
 
-			extendedWit, err := witr.LoadTypeFromDB(*extendedTypeName)
+			extendedWit, err := witr.LoadTypeFromDB(ctx, *extendedTypeName)
 			if err != nil {
 				return errs.WithStack(err)
 			}

--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -362,7 +362,7 @@ func (r *GormSearchRepository) SearchFullText(ctx context.Context, rawSearchStri
 	for index, value := range rows {
 		var err error
 		// FIXME: Against best practice http://go-database-sql.org/retrieving.html
-		wiType, err := r.wir.LoadTypeFromDB(value.Type)
+		wiType, err := r.wir.LoadTypeFromDB(ctx, value.Type)
 		if err != nil {
 			return nil, 0, errors.NewInternalError(err.Error())
 		}

--- a/workitem/link/type_repository.go
+++ b/workitem/link/type_repository.go
@@ -105,8 +105,8 @@ func (r *GormWorkItemLinkTypeRepository) Load(ctx context.Context, ID string) (*
 
 // LoadTypeFromDB return work item link type for the given name in the correct link category
 // NOTE: Two link types can coexist with different categoryIDs.
-func (r *GormWorkItemLinkTypeRepository) LoadTypeFromDBByNameAndCategory(name string, categoryId satoriuuid.UUID) (*WorkItemLinkType, error) {
-	log.Info(nil, map[string]interface{}{
+func (r *GormWorkItemLinkTypeRepository) LoadTypeFromDBByNameAndCategory(ctx context.Context, name string, categoryId satoriuuid.UUID) (*WorkItemLinkType, error) {
+	log.Info(ctx, map[string]interface{}{
 		"pkg":        "link",
 		"wiltName":   name,
 		"categoryId": categoryId,
@@ -115,7 +115,7 @@ func (r *GormWorkItemLinkTypeRepository) LoadTypeFromDBByNameAndCategory(name st
 	res := WorkItemLinkType{}
 	db := r.db.Model(&res).Where("name=? AND link_category_id=?", name, categoryId.String()).First(&res)
 	if db.RecordNotFound() {
-		log.Error(nil, map[string]interface{}{
+		log.Error(ctx, map[string]interface{}{
 			"wiltName":   name,
 			"categoryId": categoryId.String(),
 		}, "work item link type not found")
@@ -128,8 +128,8 @@ func (r *GormWorkItemLinkTypeRepository) LoadTypeFromDBByNameAndCategory(name st
 }
 
 // LoadTypeFromDB return work item link type for the given ID
-func (r *GormWorkItemLinkTypeRepository) LoadTypeFromDBByID(ID satoriuuid.UUID) (*WorkItemLinkType, error) {
-	log.Info(nil, map[string]interface{}{
+func (r *GormWorkItemLinkTypeRepository) LoadTypeFromDBByID(ctx context.Context, ID satoriuuid.UUID) (*WorkItemLinkType, error) {
+	log.Info(ctx, map[string]interface{}{
 		"pkg":    "link",
 		"wiltID": ID.String(),
 	}, "Loading work item link type with ID ", ID)
@@ -137,7 +137,7 @@ func (r *GormWorkItemLinkTypeRepository) LoadTypeFromDBByID(ID satoriuuid.UUID) 
 	res := WorkItemLinkType{}
 	db := r.db.Model(&res).Where("ID=?", ID.String()).First(&res)
 	if db.RecordNotFound() {
-		log.Error(nil, map[string]interface{}{
+		log.Error(ctx, map[string]interface{}{
 			"wiltID": ID.String(),
 		}, "work item link type not found")
 		return nil, errors.NewNotFoundError("work item link type", ID.String())


### PR DESCRIPTION
@aslakknutsen detected that the `req_id` value was missing in the logs for some of the operations in the repositories. This PR fixes this problem and sets request id also for the database propagation. 
