### PR TITLE
Modify the unique index on `identities` table (#863)

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -185,6 +185,9 @@ func getMigrations() migrations {
 	// Version 29
 	m = append(m, steps{executeSQLFile("029-identities-foreign-key.sql")})
 
+	// Version 30
+	m = append(m, steps{executeSQLFile("030-indentities-unique-index.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/030-indentities-unique-index.sql
+++ b/migration/sql-files/030-indentities-unique-index.sql
@@ -1,0 +1,3 @@
+-- replace the unique index on `profile_url` with a check on 'DELETED_AT' to support soft deletes.
+DROP INDEX uix_identity_profileurl;
+CREATE UNIQUE INDEX uix_identity_profileurl ON identities USING btree (profile_url) WHERE deleted_at IS NULL;


### PR DESCRIPTION
Replaced the unique index by adding a check on 'deleted_at' to
support soft deletes performed by GORM.

Fixes #863

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

