### PR TITLE
Removed unnecessary newlines

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,8 +96,8 @@ func main() {
 		db, err = gorm.Open("postgres", configuration.GetPostgresConfigString())
 		if err != nil {
 			db.Close()
-			log.Logger().Errorf("ERROR: Unable to open connection to database %v\n", err)
-			log.Logger().Infof("Retrying to connect in %v...\n", configuration.GetPostgresConnectionRetrySleep())
+			log.Logger().Errorf("ERROR: Unable to open connection to database %v", err)
+			log.Logger().Infof("Retrying to connect in %v...", configuration.GetPostgresConnectionRetrySleep())
 			time.Sleep(configuration.GetPostgresConnectionRetrySleep())
 		} else {
 			defer db.Close()


### PR DESCRIPTION
We don't want the logs to prompt `\n`
```
{"level":"error","msg":"ERROR: Unable to open connection to database dial tcp 127.0.0.1:5432: getsockopt: connection refused\n","time":"2017-02-21 01:10:21"}
{"level":"info","msg":"Retrying to connect in 1s...\n","time":"2017-02-21 01:10:21"}
```