### PR TITLE
work item count for an iteration (create/update/show/create-child).

### DIFF
--- a/iteration.go
+++ b/iteration.go
@@ -61,9 +61,11 @@ func (c *IterationController) CreateChild(ctx *app.CreateChildIterationContext) 
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
-
+		// For create, count will always be zero hence no need to query
+		// by passing empty map, UpdateIterationsWithCounts will be able to put zero values
+		wiCounts := make(map[string]workitem.WICountsPerIteration)
 		res := &app.IterationSingle{
-			Data: ConvertIteration(ctx.RequestData, &newItr),
+			Data: ConvertIteration(ctx.RequestData, &newItr, UpdateIterationsWithCounts(wiCounts)),
 		}
 		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData, app.IterationHref(res.Data.ID)))
 		return ctx.Created(res)
@@ -83,11 +85,14 @@ func (c *IterationController) Show(ctx *app.ShowIterationContext) error {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 
+		wiCounts, err := appl.WorkItems().GetCountsForIteration(ctx, c.ID)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, err)
+		}
 		res := &app.IterationSingle{}
 		res.Data = ConvertIteration(
 			ctx.RequestData,
-			c)
-
+			c, UpdateIterationsWithCounts(wiCounts))
 		return ctx.OK(res)
 	})
 }
@@ -133,9 +138,12 @@ func (c *IterationController) Update(ctx *app.UpdateIterationContext) error {
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
-
+		wiCounts, err := appl.WorkItems().GetCountsForIteration(ctx, itr.ID)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, err)
+		}
 		response := app.IterationSingle{
-			Data: ConvertIteration(ctx.RequestData, itr),
+			Data: ConvertIteration(ctx.RequestData, itr, UpdateIterationsWithCounts(wiCounts)),
 		}
 
 		return ctx.OK(&response)

--- a/iteration.go
+++ b/iteration.go
@@ -62,10 +62,10 @@ func (c *IterationController) CreateChild(ctx *app.CreateChildIterationContext) 
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 		// For create, count will always be zero hence no need to query
-		// by passing empty map, UpdateIterationsWithCounts will be able to put zero values
+		// by passing empty map, updateIterationsWithCounts will be able to put zero values
 		wiCounts := make(map[string]workitem.WICountsPerIteration)
 		res := &app.IterationSingle{
-			Data: ConvertIteration(ctx.RequestData, &newItr, UpdateIterationsWithCounts(wiCounts)),
+			Data: ConvertIteration(ctx.RequestData, &newItr, updateIterationsWithCounts(wiCounts)),
 		}
 		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData, app.IterationHref(res.Data.ID)))
 		return ctx.Created(res)
@@ -92,7 +92,7 @@ func (c *IterationController) Show(ctx *app.ShowIterationContext) error {
 		res := &app.IterationSingle{}
 		res.Data = ConvertIteration(
 			ctx.RequestData,
-			c, UpdateIterationsWithCounts(wiCounts))
+			c, updateIterationsWithCounts(wiCounts))
 		return ctx.OK(res)
 	})
 }
@@ -143,7 +143,7 @@ func (c *IterationController) Update(ctx *app.UpdateIterationContext) error {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 		response := app.IterationSingle{
-			Data: ConvertIteration(ctx.RequestData, itr, UpdateIterationsWithCounts(wiCounts)),
+			Data: ConvertIteration(ctx.RequestData, itr, updateIterationsWithCounts(wiCounts)),
 		}
 
 		return ctx.OK(&response)
@@ -241,11 +241,11 @@ func createIterationLinks(request *goa.RequestData, id interface{}) *app.Generic
 	}
 }
 
-// UpdateIterationsWithCounts accepts map of 'iterationID to a workitem.WICountsPerIteration instance'.
+// updateIterationsWithCounts accepts map of 'iterationID to a workitem.WICountsPerIteration instance'.
 // This function returns function of type IterationConvertFunc
 // Inner function is able to access `wiCounts` in closure and it is responsible
 // for adding 'closed' and 'total' count of WI in relationship's meta for every given iteration.
-func UpdateIterationsWithCounts(wiCounts map[string]workitem.WICountsPerIteration) IterationConvertFunc {
+func updateIterationsWithCounts(wiCounts map[string]workitem.WICountsPerIteration) IterationConvertFunc {
 	return func(request *goa.RequestData, itr *iteration.Iteration, appIteration *app.Iteration) {
 		var counts workitem.WICountsPerIteration
 		if _, ok := wiCounts[appIteration.ID.String()]; ok {

--- a/iteration_test.go
+++ b/iteration_test.go
@@ -181,25 +181,30 @@ func (rest *TestIterationREST) TestSuccessUpdateIterationWithWICounts() {
 	// add WI to this iteration and test counts in the response of update iteration API
 	wirepo := workitem.NewWorkItemRepository(rest.DB)
 	for i := 0; i < 4; i++ {
-		wirepo.Create(
+		wi, err := wirepo.Create(
 			context.Background(), workitem.SystemBug,
 			map[string]interface{}{
 				workitem.SystemTitle:     fmt.Sprintf("New issue #%d", i),
 				workitem.SystemState:     workitem.SystemStateNew,
 				workitem.SystemIteration: itr.ID.String(),
 			}, "xx")
+		require.NotNil(t, wi)
+		require.Nil(t, err)
 	}
 	for i := 0; i < 5; i++ {
-		wirepo.Create(
+		wi, err := wirepo.Create(
 			context.Background(), workitem.SystemBug,
 			map[string]interface{}{
 				workitem.SystemTitle:     fmt.Sprintf("Closed issue #%d", i),
 				workitem.SystemState:     workitem.SystemStateClosed,
 				workitem.SystemIteration: itr.ID.String(),
 			}, "xx")
+		require.NotNil(t, wi)
+		require.Nil(t, err)
 	}
 	svc, ctrl := rest.SecuredController()
 	_, updated := test.UpdateIterationOK(t, svc.Context, svc, ctrl, itr.ID.String(), &payload)
+	require.NotNil(t, updated)
 	assert.Equal(t, newName, *updated.Data.Attributes.Name)
 	assert.Equal(t, newDesc, *updated.Data.Attributes.Description)
 	require.NotNil(t, updated.Data.Relationships.Workitems.Meta)

--- a/iteration_test.go
+++ b/iteration_test.go
@@ -67,8 +67,12 @@ func (rest *TestIterationREST) TestSuccessCreateChildIteration() {
 
 	svc, ctrl := rest.SecuredController()
 	_, created := test.CreateChildIterationCreated(t, svc.Context, svc, ctrl, parentID.String(), ci)
+	require.NotNil(t, created)
 	assertChildIterationLinking(t, created.Data)
 	assert.Equal(t, *ci.Data.Attributes.Name, *created.Data.Attributes.Name)
+	require.NotNil(t, created.Data.Relationships.Workitems.Meta)
+	assert.Equal(t, 0, created.Data.Relationships.Workitems.Meta["total"])
+	assert.Equal(t, 0, created.Data.Relationships.Workitems.Meta["closed"])
 }
 
 func (rest *TestIterationREST) TestFailCreateChildIterationMissingName() {
@@ -114,6 +118,9 @@ func (rest *TestIterationREST) TestSuccessShowIteration() {
 	svc, ctrl := rest.SecuredController()
 	_, created := test.ShowIterationOK(t, svc.Context, svc, ctrl, itrID.ID.String())
 	assertIterationLinking(t, created.Data)
+	require.NotNil(t, created.Data.Relationships.Workitems.Meta)
+	assert.Equal(t, 0, created.Data.Relationships.Workitems.Meta["total"])
+	assert.Equal(t, 0, created.Data.Relationships.Workitems.Meta["closed"])
 }
 
 func (rest *TestIterationREST) TestFailShowIterationMissing() {
@@ -146,6 +153,9 @@ func (rest *TestIterationREST) TestSuccessUpdateIteration() {
 	_, updated := test.UpdateIterationOK(t, svc.Context, svc, ctrl, itr.ID.String(), &payload)
 	assert.Equal(t, newName, *updated.Data.Attributes.Name)
 	assert.Equal(t, newDesc, *updated.Data.Attributes.Description)
+	require.NotNil(t, updated.Data.Relationships.Workitems.Meta)
+	assert.Equal(t, 0, updated.Data.Relationships.Workitems.Meta["total"])
+	assert.Equal(t, 0, updated.Data.Relationships.Workitems.Meta["closed"])
 }
 
 func (rest *TestIterationREST) TestFailUpdateIterationNotFound() {

--- a/iteration_whitebox_test.go
+++ b/iteration_whitebox_test.go
@@ -33,7 +33,7 @@ func TestUpdateIterationsWithCounts(t *testing.T) {
 		Closed:      1,
 	}
 
-	iterationSliceWithCounts := UpdateIterationsWithCounts(counts)
+	iterationSliceWithCounts := updateIterationsWithCounts(counts)
 
 	for _, iteration := range iterationSlice {
 		appIteration := &app.Iteration{

--- a/space-iterations.go
+++ b/space-iterations.go
@@ -64,10 +64,10 @@ func (c *SpaceIterationsController) Create(ctx *app.CreateSpaceIterationsContext
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 		// For create, count will always be zero hence no need to query
-		// by passing empty map, UpdateIterationsWithCounts will be able to put zero values
+		// by passing empty map, updateIterationsWithCounts will be able to put zero values
 		wiCounts := make(map[string]workitem.WICountsPerIteration)
 		res := &app.IterationSingle{
-			Data: ConvertIteration(ctx.RequestData, &newItr, UpdateIterationsWithCounts(wiCounts)),
+			Data: ConvertIteration(ctx.RequestData, &newItr, updateIterationsWithCounts(wiCounts)),
 		}
 		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData, app.IterationHref(res.Data.ID)))
 		return ctx.Created(res)
@@ -99,7 +99,7 @@ func (c *SpaceIterationsController) List(ctx *app.ListSpaceIterationsContext) er
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 		res := &app.IterationList{}
-		res.Data = ConvertIterations(ctx.RequestData, iterations, UpdateIterationsWithCounts(wiCounts))
+		res.Data = ConvertIterations(ctx.RequestData, iterations, updateIterationsWithCounts(wiCounts))
 
 		return ctx.OK(res)
 	})

--- a/space-iterations.go
+++ b/space-iterations.go
@@ -8,6 +8,7 @@ import (
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/login"
 	"github.com/almighty/almighty-core/rest"
+	"github.com/almighty/almighty-core/workitem"
 	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
 )
@@ -62,9 +63,11 @@ func (c *SpaceIterationsController) Create(ctx *app.CreateSpaceIterationsContext
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
-
+		// For create, count will always be zero hence no need to query
+		// by passing empty map, UpdateIterationsWithCounts will be able to put zero values
+		wiCounts := make(map[string]workitem.WICountsPerIteration)
 		res := &app.IterationSingle{
-			Data: ConvertIteration(ctx.RequestData, &newItr),
+			Data: ConvertIteration(ctx.RequestData, &newItr, UpdateIterationsWithCounts(wiCounts)),
 		}
 		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData, app.IterationHref(res.Data.ID)))
 		return ctx.Created(res)

--- a/space-iterations_test.go
+++ b/space-iterations_test.go
@@ -82,6 +82,9 @@ func (rest *TestSpaceIterationREST) TestSuccessCreateIteration() {
 	require.NotNil(t, c.Data.Relationships.Space)
 	assert.Equal(t, p.ID.String(), *c.Data.Relationships.Space.Data.ID)
 	assert.Equal(t, iteration.IterationStateNew, *c.Data.Attributes.State)
+	require.NotNil(t, c.Data.Relationships.Workitems.Meta)
+	assert.Equal(t, 0, c.Data.Relationships.Workitems.Meta["total"])
+	assert.Equal(t, 0, c.Data.Relationships.Workitems.Meta["closed"])
 }
 
 func (rest *TestSpaceIterationREST) TestSuccessCreateIterationWithOptionalValues() {

--- a/test/work_item_repository.go
+++ b/test/work_item_repository.go
@@ -278,5 +278,8 @@ func (fake *WorkItemRepository) recordInvocation(key string, args []interface{})
 func (fake *WorkItemRepository) GetCountsPerIteration(ctx context.Context, spaceId uuid.UUID) (map[string]workitem.WICountsPerIteration, error) {
 	return map[string]workitem.WICountsPerIteration{}, nil
 }
+func (fake *WorkItemRepository) GetCountsForIteration(ctx context.Context, iterationId uuid.UUID) (map[string]workitem.WICountsPerIteration, error) {
+	return map[string]workitem.WICountsPerIteration{}, nil
+}
 
 var _ workitem.WorkItemRepository = new(WorkItemRepository)

--- a/workitem/undoable_wi_repo.go
+++ b/workitem/undoable_wi_repo.go
@@ -125,3 +125,7 @@ func (r *UndoableWorkItemRepository) List(ctx context.Context, criteria criteria
 func (r *UndoableWorkItemRepository) GetCountsPerIteration(ctx context.Context, spaceId uuid.UUID) (map[string]WICountsPerIteration, error) {
 	return map[string]WICountsPerIteration{}, nil
 }
+
+func (r *UndoableWorkItemRepository) GetCountsForIteration(ctx context.Context, iterationId uuid.UUID) (map[string]WICountsPerIteration, error) {
+	return map[string]WICountsPerIteration{}, nil
+}

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -5,6 +5,8 @@ import (
 
 	"golang.org/x/net/context"
 
+	"fmt"
+
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/criteria"
 	"github.com/almighty/almighty-core/errors"
@@ -23,6 +25,7 @@ type WorkItemRepository interface {
 	Create(ctx context.Context, typeID string, fields map[string]interface{}, creator string) (*app.WorkItem, error)
 	List(ctx context.Context, criteria criteria.Expression, start *int, length *int) ([]*app.WorkItem, uint64, error)
 	GetCountsPerIteration(ctx context.Context, spaceID uuid.UUID) (map[string]WICountsPerIteration, error)
+	GetCountsForIteration(ctx context.Context, iterationID uuid.UUID) (map[string]WICountsPerIteration, error)
 }
 
 // GormWorkItemRepository implements WorkItemRepository using gorm
@@ -315,7 +318,6 @@ func (r *GormWorkItemRepository) List(ctx context.Context, criteria criteria.Exp
 // 		on fields@> concat('{"system.iteration": "', iterations.id, '"}')::jsonb
 // 		WHERE (iterations.space_id = '33406de1-25f1-4969-bcec-88f29d0a7de3'
 // 		and work_items.deleted_at IS NULL) GROUP BY IterationId
-
 func (r *GormWorkItemRepository) GetCountsPerIteration(ctx context.Context, spaceID uuid.UUID) (map[string]WICountsPerIteration, error) {
 	var res []WICountsPerIteration
 	db := r.db.Table("work_items").Select(`iterations.id as IterationId, count(*) as Total,
@@ -328,6 +330,30 @@ func (r *GormWorkItemRepository) GetCountsPerIteration(ctx context.Context, spac
 	countsMap := map[string]WICountsPerIteration{}
 	for _, iterationWithCount := range res {
 		countsMap[iterationWithCount.IterationId] = iterationWithCount
+	}
+	return countsMap, nil
+}
+
+// GetCountsForIteration returns Closed and Total counts of WI for given iteration
+// It executes
+// SELECT count(*) as Total, count( case fields->>'system.state' when 'closed' then '1' else null end ) as Closed FROM "work_items" where fields@> concat('{"system.iteration": "%s"}')::jsonb and work_items.deleted_at is null
+func (r *GormWorkItemRepository) GetCountsForIteration(ctx context.Context, iterationID uuid.UUID) (map[string]WICountsPerIteration, error) {
+	var res WICountsPerIteration
+	query := fmt.Sprintf(`SELECT count(*) as Total,
+						count( case fields->>'system.state' when 'closed' then '1' else null end ) as Closed
+						FROM "work_items"
+						where fields@> concat('{"system.iteration": "%s"}')::jsonb
+						and work_items.deleted_at is null`, iterationID)
+	db := r.db.Raw(query)
+	db.Scan(&res)
+	if db.Error != nil {
+		return nil, errors.NewInternalError(db.Error.Error())
+	}
+	countsMap := map[string]WICountsPerIteration{}
+	countsMap[iterationID.String()] = WICountsPerIteration{
+		IterationId: iterationID.String(),
+		Closed:      res.Closed,
+		Total:       res.Total,
 	}
 	return countsMap, nil
 }


### PR DESCRIPTION
Related story https://github.com/fabric8io/fabric8-planner/issues/647
Allows UI to use same model as there is same response for all iteration related APIs.

Like we did in list-iterations response, need to add  WI counts in response of create/update/show/create-child iterations.
Added and modified tests around WI counts.