### PR TITLE
Use relative URL's rather than FQDN's for dependency services

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -79,8 +79,12 @@ token.publickey : >
 
 keycloak.client.id : fabric8-online-platform
 keycloak.secret : 08a8bcd1-f362-446a-9d2b-d34b8d464185
-keycloak.endpoint.auth : http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/auth
-keycloak.endpoint.token : http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/token
-keycloak.endpoint.userinfo : http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/userinfo
+keycloak.domain.prefix : sso
+keycloak.realm : demo
 keycloak.testuser.name : testuser
 keycloak.testuser.secret : testuser
+
+# Uncomment if FQDN URL's should be used instead of relative URL's:
+# keycloak.endpoint.auth : http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/auth
+# keycloak.endpoint.token : http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/token
+# keycloak.endpoint.userinfo : http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/userinfo

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -305,9 +305,18 @@ func getKeycloakURL(req *goa.RequestData, path string) (string, error) {
 		scheme = "https"
 	}
 	currentHost := req.Host
-	newHost, err := rest.ReplaceDomainPrefix(currentHost, GetKeycloakDomainPrefix())
-	if err != nil {
-		return "", err
+	var newHost string
+	var err error
+	if currentHost == "demo.api.almighty.io" {
+		// demo.api.almighty.io doesn't follow the service name convention <serviceName>.<domain>
+		// The correct name would be something like API.demo.almighty.io which is to be converted to SSO.demo.almighty.io
+		// So, we need to treat it as an exception
+		newHost = "sso.demo.almighty.io"
+	} else {
+		newHost, err = rest.ReplaceDomainPrefix(currentHost, GetKeycloakDomainPrefix())
+		if err != nil {
+			return "", err
+		}
 	}
 	newURL := fmt.Sprintf("%s://%s/%s", scheme, newHost, path)
 

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -42,7 +42,7 @@ func Setup(configFilePath string) error {
 	// To override nested variables through environment variables, we
 	// need to make sure that we don't have to use dots (".") inside the
 	// environment variable names.
-	// To override foo.bar you need to set ALM_FOO_BAR
+	// To override foo.bar you need to set ALMIGHTY_FOO_BAR
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 
 	viper.SetTypeByDefaultValue(true)

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -1,0 +1,56 @@
+package configuration
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"net/http"
+
+	"github.com/almighty/almighty-core/resource"
+	"github.com/goadesign/goa"
+	"github.com/stretchr/testify/assert"
+)
+
+var req *goa.RequestData
+
+func TestMain(m *testing.M) {
+	if err := Setup(""); err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+
+	req = &goa.RequestData{
+		Request: &http.Request{Host: "api.service.domain.org"},
+	}
+	os.Exit(m.Run())
+}
+
+func TestGetKeycloakEndpointAuthOK(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	t.Parallel()
+
+	url, err := GetKeycloakEndpointAuth(req)
+	assert.Nil(t, err)
+	// In dev mode it's always the defualt value regardless of the request
+	assert.Equal(t, "http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/auth", url)
+}
+
+func TestGetKeycloakEndpointTokenOK(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	t.Parallel()
+
+	url, err := GetKeycloakEndpointToken(req)
+	assert.Nil(t, err)
+	// In dev mode it's always the defualt value regardless of the request
+	assert.Equal(t, "http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/token", url)
+}
+
+func TestGetKeycloakEndpointUserInfoOK(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	t.Parallel()
+
+	url, err := GetKeycloakEndpointUserInfo(req)
+	assert.Nil(t, err)
+	// In dev mode it's always the defualt value regardless of the request
+	assert.Equal(t, "http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/userinfo", url)
+}

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -15,9 +15,7 @@ import (
 var req *goa.RequestData
 
 func TestMain(m *testing.M) {
-	if err := Setup(""); err != nil {
-		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
-	}
+	resetConfiguration()
 
 	req = &goa.RequestData{
 		Request: &http.Request{Host: "api.service.domain.org"},
@@ -25,7 +23,13 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestGetKeycloakEndpointAuthOK(t *testing.T) {
+func resetConfiguration() {
+	if err := Setup(""); err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+}
+
+func TestGetKeycloakEndpointAuthDevModeOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
 
@@ -33,6 +37,22 @@ func TestGetKeycloakEndpointAuthOK(t *testing.T) {
 	assert.Nil(t, err)
 	// In dev mode it's always the defualt value regardless of the request
 	assert.Equal(t, "http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/auth", url)
+}
+
+func TestGetKeycloakEndpointAuthSetByEnvVaribaleOK(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	env := os.Getenv("ALMIGHTY_KEYCLOAK_ENDPOINT_AUTH")
+	defer func() {
+		os.Setenv("ALMIGHTY_KEYCLOAK_ENDPOINT_AUTH", env)
+		resetConfiguration()
+	}()
+
+	os.Setenv("ALMIGHTY_KEYCLOAK_ENDPOINT_AUTH", "authEndpoint")
+	resetConfiguration()
+
+	url, err := GetKeycloakEndpointAuth(req)
+	assert.Nil(t, err)
+	assert.Equal(t, "authEndpoint", url)
 }
 
 func TestGetKeycloakEndpointTokenOK(t *testing.T) {
@@ -45,6 +65,22 @@ func TestGetKeycloakEndpointTokenOK(t *testing.T) {
 	assert.Equal(t, "http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/token", url)
 }
 
+func TestGetKeycloakEndpointTokenSetByEnvVaribaleOK(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	env := os.Getenv("ALMIGHTY_KEYCLOAK_ENDPOINT_TOKEN")
+	defer func() {
+		os.Setenv("ALMIGHTY_KEYCLOAK_ENDPOINT_TOKEN", env)
+		resetConfiguration()
+	}()
+
+	os.Setenv("ALMIGHTY_KEYCLOAK_ENDPOINT_TOKEN", "tokenEndpoint")
+	resetConfiguration()
+
+	url, err := GetKeycloakEndpointToken(req)
+	assert.Nil(t, err)
+	assert.Equal(t, "tokenEndpoint", url)
+}
+
 func TestGetKeycloakEndpointUserInfoOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
@@ -53,4 +89,20 @@ func TestGetKeycloakEndpointUserInfoOK(t *testing.T) {
 	assert.Nil(t, err)
 	// In dev mode it's always the defualt value regardless of the request
 	assert.Equal(t, "http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/userinfo", url)
+}
+
+func TestGetKeycloakEndpointUserInfoSetByEnvVaribaleOK(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	env := os.Getenv("ALMIGHTY_KEYCLOAK_ENDPOINT_USERINFO")
+	defer func() {
+		os.Setenv("ALMIGHTY_KEYCLOAK_ENDPOINT_USERINFO", env)
+		resetConfiguration()
+	}()
+
+	os.Setenv("ALMIGHTY_KEYCLOAK_ENDPOINT_USERINFO", "userinfoEndpoint")
+	resetConfiguration()
+
+	url, err := GetKeycloakEndpointUserInfo(req)
+	assert.Nil(t, err)
+	assert.Equal(t, "userinfoEndpoint", url)
 }

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -12,13 +12,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var req *goa.RequestData
+var reqLong *goa.RequestData
+var reqShort *goa.RequestData
 
 func TestMain(m *testing.M) {
 	resetConfiguration()
 
-	req = &goa.RequestData{
+	reqLong = &goa.RequestData{
 		Request: &http.Request{Host: "api.service.domain.org"},
+	}
+	reqShort = &goa.RequestData{
+		Request: &http.Request{Host: "api.domain.org"},
 	}
 	os.Exit(m.Run())
 }
@@ -33,7 +37,12 @@ func TestGetKeycloakEndpointAuthDevModeOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
 
-	url, err := GetKeycloakEndpointAuth(req)
+	url, err := GetKeycloakEndpointAuth(reqLong)
+	assert.Nil(t, err)
+	// In dev mode it's always the defualt value regardless of the request
+	assert.Equal(t, "http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/auth", url)
+
+	url, err = GetKeycloakEndpointAuth(reqShort)
 	assert.Nil(t, err)
 	// In dev mode it's always the defualt value regardless of the request
 	assert.Equal(t, "http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/auth", url)
@@ -50,7 +59,11 @@ func TestGetKeycloakEndpointAuthSetByEnvVaribaleOK(t *testing.T) {
 	os.Setenv("ALMIGHTY_KEYCLOAK_ENDPOINT_AUTH", "authEndpoint")
 	resetConfiguration()
 
-	url, err := GetKeycloakEndpointAuth(req)
+	url, err := GetKeycloakEndpointAuth(reqLong)
+	assert.Nil(t, err)
+	assert.Equal(t, "authEndpoint", url)
+
+	url, err = GetKeycloakEndpointAuth(reqShort)
 	assert.Nil(t, err)
 	assert.Equal(t, "authEndpoint", url)
 }
@@ -59,7 +72,12 @@ func TestGetKeycloakEndpointTokenOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
 
-	url, err := GetKeycloakEndpointToken(req)
+	url, err := GetKeycloakEndpointToken(reqLong)
+	assert.Nil(t, err)
+	// In dev mode it's always the defualt value regardless of the request
+	assert.Equal(t, "http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/token", url)
+
+	url, err = GetKeycloakEndpointToken(reqShort)
 	assert.Nil(t, err)
 	// In dev mode it's always the defualt value regardless of the request
 	assert.Equal(t, "http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/token", url)
@@ -76,7 +94,11 @@ func TestGetKeycloakEndpointTokenSetByEnvVaribaleOK(t *testing.T) {
 	os.Setenv("ALMIGHTY_KEYCLOAK_ENDPOINT_TOKEN", "tokenEndpoint")
 	resetConfiguration()
 
-	url, err := GetKeycloakEndpointToken(req)
+	url, err := GetKeycloakEndpointToken(reqLong)
+	assert.Nil(t, err)
+	assert.Equal(t, "tokenEndpoint", url)
+
+	url, err = GetKeycloakEndpointToken(reqShort)
 	assert.Nil(t, err)
 	assert.Equal(t, "tokenEndpoint", url)
 }
@@ -85,7 +107,12 @@ func TestGetKeycloakEndpointUserInfoOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
 
-	url, err := GetKeycloakEndpointUserInfo(req)
+	url, err := GetKeycloakEndpointUserInfo(reqLong)
+	assert.Nil(t, err)
+	// In dev mode it's always the defualt value regardless of the request
+	assert.Equal(t, "http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/userinfo", url)
+
+	url, err = GetKeycloakEndpointUserInfo(reqShort)
 	assert.Nil(t, err)
 	// In dev mode it's always the defualt value regardless of the request
 	assert.Equal(t, "http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/userinfo", url)
@@ -102,7 +129,11 @@ func TestGetKeycloakEndpointUserInfoSetByEnvVaribaleOK(t *testing.T) {
 	os.Setenv("ALMIGHTY_KEYCLOAK_ENDPOINT_USERINFO", "userinfoEndpoint")
 	resetConfiguration()
 
-	url, err := GetKeycloakEndpointUserInfo(req)
+	url, err := GetKeycloakEndpointUserInfo(reqLong)
+	assert.Nil(t, err)
+	assert.Equal(t, "userinfoEndpoint", url)
+
+	url, err = GetKeycloakEndpointUserInfo(reqShort)
 	assert.Nil(t, err)
 	assert.Equal(t, "userinfoEndpoint", url)
 }

--- a/configuration/configuration_whitebox_test.go
+++ b/configuration/configuration_whitebox_test.go
@@ -21,9 +21,13 @@ func TestGetKeycloakURLOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
 
-	url, err := getKeycloakURL(req, "somepath")
+	url, err := getKeycloakURL(reqLong, "somepath")
 	assert.Nil(t, err)
 	assert.Equal(t, "http://sso.service.domain.org/somepath", url)
+
+	url, err = getKeycloakURL(reqShort, "somepath2")
+	assert.Nil(t, err)
+	assert.Equal(t, "http://sso.domain.org/somepath2", url)
 }
 
 func TestGetKeycloakURLForTooShortHostFails(t *testing.T) {
@@ -49,7 +53,7 @@ func TestDemoApiAlmightyIoExceptionOK(t *testing.T) {
 		Request: &http.Request{Host: "demo.api.almighty.io"},
 	}
 
-	url, err := getKeycloakURL(r, "somepath")
+	url, err := getKeycloakURL(r, "somepath3")
 	assert.Nil(t, err)
-	assert.Equal(t, "http://sso.demo.almighty.io/somepath", url)
+	assert.Equal(t, "http://sso.demo.almighty.io/somepath3", url)
 }

--- a/configuration/configuration_whitebox_test.go
+++ b/configuration/configuration_whitebox_test.go
@@ -1,0 +1,38 @@
+package configuration
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/almighty/almighty-core/resource"
+	"github.com/goadesign/goa"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOpenIDConnectPathOK(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	t.Parallel()
+
+	path := openIDConnectPath("somesufix")
+	assert.Equal(t, "auth/realms/demo/protocol/openid-connect/somesufix", path)
+}
+
+func TestGetKeycloakURLOK(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	t.Parallel()
+
+	url, err := getKeycloakURL(req, "somepath")
+	assert.Nil(t, err)
+	assert.Equal(t, "http://sso.service.domain.org/somepath", url)
+}
+
+func TestGetKeycloakURLForTooShortHostFails(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	t.Parallel()
+
+	r := &goa.RequestData{
+		Request: &http.Request{Host: "org"},
+	}
+	_, err := getKeycloakURL(r, "somepath")
+	assert.NotNil(t, err)
+}

--- a/configuration/configuration_whitebox_test.go
+++ b/configuration/configuration_whitebox_test.go
@@ -36,3 +36,20 @@ func TestGetKeycloakURLForTooShortHostFails(t *testing.T) {
 	_, err := getKeycloakURL(r, "somepath")
 	assert.NotNil(t, err)
 }
+
+func TestDemoApiAlmightyIoExceptionOK(t *testing.T) {
+	// demo.api.almighty.io doesn't follow the service name convention <serviceName>.<domain>
+	// The correct name would be something like API.demo.almighty.io which is to be converted to SSO.demo.almighty.io
+	// So, it should be treated as an exception
+
+	resource.Require(t, resource.UnitTest)
+	t.Parallel()
+
+	r := &goa.RequestData{
+		Request: &http.Request{Host: "demo.api.almighty.io"},
+	}
+
+	url, err := getKeycloakURL(r, "somepath")
+	assert.Nil(t, err)
+	assert.Equal(t, "http://sso.demo.almighty.io/somepath", url)
+}

--- a/design/auth.go
+++ b/design/auth.go
@@ -16,6 +16,7 @@ var _ = a.Resource("login", func() {
 		a.Description("Authorize with the ALM")
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.TemporaryRedirect)
+		a.Response(d.InternalServerError, JSONAPIErrors)
 	})
 
 	a.Action("generate", func() {

--- a/login.go
+++ b/login.go
@@ -50,7 +50,14 @@ func (c *LoginController) Refresh(ctx *app.RefreshLoginContext) error {
 	}
 
 	client := &http.Client{Timeout: 10 * time.Second}
-	res, err := client.PostForm(configuration.GetKeycloakEndpointToken(), url.Values{
+	endpoint, err := configuration.GetKeycloakEndpointToken(ctx.RequestData)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"err": err,
+		}, "Unable to get Keycloak token endpoint URL")
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("unable to get Keycloak token endpoint URL "+err.Error()))
+	}
+	res, err := client.PostForm(endpoint, url.Values{
 		"client_id":     {configuration.GetKeycloakClientID()},
 		"client_secret": {configuration.GetKeycloakSecret()},
 		"refresh_token": {*refreshToken},
@@ -116,7 +123,16 @@ func (c *LoginController) Generate(ctx *app.GenerateLoginContext) error {
 	client := &http.Client{Timeout: 10 * time.Second}
 
 	username := configuration.GetKeycloakTestUserName()
-	res, err := client.PostForm(configuration.GetKeycloakEndpointToken(), url.Values{
+
+	endpoint, err := configuration.GetKeycloakEndpointToken(ctx.RequestData)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"err": err,
+		}, "Unable to get Keycloak token endpoint URL")
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("unable to get Keycloak token endpoint URL "+err.Error()))
+	}
+
+	res, err := client.PostForm(endpoint, url.Values{
 		"client_id":     {configuration.GetKeycloakClientID()},
 		"client_secret": {configuration.GetKeycloakSecret()},
 		"username":      {username},

--- a/login/service_blackbox_test.go
+++ b/login/service_blackbox_test.go
@@ -25,8 +25,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var db *gorm.DB
-var loginService Service
+var (
+	db           *gorm.DB
+	loginService Service
+	oauth        = &oauth2.Config{
+		ClientID:     configuration.GetKeycloakClientID(),
+		ClientSecret: configuration.GetKeycloakSecret(),
+		Scopes:       []string{"user:email"},
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  "http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/auth",
+			TokenURL: "http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/token",
+		},
+	}
+)
 
 func TestMain(m *testing.M) {
 	if _, c := os.LookupEnv(resource.Database); c != false {
@@ -47,16 +58,6 @@ func TestMain(m *testing.M) {
 			panic(err.Error())
 		}
 
-	}
-
-	oauth := &oauth2.Config{
-		ClientID:     configuration.GetKeycloakClientID(),
-		ClientSecret: configuration.GetKeycloakSecret(),
-		Scopes:       []string{"user:email"},
-		Endpoint: oauth2.Endpoint{
-			AuthURL:  "http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/auth",
-			TokenURL: "http://sso.demo.almighty.io/auth/realms/demo/protocol/openid-connect/token",
-		},
 	}
 
 	privateKey, err := token.ParsePrivateKey([]byte(token.RSAPrivateKey))
@@ -101,7 +102,8 @@ func TestKeycloakAuthorizationRedirect(t *testing.T) {
 	err = loginService.Perform(authorizeCtx)
 
 	assert.Equal(t, 307, rw.Code)
-	assert.Contains(t, rw.Header().Get("Location"), configuration.GetKeycloakEndpointAuth())
+	configuration.GetKeycloakEndpointAuth(authorizeCtx.RequestData)
+	assert.Contains(t, rw.Header().Get("Location"), oauth.Endpoint.AuthURL)
 }
 
 func TestValidOAuthAuthorizationCode(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -181,10 +181,7 @@ func main() {
 		ClientID:     configuration.GetKeycloakClientID(),
 		ClientSecret: configuration.GetKeycloakSecret(),
 		Scopes:       []string{"user:email"},
-		Endpoint: oauth2.Endpoint{
-			AuthURL:  configuration.GetKeycloakEndpointAuth(),
-			TokenURL: configuration.GetKeycloakEndpointToken(),
-		},
+		Endpoint:     oauth2.Endpoint{},
 	}
 
 	appDB := gormapplication.NewGormDB(db)

--- a/rest/url.go
+++ b/rest/url.go
@@ -2,7 +2,9 @@ package rest
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/almighty/almighty-core/errors"
 	"github.com/goadesign/goa"
 )
 
@@ -13,4 +15,13 @@ func AbsoluteURL(req *goa.RequestData, relative string) string {
 		scheme = "https"
 	}
 	return fmt.Sprintf("%s://%s%s", scheme, req.Host, relative)
+}
+
+// ReplaceDomainPrefix replaces the last name in the host by a new name. Example: api.service.domain.org -> sso.service.domain.org
+func ReplaceDomainPrefix(host string, replaceBy string) (string, error) {
+	split := strings.SplitN(host, ".", 2)
+	if len(split) < 2 {
+		return host, errors.NewBadParameterError("host", host).Expected("must contain more than one domain")
+	}
+	return replaceBy + "." + split[1], nil
 }

--- a/rest/url_blackbox_test.go
+++ b/rest/url_blackbox_test.go
@@ -1,0 +1,46 @@
+package rest
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"net/http"
+
+	"github.com/almighty/almighty-core/resource"
+	"github.com/goadesign/goa"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAbsoluteURLOK(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	t.Parallel()
+
+	req := &goa.RequestData{
+		Request: &http.Request{Host: "api.service.domain.org"},
+	}
+	// HTTP
+	url := AbsoluteURL(req, "/testpath")
+	assert.Equal(t, "http://api.service.domain.org/testpath", url)
+	req.TLS = &tls.ConnectionState{}
+
+	// HTTPS
+	url = AbsoluteURL(req, "/testpath2")
+	assert.Equal(t, "https://api.service.domain.org/testpath2", url)
+}
+
+func TestReplaceDomainPrefixOK(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	t.Parallel()
+
+	host, err := ReplaceDomainPrefix("api.service.domain.org", "sso")
+	assert.Nil(t, err)
+	assert.Equal(t, "sso.service.domain.org", host)
+}
+
+func TestReplaceDomainPrefixInTooShortHostFails(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	t.Parallel()
+
+	_, err := ReplaceDomainPrefix("org", "sso")
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
This PR switches the pre-configured FQNS keycloak URL's to relative URL's.

1. If the `keycloak.*` variables set up then they are always used.
2. If not set up then if in Dev Mode the hardcoded `sso.demo.almighty.io` is used.
3. If not set up nor in Dev Mode then the last segment of the core host name is replaced by "sso" (also configurable). Example: `api.service.domain.org` -> `sso.service.domain.org`

Fixes #775

**Please note (!!!)** that the current `demo.api.almighty.io` doesn't follow the service name convention used by this PR: `<serviceName>.<domain>`. It's should be `api.demo.almighty.io` instead to be correctly converted to `sso.demo.almighty.io`