### PR TITLE
Handle remote work item creator's identity (#806)

### DIFF
--- a/account/identity.go
+++ b/account/identity.go
@@ -166,8 +166,8 @@ func (m *GormIdentityRepository) Create(ctx context.Context, model *Identity) er
 
 // Lookup looks for an existing identity with the given `profileURL` or creates a new one
 func (m *GormIdentityRepository) Lookup(ctx context.Context, username, profileURL, providerType string) (*Identity, error) {
-	if username == "" || profileURL == "" {
-		return nil, errors.New("Cannot lookup identity with empty username or profile URL")
+	if username == "" || profileURL == "" || providerType == "" {
+		return nil, errors.New("Cannot lookup identity with empty username, profile URL or provider type")
 	}
 	log.Debug(nil, map[string]interface{}{
 		"pkg": "account",

--- a/account/identity.go
+++ b/account/identity.go
@@ -109,6 +109,7 @@ func NewIdentityRepository(db *gorm.DB) *GormIdentityRepository {
 type IdentityRepository interface {
 	Load(ctx context.Context, id uuid.UUID) (*Identity, error)
 	Create(ctx context.Context, identity *Identity) error
+	Lookup(ctx context.Context, username, profileURL, providerType string) (*Identity, error)
 	Save(ctx context.Context, identity *Identity) error
 	Delete(ctx context.Context, id uuid.UUID) error
 	Query(funcs ...func(*gorm.DB) *gorm.DB) ([]*Identity, error)
@@ -161,6 +162,42 @@ func (m *GormIdentityRepository) Create(ctx context.Context, model *Identity) er
 	}, "Identity created!")
 
 	return nil
+}
+
+// Lookup looks for an existing identity with the given `profileURL` or creates a new one
+func (m *GormIdentityRepository) Lookup(ctx context.Context, username, profileURL, providerType string) (*Identity, error) {
+	log.Debug(nil, map[string]interface{}{
+		"pkg": "account",
+	}, "Looking for identity of user with profile URL=%s\n", profileURL)
+	// bind the assignee to an existing identity, or create a new one
+	identity, err := m.First(IdentityFilterByProfileURL(profileURL))
+	if err != nil {
+		return nil, err
+	}
+	if identity == nil {
+		// create the identity if it does not exist yet
+		log.Debug(nil, map[string]interface{}{
+			"pkg": "account",
+		}, "Creating an identity for username '%s' with profile '%s' on '%s'\n", username, profileURL, providerType)
+		identity = &Identity{
+			ProviderType: providerType,
+			Username:     username,
+			ProfileURL:   profileURL,
+		}
+		err = m.Create(context.Background(), identity)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// use existing identity
+		log.Debug(nil, map[string]interface{}{
+			"pkg": "account",
+		}, "Using existing identity with ID: %v", identity.ID.String())
+	}
+	log.Debug(nil, map[string]interface{}{
+		"pkg": "account",
+	}, "Found identity of user with profile URL=%s: %s", profileURL, identity.ID)
+	return identity, nil
 }
 
 // Save modifies a single record.

--- a/remoteworkitem/remoteworkitem.go
+++ b/remoteworkitem/remoteworkitem.go
@@ -16,24 +16,26 @@ const (
 	ProviderJira   = "jira"
 
 	// The keys in the flattened response JSON of a typical Github issue.
-	GithubTitle                 = "title"
-	GithubDescription           = "body"
-	GithubState                 = "state"
-	GithubID                    = "url"
-	GithubCreator               = "user.login"
-	GithubAssigneesLogin        = "assignees.0.login"
-	GithubAssigneesLoginPattern = "assignees.?.login"
-	GithubAssigneesURL          = "assignees.0.url"
-	GithubAssigneesURLPattern   = "assignees.?.url"
+	GithubTitle                      = "title"
+	GithubDescription                = "body"
+	GithubState                      = "state"
+	GithubID                         = "url"
+	GithubCreatorLogin               = "user.login"
+	GithubCreatorProfileURL          = "user.url"
+	GithubAssigneesLogin             = "assignees.0.login"
+	GithubAssigneesLoginPattern      = "assignees.?.login"
+	GithubAssigneesProfileURL        = "assignees.0.url"
+	GithubAssigneesProfileURLPattern = "assignees.?.url"
 
 	// The keys in the flattened response JSON of a typical Jira issue.
-	JiraTitle         = "fields.summary"
-	JiraBody          = "fields.description"
-	JiraState         = "fields.status.name"
-	JiraID            = "self"
-	JiraCreator       = "fields.creator.key"
-	JiraAssigneeLogin = "fields.assignee.key"
-	JiraAssigneeURL   = "fields.assignee.self"
+	JiraTitle              = "fields.summary"
+	JiraBody               = "fields.description"
+	JiraState              = "fields.status.name"
+	JiraID                 = "self"
+	JiraCreatorLogin       = "fields.creator.key"
+	JiraCreatorProfileURL  = "fields.creator.self"
+	JiraAssigneeLogin      = "fields.assignee.key"
+	JiraAssigneeProfileURL = "fields.assignee.self"
 )
 
 // RemoteWorkItem a temporary structure that holds the relevant field values retrieved from a remote work item
@@ -51,7 +53,8 @@ const (
 	remoteDescription         = workitem.SystemDescription
 	remoteState               = workitem.SystemState
 	remoteItemID              = workitem.SystemRemoteItemID
-	remoteCreator             = workitem.SystemCreator
+	remoteCreatorLogin        = "system.creator.login"
+	remoteCreatorProfileURL   = "system.creator.profile_url"
 	remoteAssigneeLogins      = "system.assignees.login"
 	remoteAssigneeProfileURLs = "system.assignees.profile_url"
 )
@@ -59,22 +62,24 @@ const (
 // RemoteWorkItemKeyMaps relate remote attribute keys to internal representation
 var RemoteWorkItemKeyMaps = map[string]RemoteWorkItemMap{
 	ProviderGithub: {
-		AttributeMapper{AttributeExpression(GithubTitle), StringConverter{}}:                                                     remoteTitle,
-		AttributeMapper{AttributeExpression(GithubDescription), MarkupConverter{markup: rendering.SystemMarkupMarkdown}}:         remoteDescription,
-		AttributeMapper{AttributeExpression(GithubState), GithubStateConverter{}}:                                                remoteState,
-		AttributeMapper{AttributeExpression(GithubID), StringConverter{}}:                                                        remoteItemID,
-		AttributeMapper{AttributeExpression(GithubCreator), StringConverter{}}:                                                   remoteCreator,
-		AttributeMapper{AttributeExpression(GithubAssigneesLogin), PatternToListConverter{pattern: GithubAssigneesLoginPattern}}: remoteAssigneeLogins,
-		AttributeMapper{AttributeExpression(GithubAssigneesURL), PatternToListConverter{pattern: GithubAssigneesURLPattern}}:     remoteAssigneeProfileURLs,
+		AttributeMapper{AttributeExpression(GithubTitle), StringConverter{}}:                                                               remoteTitle,
+		AttributeMapper{AttributeExpression(GithubDescription), MarkupConverter{markup: rendering.SystemMarkupMarkdown}}:                   remoteDescription,
+		AttributeMapper{AttributeExpression(GithubState), GithubStateConverter{}}:                                                          remoteState,
+		AttributeMapper{AttributeExpression(GithubID), StringConverter{}}:                                                                  remoteItemID,
+		AttributeMapper{AttributeExpression(GithubCreatorLogin), StringConverter{}}:                                                        remoteCreatorLogin,
+		AttributeMapper{AttributeExpression(GithubCreatorProfileURL), StringConverter{}}:                                                   remoteCreatorProfileURL,
+		AttributeMapper{AttributeExpression(GithubAssigneesLogin), PatternToListConverter{pattern: GithubAssigneesLoginPattern}}:           remoteAssigneeLogins,
+		AttributeMapper{AttributeExpression(GithubAssigneesProfileURL), PatternToListConverter{pattern: GithubAssigneesProfileURLPattern}}: remoteAssigneeProfileURLs,
 	},
 	ProviderJira: {
 		AttributeMapper{AttributeExpression(JiraTitle), StringConverter{}}:                                      remoteTitle,
 		AttributeMapper{AttributeExpression(JiraBody), MarkupConverter{markup: rendering.SystemMarkupJiraWiki}}: remoteDescription,
 		AttributeMapper{AttributeExpression(JiraState), JiraStateConverter{}}:                                   remoteState,
 		AttributeMapper{AttributeExpression(JiraID), StringConverter{}}:                                         remoteItemID,
-		AttributeMapper{AttributeExpression(JiraCreator), StringConverter{}}:                                    remoteCreator,
+		AttributeMapper{AttributeExpression(JiraCreatorLogin), StringConverter{}}:                               remoteCreatorLogin,
+		AttributeMapper{AttributeExpression(JiraCreatorProfileURL), StringConverter{}}:                          remoteCreatorProfileURL,
 		AttributeMapper{AttributeExpression(JiraAssigneeLogin), ListConverter{}}:                                remoteAssigneeLogins,
-		AttributeMapper{AttributeExpression(JiraAssigneeURL), ListConverter{}}:                                  remoteAssigneeProfileURLs,
+		AttributeMapper{AttributeExpression(JiraAssigneeProfileURL), ListConverter{}}:                           remoteAssigneeProfileURLs,
 	},
 }
 

--- a/remoteworkitem/remoteworkitem_test.go
+++ b/remoteworkitem/remoteworkitem_test.go
@@ -165,7 +165,7 @@ func TestFlattenGithubResponseMapWithoutAssignee(t *testing.T) {
 	// when/then
 	for _, data := range gitData {
 		// skipping assignees login and URL since the test data contain no assignee
-		doTestFlattenResponseMap(t, data, ProviderGithub, GithubAssigneesLogin, GithubAssigneesURL)
+		doTestFlattenResponseMap(t, data, ProviderGithub, GithubAssigneesLogin, GithubAssigneesProfileURL)
 	}
 }
 
@@ -184,7 +184,7 @@ func TestFlattenJiraResponseMapWithoutAssignee(t *testing.T) {
 
 	for _, data := range jir {
 		// skipping assignee login and URL since the test data contain no assignee
-		doTestFlattenResponseMap(t, data, ProviderJira, JiraAssigneeLogin, JiraAssigneeURL)
+		doTestFlattenResponseMap(t, data, ProviderJira, JiraAssigneeLogin, JiraAssigneeProfileURL)
 	}
 }
 
@@ -363,7 +363,7 @@ func TestListConverter(t *testing.T) {
 	content := make(map[string]interface{})
 	content[JiraState] = "open"
 	content[JiraAssigneeLogin] = "foo0"
-	content[JiraAssigneeURL] = "/foo/1"
+	content[JiraAssigneeProfileURL] = "/foo/1"
 	workItem := TestWorkItem{
 		content: content,
 	}
@@ -375,7 +375,7 @@ func TestListConverter(t *testing.T) {
 	require.NotNil(t, result.Fields[remoteAssigneeLogins])
 	assert.Contains(t, result.Fields[remoteAssigneeLogins], content[JiraAssigneeLogin])
 	require.NotNil(t, result.Fields[remoteAssigneeProfileURLs])
-	assert.Contains(t, result.Fields[remoteAssigneeProfileURLs], content[JiraAssigneeURL])
+	assert.Contains(t, result.Fields[remoteAssigneeProfileURLs], content[JiraAssigneeProfileURL])
 }
 
 func TestListConverterWithNoValue(t *testing.T) {

--- a/remoteworkitem/trackeritem_repository.go
+++ b/remoteworkitem/trackeritem_repository.go
@@ -78,6 +78,7 @@ func lookupIdentities(db *gorm.DB, remoteWorkItem RemoteWorkItem, providerType s
 			creatorProfileURL := remoteWorkItem.Fields[remoteCreatorProfileURL].(string)
 			identity, err := identityRepository.Lookup(context.Background(), creatorLogin, creatorProfileURL, providerType)
 			if err != nil {
+				return nil, errors.Wrap(err, "failed to create identity during lookup")
 				return nil, err
 			}
 			// associate the identities to the work item

--- a/remoteworkitem/trackeritem_repository.go
+++ b/remoteworkitem/trackeritem_repository.go
@@ -87,7 +87,7 @@ func lookupIdentities(db *gorm.DB, remoteWorkItem RemoteWorkItem, providerType s
 			// ignore here, it is being processed above
 		} else
 		// assignees
-		if fieldName == remoteAssigneeProfileURLs {
+		if fieldName == remoteAssigneeLogins {
 			if fieldValue == nil {
 				workItem.Fields[workitem.SystemAssignees] = make([]string, 0)
 				continue

--- a/remoteworkitem/trackeritem_repository_test.go
+++ b/remoteworkitem/trackeritem_repository_test.go
@@ -21,7 +21,7 @@ import (
 // a normal test function that will kick off TestSuiteTrackerItemRepository
 func TestSuiteTrackerItemRepository(t *testing.T) {
 	resource.Require(t, resource.Database)
-	suite.Run(t, &TrackerItemRepositorySuite{DBTestSuite: gormsupport.NewDBTestSuite("/Users/xcoulon/code/go/src/github.com/almighty/almighty-core/config.yaml")})
+	suite.Run(t, &TrackerItemRepositorySuite{DBTestSuite: gormsupport.NewDBTestSuite("../config.yaml")})
 }
 
 // ========== TrackeItemRepositorySuite struct that implements SetupSuite, TearDownSuite, SetupTest, TearDownTest ==========

--- a/remoteworkitem/trackeritem_repository_test.go
+++ b/remoteworkitem/trackeritem_repository_test.go
@@ -121,7 +121,7 @@ func (s *TrackerItemRepositorySuite) TestConvertNewWorkItemWithUnknownIdentities
 					"state": "closed",
 					"body": "body of issue",
 					"user": {
-						"login": "sbose78",
+						"login": "jdoe0",
 						"url": "https://api.github.com/users/jdoe0"
 					},
 					"assignees": [
@@ -157,7 +157,11 @@ func (s *TrackerItemRepositorySuite) TestConvertNewWorkItemWithUnknownIdentities
 	require.NotEmpty(s.T(), workItem.Fields[workitem.SystemAssignees])
 	identityIDs := workItem.Fields[workitem.SystemAssignees].([]interface{})
 	for _, identityID := range identityIDs {
-		assert.NotNil(s.T(), s.lookupIdentityByID(identityID.(string)))
+		identity := s.lookupIdentityByID(identityID.(string))
+		require.NotNil(s.T(), identity)
+		assert.Contains(s.T(), identity.Username, "jdoe")
+		assert.NotContains(s.T(), identity.Username, "https://api.github.com/users/jdoe")
+		assert.Contains(s.T(), identity.ProfileURL, "https://api.github.com/users/jdoe")
 	}
 }
 

--- a/user_test.go
+++ b/user_test.go
@@ -102,6 +102,11 @@ func (m TestIdentityRepository) Create(ctx context.Context, model *account.Ident
 	return nil
 }
 
+// Lookup looks up a record or creates a new one.
+func (m TestIdentityRepository) Lookup(ctx context.Context, username, profileURL, providerType string) (*account.Identity, error) {
+	return nil, nil
+}
+
 // Save modifies a single record.
 func (m TestIdentityRepository) Save(ctx context.Context, model *account.Identity) error {
 	return m.Create(ctx, model)


### PR DESCRIPTION
Applied same logic as in #756 by looking-up the identity of the
remote work item creator (or creating a new one) based on the
profile URL provided in by the remote service (GitHub or JIRA)

Fixes #806

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

