### PR TITLE
Change the default Keycloak realm name from 'demo' to 'fabric8'

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -80,7 +80,7 @@ token.publickey : >
 keycloak.client.id : fabric8-online-platform
 keycloak.secret : 08a8bcd1-f362-446a-9d2b-d34b8d464185
 keycloak.domain.prefix : sso
-keycloak.realm : demo
+keycloak.realm : fabric8
 keycloak.testuser.name : testuser
 keycloak.testuser.secret : testuser
 

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -381,7 +381,7 @@ var defaultKeycloakClientID = "fabric8-online-platform"
 var defaultKeycloakSecret = "08a8bcd1-f362-446a-9d2b-d34b8d464185"
 
 var defaultKeycloakDomainPrefix = "sso"
-var defaultKeycloakRealm = "demo"
+var defaultKeycloakRealm = "fabric8"
 
 // Github does not allow committing actual OAuth tokens no matter how less privilege the token has
 var camouflagedAccessToken = "751e16a8b39c0985066-AccessToken-4871777f2c13b32be8550"

--- a/configuration/configuration_whitebox_test.go
+++ b/configuration/configuration_whitebox_test.go
@@ -14,7 +14,7 @@ func TestOpenIDConnectPathOK(t *testing.T) {
 	t.Parallel()
 
 	path := openIDConnectPath("somesufix")
-	assert.Equal(t, "auth/realms/demo/protocol/openid-connect/somesufix", path)
+	assert.Equal(t, "auth/realms/fabric8/protocol/openid-connect/somesufix", path)
 }
 
 func TestGetKeycloakURLOK(t *testing.T) {


### PR DESCRIPTION
With this change we don't need to pass the Keycloak realm name to the preview instance configuration. The default "fabric8" will just work.