### PR TITLE
Added identity_id to the logs for better traceability 

### DIFF
--- a/log/context.go
+++ b/log/context.go
@@ -3,14 +3,13 @@ package log
 import (
 	"context"
 
-	"github.com/pkg/errors"
-
 	tokencontext "github.com/almighty/almighty-core/login/token_context"
 
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa/client"
 	"github.com/goadesign/goa/middleware"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+  "github.com/pkg/errors"
 )
 
 // extractIdentityID obtains the identity ID out of the authentication context

--- a/log/context.go
+++ b/log/context.go
@@ -1,0 +1,43 @@
+package log
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	tokencontext "github.com/almighty/almighty-core/login/token_context"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/goadesign/goa/client"
+	"github.com/goadesign/goa/middleware"
+	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+)
+
+// extractIdentityID obtains the identity ID out of the authentication context
+func extractIdentityID(ctx context.Context) (string, error) {
+	tm := tokencontext.ReadTokenManagerFromContext(ctx)
+	if tm == nil {
+		return "", errors.New("Missing token manager")
+	}
+
+	token := goajwt.ContextJWT(ctx)
+	if token == nil {
+		return "", errors.New("Missing token")
+	}
+	id := token.Claims.(jwt.MapClaims)["sub"]
+	if id == nil {
+		return "", errors.New("Missing sub")
+	}
+
+	return id.(string), nil
+}
+
+// extractRequestID obtains the request ID either from a goa client or middleware
+func extractRequestID(ctx context.Context) string {
+	reqID := middleware.ContextRequestID(ctx)
+	if reqID == "" {
+		return client.ContextRequestID(ctx)
+	}
+
+	return reqID
+}

--- a/log/context.go
+++ b/log/context.go
@@ -1,7 +1,7 @@
 package log
 
 import (
-	"context"
+	"golang.org/x/net/context"
 
 	tokencontext "github.com/almighty/almighty-core/login/token_context"
 

--- a/log/context.go
+++ b/log/context.go
@@ -9,7 +9,7 @@ import (
 	"github.com/goadesign/goa/client"
 	"github.com/goadesign/goa/middleware"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
-  "github.com/pkg/errors"
+	"github.com/pkg/errors"
 )
 
 // extractIdentityID obtains the identity ID out of the authentication context

--- a/log/log.go
+++ b/log/log.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/goadesign/goa/client"
-	"github.com/goadesign/goa/middleware"
 	"golang.org/x/net/context"
 )
 
@@ -104,6 +102,10 @@ func Error(ctx context.Context, fields map[string]interface{}, format string, ar
 
 		if ctx != nil {
 			entry = entry.WithField("req_id", extractRequestID(ctx))
+			identity_id, err := extractIdentityID(ctx)
+			if err == nil {
+				entry = entry.WithField("identity_id", identity_id)
+			}
 		}
 
 		if len(args) > 0 {
@@ -131,6 +133,10 @@ func Warn(ctx context.Context, fields map[string]interface{}, format string, arg
 
 		if ctx != nil {
 			entry = entry.WithField("req_id", extractRequestID(ctx))
+			identity_id, err := extractIdentityID(ctx)
+			if err == nil { // Otherwise we don't use the identity_id
+				entry = entry.WithField("identity_id", identity_id)
+			}
 		}
 
 		if len(args) > 0 {
@@ -151,6 +157,10 @@ func Info(ctx context.Context, fields map[string]interface{}, format string, arg
 
 		if ctx != nil {
 			entry = entry.WithField("req_id", extractRequestID(ctx))
+			identity_id, err := extractIdentityID(ctx)
+			if err == nil { // Otherwise we don't use the identity_id
+				entry = entry.WithField("identity_id", identity_id)
+			}
 		}
 
 		if len(args) > 0 {
@@ -172,6 +182,10 @@ func Panic(ctx context.Context, fields map[string]interface{}, format string, ar
 
 		if ctx != nil {
 			entry = entry.WithField("req_id", extractRequestID(ctx))
+			identity_id, err := extractIdentityID(ctx)
+			if err == nil { // Otherwise we don't use the identity_id
+				entry = entry.WithField("identity_id", identity_id)
+			}
 		}
 
 		if len(args) > 0 {
@@ -192,6 +206,10 @@ func Debug(ctx context.Context, fields map[string]interface{}, format string, ar
 
 		if ctx != nil {
 			entry = entry.WithField("req_id", extractRequestID(ctx))
+			identity_id, err := extractIdentityID(ctx)
+			if err == nil {
+				entry = entry.WithField("identity_id", identity_id)
+			}
 		}
 
 		if len(args) > 0 {
@@ -200,16 +218,6 @@ func Debug(ctx context.Context, fields map[string]interface{}, format string, ar
 			entry.WithFields(fields).Debugln(format)
 		}
 	}
-}
-
-// extractRequestID obtains the request ID either from a goa client or middleware
-func extractRequestID(ctx context.Context) string {
-	reqID := middleware.ContextRequestID(ctx)
-	if reqID == "" {
-		return client.ContextRequestID(ctx)
-	}
-
-	return reqID
 }
 
 // extractCallerDetails gets information about the file, line and function that

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -18,8 +18,6 @@ func LogAndAssertJSON(t *testing.T, log func(), assertions func(fields logrus.Fi
 	logger.Level = logrus.DebugLevel
 	log()
 
-	Error(nil, nil, string(buffer.Bytes()))
-
 	err := json.Unmarshal(buffer.Bytes(), &fields)
 	assert.Nil(t, err)
 

--- a/login/service.go
+++ b/login/service.go
@@ -342,6 +342,7 @@ func ContextIdentity(ctx context.Context) (string, error) {
 
 		return "", errs.New("Missing token manager")
 	}
+	// As mentioned in token.go, we can now safely convert tm to a token.Manager
 	manager := tm.(token.Manager)
 	uuid, err := manager.Locate(ctx)
 	if err != nil {

--- a/login/token_context/token.go
+++ b/login/token_context/token.go
@@ -13,8 +13,9 @@ const (
 	contextTokenManagerKey contextTMKey = iota + 1
 )
 
-//ReadTokenManagerFromContext returns tokenManager from context.
-// Must have been set by ContextWithTokenManager ONLY
+// ReadTokenManagerFromContext returns an interface that encapsulates the
+// tokenManager extracted from context. This interface can be safely converted.
+// Must have been set by ContextWithTokenManager ONLY.
 func ReadTokenManagerFromContext(ctx context.Context) interface{} {
 	tm := ctx.Value(contextTokenManagerKey)
 	if tm != nil {

--- a/login/token_context/token.go
+++ b/login/token_context/token.go
@@ -1,0 +1,31 @@
+// Package token_context contains the code that extract token manager from the
+// context.
+package token_context
+
+import (
+	"context"
+)
+
+type contextTMKey int
+
+const (
+	//contextTokenManagerKey is a key that will be used to put and to get `tokenManager` from goa.context
+	contextTokenManagerKey contextTMKey = iota + 1
+)
+
+//ReadTokenManagerFromContext returns tokenManager from context.
+// Must have been set by ContextWithTokenManager ONLY
+func ReadTokenManagerFromContext(ctx context.Context) interface{} {
+	tm := ctx.Value(contextTokenManagerKey)
+	if tm != nil {
+		return tm
+	}
+	return nil
+}
+
+// ContextWithTokenManager injects tokenManager in the context for every incoming request
+// Accepts Token.Manager in order to make sure that correct object is set in the context.
+// Only other possible value is nil
+func ContextWithTokenManager(ctx context.Context, tm interface{}) context.Context {
+	return context.WithValue(ctx, contextTokenManagerKey, tm)
+}

--- a/login/token_context/token_context.go
+++ b/login/token_context/token_context.go
@@ -3,7 +3,7 @@
 package token_context
 
 import (
-	"context"
+	"golang.org/x/net/context"
 )
 
 type contextTMKey int

--- a/test/login.go
+++ b/test/login.go
@@ -4,7 +4,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/almighty/almighty-core/account"
-	"github.com/almighty/almighty-core/login"
+	tokencontext "github.com/almighty/almighty-core/login/token_context"
 	"github.com/almighty/almighty-core/token"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
@@ -26,6 +26,6 @@ func WithIdentity(ctx context.Context, ident account.Identity) context.Context {
 func ServiceAsUser(serviceName string, tm token.Manager, u account.Identity) *goa.Service {
 	svc := goa.New(serviceName)
 	svc.Context = WithIdentity(svc.Context, u)
-	svc.Context = login.ContextWithTokenManager(svc.Context, tm)
+	svc.Context = tokencontext.ContextWithTokenManager(svc.Context, tm)
 	return svc
 }

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -90,6 +90,8 @@ func (r *GormWorkItemRepository) Delete(ctx context.Context, ID string) error {
 		return errors.NewNotFoundError("work item", ID)
 	}
 
+	log.Debug(ctx, map[string]interface{}{"wiID": ID}, "Work item deleted successfully!")
+
 	return nil
 }
 
@@ -192,7 +194,15 @@ func (r *GormWorkItemRepository) Create(ctx context.Context, typeID string, fiel
 	if err = tx.Create(&wi).Error; err != nil {
 		return nil, errors.NewInternalError(err.Error())
 	}
-	return convertWorkItemModelToApp(wiType, &wi)
+
+	witem, err := convertWorkItemModelToApp(wiType, &wi)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debug(ctx, map[string]interface{}{"wiID": wi.ID}, "Work item created successfully!")
+
+	return witem, nil
 }
 
 func convertWorkItemModelToApp(wiType *WorkItemType, wi *WorkItem) (*app.WorkItem, error) {

--- a/workitem/workitemtype_repository.go
+++ b/workitem/workitemtype_repository.go
@@ -137,6 +137,9 @@ func (r *GormWorkItemTypeRepository) Create(ctx context.Context, extendedTypeNam
 	}
 
 	result := convertTypeFromModels(&created)
+
+	log.Debug(ctx, map[string]interface{}{"witName": created.Name}, "Work item type created successfully!")
+
 	return &result, nil
 }
 


### PR DESCRIPTION

I had to make some adjustments to other packages to avoid import cycles. To avoid some spaghetti code, I decided to go with this solution instead of creating interfaces here and there.

I named the property as `identity_id` similar to the other property `req_id`.