### PR TITLE
`ContextIdentity(context.Context)` function should return `(*uuid.UUID…D, error)` (#866)

### DIFF
--- a/comments.go
+++ b/comments.go
@@ -56,7 +56,7 @@ func (c *CommentsController) Update(ctx *app.UpdateCommentsContext) error {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 
-		if identity != cm.CreatedBy.String() {
+		if *identity != cm.CreatedBy {
 			// need to use the goa.NewErrorClass() func as there is no native support for 403 in goa
 			// and it is not planned to be supported yet: https://github.com/goadesign/goa/pull/1030
 			return jsonapi.JSONErrorResponse(ctx, goa.NewErrorClass("forbidden", 403)("User is not the comment author"))
@@ -88,7 +88,7 @@ func (c *CommentsController) Delete(ctx *app.DeleteCommentsContext) error {
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
-		if identity != cm.CreatedBy.String() {
+		if *identity != cm.CreatedBy {
 			// need to use the goa.NewErrorClass() func as there is no native support for 403 in goa
 			// and it is not planned to be supported yet: https://github.com/goadesign/goa/pull/1030
 			return jsonapi.JSONErrorResponse(ctx, goa.NewErrorClass("forbidden", 403)("User is not the comment author"))

--- a/comments.go
+++ b/comments.go
@@ -45,7 +45,7 @@ func (c *CommentsController) Show(ctx *app.ShowCommentsContext) error {
 
 // Update does PATCH comment
 func (c *CommentsController) Update(ctx *app.UpdateCommentsContext) error {
-	identity, err := login.ContextIdentity(ctx)
+	identityID, err := login.ContextIdentity(ctx)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(err.Error()))
 	}
@@ -56,7 +56,7 @@ func (c *CommentsController) Update(ctx *app.UpdateCommentsContext) error {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 
-		if *identity != cm.CreatedBy {
+		if *identityID != cm.CreatedBy {
 			// need to use the goa.NewErrorClass() func as there is no native support for 403 in goa
 			// and it is not planned to be supported yet: https://github.com/goadesign/goa/pull/1030
 			return jsonapi.JSONErrorResponse(ctx, goa.NewErrorClass("forbidden", 403)("User is not the comment author"))
@@ -78,7 +78,7 @@ func (c *CommentsController) Update(ctx *app.UpdateCommentsContext) error {
 
 // Delete does DELETE comment
 func (c *CommentsController) Delete(ctx *app.DeleteCommentsContext) error {
-	identity, err := login.ContextIdentity(ctx)
+	identityID, err := login.ContextIdentity(ctx)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(err.Error()))
 	}
@@ -88,7 +88,7 @@ func (c *CommentsController) Delete(ctx *app.DeleteCommentsContext) error {
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
-		if *identity != cm.CreatedBy {
+		if *identityID != cm.CreatedBy {
 			// need to use the goa.NewErrorClass() func as there is no native support for 403 in goa
 			// and it is not planned to be supported yet: https://github.com/goadesign/goa/pull/1030
 			return jsonapi.JSONErrorResponse(ctx, goa.NewErrorClass("forbidden", 403)("User is not the comment author"))

--- a/iteration_test.go
+++ b/iteration_test.go
@@ -192,7 +192,7 @@ func (rest *TestIterationREST) TestSuccessUpdateIterationWithWICounts() {
 				workitem.SystemTitle:     fmt.Sprintf("New issue #%d", i),
 				workitem.SystemState:     workitem.SystemStateNew,
 				workitem.SystemIteration: itr.ID.String(),
-			}, "xx")
+			}, uuid.NewV4())
 		require.NotNil(t, wi)
 		require.Nil(t, err)
 	}
@@ -203,7 +203,7 @@ func (rest *TestIterationREST) TestSuccessUpdateIterationWithWICounts() {
 				workitem.SystemTitle:     fmt.Sprintf("Closed issue #%d", i),
 				workitem.SystemState:     workitem.SystemStateClosed,
 				workitem.SystemIteration: itr.ID.String(),
-			}, "xx")
+			}, uuid.NewV4())
 		require.NotNil(t, wi)
 		require.Nil(t, err)
 	}

--- a/login/service.go
+++ b/login/service.go
@@ -348,14 +348,14 @@ func fillUser(claims *keycloakTokenClaims, user *account.User) error {
 
 // ContextIdentity returns the identity's ID found in given context
 // Uses tokenManager.Locate to fetch the identity of currently logged in user
-func ContextIdentity(ctx context.Context) (string, error) {
+func ContextIdentity(ctx context.Context) (*uuid.UUID, error) {
 	tm := tokencontext.ReadTokenManagerFromContext(ctx)
 	if tm == nil {
 		log.Error(ctx, map[string]interface{}{
 			"token": tm,
 		}, "missing token manager")
 
-		return "", errs.New("Missing token manager")
+		return nil, errs.New("Missing token manager")
 	}
 	// As mentioned in token.go, we can now safely convert tm to a token.Manager
 	manager := tm.(token.Manager)
@@ -368,9 +368,9 @@ func ContextIdentity(ctx context.Context) (string, error) {
 			"err":          err,
 		}, "identity belongs to a Guest User")
 
-		return "", errs.WithStack(err)
+		return nil, errs.WithStack(err)
 	}
-	return uuid.String(), nil
+	return &uuid, nil
 }
 
 // InjectTokenManager is a middleware responsible for setting up tokenManager in the context for every request.

--- a/remoteworkitem/trackeritem_repository.go
+++ b/remoteworkitem/trackeritem_repository.go
@@ -12,6 +12,7 @@ import (
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
+	uuid "github.com/satori/go.uuid"
 )
 
 // upload imports the items into database
@@ -147,9 +148,11 @@ func upsert(db *gorm.DB, workItem app.WorkItem) (*app.WorkItem, error) {
 			"pkg": "remoteworkitem",
 		}, "Workitem does not exist, will be created")
 		c := workItem.Fields[workitem.SystemCreator]
-		var creator string
+		var creator uuid.UUID
 		if c != nil {
-			creator = c.(string)
+			if creator, err = uuid.FromString(c.(string)); err != nil {
+				return nil, errors.Wrapf(err, "Failed to convert creator id into a UUID: %s", err.Error())
+			}
 		}
 		resultWorkItem, err = wir.Create(context.Background(), workitem.SystemBug, workItem.Fields, creator)
 		if err != nil {

--- a/search/search_repository_blackbox_test.go
+++ b/search/search_repository_blackbox_test.go
@@ -78,14 +78,14 @@ func (s *searchRepositoryBlackboxTest) TestRestrictByType() {
 	wi1, err := wiRepo.Create(ctx, "sub1", map[string]interface{}{
 		workitem.SystemTitle: "Test TestRestrictByType",
 		workitem.SystemState: "closed",
-	}, testsupport.TestIdentity.ID.String())
+	}, testsupport.TestIdentity.ID)
 	require.NotNil(s.T(), wi1)
 	require.Nil(s.T(), err)
 
 	wi2, err := wiRepo.Create(ctx, "subtwo", map[string]interface{}{
 		workitem.SystemTitle: "Test TestRestrictByType 2",
 		workitem.SystemState: "closed",
-	}, testsupport.TestIdentity.ID.String())
+	}, testsupport.TestIdentity.ID)
 	require.NotNil(s.T(), wi2)
 	require.Nil(s.T(), err)
 

--- a/search/search_repository_whitebox_test.go
+++ b/search/search_repository_whitebox_test.go
@@ -154,7 +154,7 @@ func (s *searchRepositoryWhiteboxTest) TestSearchByText() {
 			minimumResults := testData.minimumResults
 			workItemURLInSearchString := "http://demo.almighty.io/work-item/list/detail/"
 
-			createdWorkItem, err := wir.Create(context.Background(), workitem.SystemBug, workItem.Fields, testsupport.TestIdentity.ID.String())
+			createdWorkItem, err := wir.Create(context.Background(), workitem.SystemBug, workItem.Fields, testsupport.TestIdentity.ID)
 			if err != nil {
 				s.T().Fatal("Couldnt create test data")
 			}
@@ -255,7 +255,7 @@ func (s *searchRepositoryWhiteboxTest) TestSearchByID() {
 			workitem.SystemState:       "closed",
 		}
 
-		createdWorkItem, err := wir.Create(context.Background(), workitem.SystemBug, workItem.Fields, testsupport.TestIdentity.ID.String())
+		createdWorkItem, err := wir.Create(context.Background(), workitem.SystemBug, workItem.Fields, testsupport.TestIdentity.ID)
 		if err != nil {
 			s.T().Fatalf("Couldn't create test data: %+v", err)
 		}
@@ -265,7 +265,7 @@ func (s *searchRepositoryWhiteboxTest) TestSearchByID() {
 		// up in search results
 
 		workItem.Fields[workitem.SystemTitle] = "Search test sbose " + createdWorkItem.ID
-		_, err = wir.Create(context.Background(), workitem.SystemBug, workItem.Fields, testsupport.TestIdentity.ID.String())
+		_, err = wir.Create(context.Background(), workitem.SystemBug, workItem.Fields, testsupport.TestIdentity.ID)
 		if err != nil {
 			s.T().Fatalf("Couldn't create test data: %+v", err)
 		}

--- a/search_blackbox_test.go
+++ b/search_blackbox_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/goadesign/goa"
 	"github.com/goadesign/goa/goatest"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
@@ -49,7 +50,7 @@ func TestSearch(t *testing.T) {
 			workitem.SystemCreator:     "baijum",
 			workitem.SystemState:       workitem.SystemStateClosed,
 		},
-		"")
+		uuid.NewV4())
 	require.Nil(t, err)
 	controller := NewSearchController(service, gormapplication.NewGormDB(DB))
 	q := "specialwordforsearch"
@@ -75,7 +76,7 @@ func TestSearchPagination(t *testing.T) {
 			workitem.SystemCreator:     "baijum",
 			workitem.SystemState:       workitem.SystemStateClosed,
 		},
-		"")
+		uuid.NewV4())
 	require.Nil(t, err)
 
 	controller := NewSearchController(service, gormapplication.NewGormDB(DB))
@@ -105,7 +106,7 @@ func TestSearchWithEmptyValue(t *testing.T) {
 			workitem.SystemCreator:     "baijum",
 			workitem.SystemState:       workitem.SystemStateClosed,
 		},
-		"")
+		uuid.NewV4())
 	require.Nil(t, err)
 
 	controller := NewSearchController(service, gormapplication.NewGormDB(DB))
@@ -131,7 +132,7 @@ func TestSearchWithDomainPortCombination(t *testing.T) {
 			workitem.SystemDescription: expectedDescription,
 			workitem.SystemCreator:     "baijum", workitem.SystemState: workitem.SystemStateClosed,
 		},
-		"")
+		uuid.NewV4())
 	require.Nil(t, err)
 
 	controller := NewSearchController(service, gormapplication.NewGormDB(DB))
@@ -159,7 +160,7 @@ func TestSearchURLWithoutPort(t *testing.T) {
 			workitem.SystemCreator:     "baijum",
 			workitem.SystemState:       workitem.SystemStateClosed,
 		},
-		"")
+		uuid.NewV4())
 	require.Nil(t, err)
 
 	controller := NewSearchController(service, gormapplication.NewGormDB(DB))
@@ -187,7 +188,7 @@ func TestUnregisteredURLWithPort(t *testing.T) {
 			workitem.SystemCreator:     "baijum",
 			workitem.SystemState:       workitem.SystemStateClosed,
 		},
-		"")
+		uuid.NewV4())
 	require.Nil(t, err)
 
 	controller := NewSearchController(service, gormapplication.NewGormDB(DB))
@@ -215,7 +216,7 @@ func TestUnwantedCharactersRelatedToSearchLogic(t *testing.T) {
 			workitem.SystemCreator:     "baijum",
 			workitem.SystemState:       workitem.SystemStateClosed,
 		},
-		"")
+		uuid.NewV4())
 	require.Nil(t, err)
 
 	controller := NewSearchController(service, gormapplication.NewGormDB(DB))

--- a/space-areas.go
+++ b/space-areas.go
@@ -25,7 +25,6 @@ func NewSpaceAreasController(service *goa.Service, db application.DB) *SpaceArea
 
 // Create runs the create action.
 func (c *SpaceAreasController) Create(ctx *app.CreateSpaceAreasContext) error {
-
 	_, err := login.ContextIdentity(ctx)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(err.Error()))

--- a/space-iterations_test.go
+++ b/space-iterations_test.go
@@ -272,7 +272,7 @@ func (rest *TestSpaceIterationREST) TestWICountsWithIterationListBySpace() {
 				workitem.SystemTitle:     fmt.Sprintf("New issue #%d", i),
 				workitem.SystemState:     workitem.SystemStateNew,
 				workitem.SystemIteration: iteration1.ID.String(),
-			}, "xx")
+			}, uuid.NewV4())
 	}
 	for i := 0; i < 2; i++ {
 		wirepo.Create(
@@ -281,7 +281,7 @@ func (rest *TestSpaceIterationREST) TestWICountsWithIterationListBySpace() {
 				workitem.SystemTitle:     fmt.Sprintf("Closed issue #%d", i),
 				workitem.SystemState:     workitem.SystemStateClosed,
 				workitem.SystemIteration: iteration1.ID.String(),
-			}, "xx")
+			}, uuid.NewV4())
 	}
 	svc, ctrl := rest.UnSecuredController()
 	_, cs := test.ListSpaceIterationsOK(t, svc.Context, svc, ctrl, spaceInstance.ID.String())
@@ -303,7 +303,7 @@ func (rest *TestSpaceIterationREST) TestWICountsWithIterationListBySpace() {
 				workitem.SystemTitle:     fmt.Sprintf("New issue #%d", i),
 				workitem.SystemState:     workitem.SystemStateNew,
 				workitem.SystemIteration: iteration2.ID.String(),
-			}, "xx")
+			}, uuid.NewV4())
 	}
 	_, cs = test.ListSpaceIterationsOK(t, svc.Context, svc, ctrl, spaceInstance.ID.String())
 	assert.Len(t, cs.Data, 2)

--- a/test/work_item_repository.go
+++ b/test/work_item_repository.go
@@ -41,13 +41,13 @@ type WorkItemRepository struct {
 	deleteReturns struct {
 		result1 error
 	}
-	CreateStub        func(ctx context.Context, typeID string, fields map[string]interface{}, creator string) (*app.WorkItem, error)
+	CreateStub        func(ctx context.Context, typeID string, fields map[string]interface{}, creator uuid.UUID) (*app.WorkItem, error)
 	createMutex       sync.RWMutex
 	createArgsForCall []struct {
 		ctx     context.Context
 		typeID  string
 		fields  map[string]interface{}
-		creator string
+		creator uuid.UUID
 	}
 	createReturns struct {
 		result1 *app.WorkItem
@@ -74,6 +74,26 @@ type WorkItemRepository struct {
 	}
 	fetchReturns struct {
 		result1 *app.WorkItem
+		result2 error
+	}
+	GetCountsPerIterationStub        func(ctx context.Context, spaceID uuid.UUID) (map[string]workitem.WICountsPerIteration, error)
+	getCountsPerIterationMutex       sync.RWMutex
+	getCountsPerIterationArgsForCall []struct {
+		ctx     context.Context
+		spaceID uuid.UUID
+	}
+	getCountsPerIterationReturns struct {
+		result1 map[string]workitem.WICountsPerIteration
+		result2 error
+	}
+	GetCountsForIterationStub        func(ctx context.Context, iterationID uuid.UUID) (map[string]workitem.WICountsPerIteration, error)
+	getCountsForIterationMutex       sync.RWMutex
+	getCountsForIterationArgsForCall []struct {
+		ctx         context.Context
+		iterationID uuid.UUID
+	}
+	getCountsForIterationReturns struct {
+		result1 map[string]workitem.WICountsPerIteration
 		result2 error
 	}
 	invocations      map[string][][]interface{}
@@ -181,13 +201,13 @@ func (fake *WorkItemRepository) DeleteReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *WorkItemRepository) Create(ctx context.Context, typeID string, fields map[string]interface{}, creator string) (*app.WorkItem, error) {
+func (fake *WorkItemRepository) Create(ctx context.Context, typeID string, fields map[string]interface{}, creator uuid.UUID) (*app.WorkItem, error) {
 	fake.createMutex.Lock()
 	fake.createArgsForCall = append(fake.createArgsForCall, struct {
 		ctx     context.Context
 		typeID  string
 		fields  map[string]interface{}
-		creator string
+		creator uuid.UUID
 	}{ctx, typeID, fields, creator})
 	fake.recordInvocation("Create", []interface{}{ctx, typeID, fields, creator})
 	fake.createMutex.Unlock()
@@ -203,7 +223,7 @@ func (fake *WorkItemRepository) CreateCallCount() int {
 	return len(fake.createArgsForCall)
 }
 
-func (fake *WorkItemRepository) CreateArgsForCall(i int) (context.Context, string, map[string]interface{}, string) {
+func (fake *WorkItemRepository) CreateArgsForCall(i int) (context.Context, string, map[string]interface{}, uuid.UUID) {
 	fake.createMutex.RLock()
 	defer fake.createMutex.RUnlock()
 	return fake.createArgsForCall[i].ctx, fake.createArgsForCall[i].typeID, fake.createArgsForCall[i].fields, fake.createArgsForCall[i].creator
@@ -288,6 +308,74 @@ func (fake *WorkItemRepository) FetchReturns(result1 *app.WorkItem, result2 erro
 	}{result1, result2}
 }
 
+func (fake *WorkItemRepository) GetCountsPerIteration(ctx context.Context, spaceID uuid.UUID) (map[string]workitem.WICountsPerIteration, error) {
+	fake.getCountsPerIterationMutex.Lock()
+	fake.getCountsPerIterationArgsForCall = append(fake.getCountsPerIterationArgsForCall, struct {
+		ctx     context.Context
+		spaceID uuid.UUID
+	}{ctx, spaceID})
+	fake.recordInvocation("GetCountsPerIteration", []interface{}{ctx, spaceID})
+	fake.getCountsPerIterationMutex.Unlock()
+	if fake.GetCountsPerIterationStub != nil {
+		return fake.GetCountsPerIterationStub(ctx, spaceID)
+	}
+	return fake.getCountsPerIterationReturns.result1, fake.getCountsPerIterationReturns.result2
+}
+
+func (fake *WorkItemRepository) GetCountsPerIterationCallCount() int {
+	fake.getCountsPerIterationMutex.RLock()
+	defer fake.getCountsPerIterationMutex.RUnlock()
+	return len(fake.getCountsPerIterationArgsForCall)
+}
+
+func (fake *WorkItemRepository) GetCountsPerIterationArgsForCall(i int) (context.Context, uuid.UUID) {
+	fake.getCountsPerIterationMutex.RLock()
+	defer fake.getCountsPerIterationMutex.RUnlock()
+	return fake.getCountsPerIterationArgsForCall[i].ctx, fake.getCountsPerIterationArgsForCall[i].spaceID
+}
+
+func (fake *WorkItemRepository) GetCountsPerIterationReturns(result1 map[string]workitem.WICountsPerIteration, result2 error) {
+	fake.GetCountsPerIterationStub = nil
+	fake.getCountsPerIterationReturns = struct {
+		result1 map[string]workitem.WICountsPerIteration
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *WorkItemRepository) GetCountsForIteration(ctx context.Context, iterationID uuid.UUID) (map[string]workitem.WICountsPerIteration, error) {
+	fake.getCountsForIterationMutex.Lock()
+	fake.getCountsForIterationArgsForCall = append(fake.getCountsForIterationArgsForCall, struct {
+		ctx         context.Context
+		iterationID uuid.UUID
+	}{ctx, iterationID})
+	fake.recordInvocation("GetCountsForIteration", []interface{}{ctx, iterationID})
+	fake.getCountsForIterationMutex.Unlock()
+	if fake.GetCountsForIterationStub != nil {
+		return fake.GetCountsForIterationStub(ctx, iterationID)
+	}
+	return fake.getCountsForIterationReturns.result1, fake.getCountsForIterationReturns.result2
+}
+
+func (fake *WorkItemRepository) GetCountsForIterationCallCount() int {
+	fake.getCountsForIterationMutex.RLock()
+	defer fake.getCountsForIterationMutex.RUnlock()
+	return len(fake.getCountsForIterationArgsForCall)
+}
+
+func (fake *WorkItemRepository) GetCountsForIterationArgsForCall(i int) (context.Context, uuid.UUID) {
+	fake.getCountsForIterationMutex.RLock()
+	defer fake.getCountsForIterationMutex.RUnlock()
+	return fake.getCountsForIterationArgsForCall[i].ctx, fake.getCountsForIterationArgsForCall[i].iterationID
+}
+
+func (fake *WorkItemRepository) GetCountsForIterationReturns(result1 map[string]workitem.WICountsPerIteration, result2 error) {
+	fake.GetCountsForIterationStub = nil
+	fake.getCountsForIterationReturns = struct {
+		result1 map[string]workitem.WICountsPerIteration
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *WorkItemRepository) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -303,6 +391,10 @@ func (fake *WorkItemRepository) Invocations() map[string][][]interface{} {
 	defer fake.listMutex.RUnlock()
 	fake.fetchMutex.RLock()
 	defer fake.fetchMutex.RUnlock()
+	fake.getCountsPerIterationMutex.RLock()
+	defer fake.getCountsPerIterationMutex.RUnlock()
+	fake.getCountsForIterationMutex.RLock()
+	defer fake.getCountsForIterationMutex.RUnlock()
 	return fake.invocations
 }
 
@@ -316,13 +408,6 @@ func (fake *WorkItemRepository) recordInvocation(key string, args []interface{})
 		fake.invocations[key] = [][]interface{}{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
-}
-
-func (fake *WorkItemRepository) GetCountsPerIteration(ctx context.Context, spaceId uuid.UUID) (map[string]workitem.WICountsPerIteration, error) {
-	return map[string]workitem.WICountsPerIteration{}, nil
-}
-func (fake *WorkItemRepository) GetCountsForIteration(ctx context.Context, iterationId uuid.UUID) (map[string]workitem.WICountsPerIteration, error) {
-	return map[string]workitem.WICountsPerIteration{}, nil
 }
 
 var _ workitem.WorkItemRepository = new(WorkItemRepository)

--- a/work-item-comments.go
+++ b/work-item-comments.go
@@ -10,7 +10,6 @@ import (
 	"github.com/almighty/almighty-core/rest"
 	"github.com/goadesign/goa"
 	"github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
 	"golang.org/x/net/context"
 )
 
@@ -33,22 +32,18 @@ func (c *WorkItemCommentsController) Create(ctx *app.CreateWorkItemCommentsConte
 			return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
 		}
 
-		currentUser, err := login.ContextIdentity(ctx)
+		currentUserID, err := login.ContextIdentity(ctx)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(err.Error()))
 		}
 
-		currentUserID, err := uuid.FromString(currentUser)
-		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(err.Error()))
-		}
 		reqComment := ctx.Payload.Data
 		markup := rendering.NilSafeGetMarkup(reqComment.Attributes.Markup)
 		newComment := comment.Comment{
 			ParentID:  ctx.ID,
 			Body:      reqComment.Attributes.Body,
 			Markup:    markup,
-			CreatedBy: currentUserID,
+			CreatedBy: *currentUserID,
 		}
 
 		err = appl.Comments().Create(ctx, &newComment)

--- a/work-item-comments.go
+++ b/work-item-comments.go
@@ -32,7 +32,7 @@ func (c *WorkItemCommentsController) Create(ctx *app.CreateWorkItemCommentsConte
 			return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
 		}
 
-		currentUserID, err := login.ContextIdentity(ctx)
+		currentUserIdentityID, err := login.ContextIdentity(ctx)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(err.Error()))
 		}
@@ -43,7 +43,7 @@ func (c *WorkItemCommentsController) Create(ctx *app.CreateWorkItemCommentsConte
 			ParentID:  ctx.ID,
 			Body:      reqComment.Attributes.Body,
 			Markup:    markup,
-			CreatedBy: *currentUserID,
+			CreatedBy: *currentUserIdentityID,
 		}
 
 		err = appl.Comments().Create(ctx, &newComment)

--- a/work-item-comments_test.go
+++ b/work-item-comments_test.go
@@ -84,7 +84,7 @@ func (rest *TestCommentREST) createDefaultWorkItem() string {
 				workitem.SystemTitle: "A",
 				workitem.SystemState: "new",
 			},
-			uuid.NewV4().String())
+			uuid.NewV4())
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/workitem.go
+++ b/workitem.go
@@ -124,7 +124,7 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 
 // Create does POST workitem
 func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
-	currentUserID, err := login.ContextIdentity(ctx)
+	currentUserIdentityID, err := login.ContextIdentity(ctx)
 	if err != nil {
 		jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(err.Error()))
 		return ctx.Unauthorized(jerrors)
@@ -146,7 +146,7 @@ func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error creating work item")))
 		}
 
-		wi, err := appl.WorkItems().Create(ctx, *wit, wi.Fields, *currentUserID)
+		wi, err := appl.WorkItems().Create(ctx, *wit, wi.Fields, *currentUserIdentityID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error creating work item")))
 		}

--- a/workitem.go
+++ b/workitem.go
@@ -124,7 +124,7 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 
 // Create does POST workitem
 func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
-	currentUser, err := login.ContextIdentity(ctx)
+	currentUserID, err := login.ContextIdentity(ctx)
 	if err != nil {
 		jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(err.Error()))
 		return ctx.Unauthorized(jerrors)
@@ -146,7 +146,7 @@ func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error creating work item")))
 		}
 
-		wi, err := appl.WorkItems().Create(ctx, *wit, wi.Fields, currentUser)
+		wi, err := appl.WorkItems().Create(ctx, *wit, wi.Fields, *currentUserID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error creating work item")))
 		}

--- a/workitem/undoable_wi_repo.go
+++ b/workitem/undoable_wi_repo.go
@@ -96,7 +96,7 @@ func (r *UndoableWorkItemRepository) Delete(ctx context.Context, ID string) erro
 }
 
 // Create implements application.WorkItemRepository
-func (r *UndoableWorkItemRepository) Create(ctx context.Context, typeID string, fields map[string]interface{}, creator string) (*app.WorkItem, error) {
+func (r *UndoableWorkItemRepository) Create(ctx context.Context, typeID string, fields map[string]interface{}, creator uuid.UUID) (*app.WorkItem, error) {
 	result, err := r.wrapped.Create(ctx, typeID, fields, creator)
 	if err != nil {
 		return result, errs.WithStack(err)

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -22,7 +22,7 @@ type WorkItemRepository interface {
 	Load(ctx context.Context, ID string) (*app.WorkItem, error)
 	Save(ctx context.Context, wi app.WorkItem) (*app.WorkItem, error)
 	Delete(ctx context.Context, ID string) error
-	Create(ctx context.Context, typeID string, fields map[string]interface{}, creator string) (*app.WorkItem, error)
+	Create(ctx context.Context, typeID string, fields map[string]interface{}, creator uuid.UUID) (*app.WorkItem, error)
 	List(ctx context.Context, criteria criteria.Expression, start *int, length *int) ([]*app.WorkItem, uint64, error)
 	Fetch(ctx context.Context, criteria criteria.Expression) (*app.WorkItem, error)
 	GetCountsPerIteration(ctx context.Context, spaceID uuid.UUID) (map[string]WICountsPerIteration, error)
@@ -167,7 +167,7 @@ func (r *GormWorkItemRepository) Save(ctx context.Context, wi app.WorkItem) (*ap
 
 // Create creates a new work item in the repository
 // returns BadParameterError, ConversionError or InternalError
-func (r *GormWorkItemRepository) Create(ctx context.Context, typeID string, fields map[string]interface{}, creator string) (*app.WorkItem, error) {
+func (r *GormWorkItemRepository) Create(ctx context.Context, typeID string, fields map[string]interface{}, creator uuid.UUID) (*app.WorkItem, error) {
 	wiType, err := r.wir.LoadTypeFromDB(ctx, typeID)
 	if err != nil {
 		return nil, errors.NewBadParameterError("type", typeID)
@@ -176,7 +176,7 @@ func (r *GormWorkItemRepository) Create(ctx context.Context, typeID string, fiel
 		Type:   typeID,
 		Fields: Fields{},
 	}
-	fields[SystemCreator] = creator
+	fields[SystemCreator] = creator.String()
 	for fieldName, fieldDef := range wiType.Fields {
 		if fieldName == SystemCreatedAt {
 			continue

--- a/workitem/workitem_repository_blackbox_test.go
+++ b/workitem/workitem_repository_blackbox_test.go
@@ -26,7 +26,9 @@ import (
 
 type workItemRepoBlackBoxTest struct {
 	gormsupport.DBTestSuite
-	repo workitem.WorkItemRepository
+	repo      workitem.WorkItemRepository
+	clean     func()
+	creatorID uuid.UUID
 }
 
 func TestRunWorkTypeRepoBlackBoxTest(t *testing.T) {
@@ -51,122 +53,129 @@ func (s *workItemRepoBlackBoxTest) SetupSuite() {
 
 func (s *workItemRepoBlackBoxTest) SetupTest() {
 	s.repo = workitem.NewWorkItemRepository(s.DB)
+	s.clean = cleaner.DeleteCreatedEntities(s.DB)
+	s.creatorID = uuid.NewV4()
+}
+
+func (s *workItemRepoBlackBoxTest) TearDownTest() {
+	s.clean()
 }
 
 func (s *workItemRepoBlackBoxTest) TestFailDeleteZeroID() {
-	defer cleaner.DeleteCreatedEntities(s.DB)()
-
 	// Create at least 1 item to avoid RowsEffectedCheck
+	// given
 	_, err := s.repo.Create(
 		context.Background(), workitem.SystemBug,
 		map[string]interface{}{
 			workitem.SystemTitle: "Title",
 			workitem.SystemState: workitem.SystemStateNew,
-		}, uuid.NewV4())
+		}, s.creatorID)
 	require.Nil(s.T(), err, "Could not create work item")
-
+	// when
 	err = s.repo.Delete(context.Background(), "0")
-	require.IsType(s.T(), errors.NotFoundError{}, errs.Cause(err))
+	// then
+	assert.IsType(s.T(), errors.NotFoundError{}, errs.Cause(err))
 }
 
 func (s *workItemRepoBlackBoxTest) TestFailSaveZeroID() {
-	defer cleaner.DeleteCreatedEntities(s.DB)()
-
 	// Create at least 1 item to avoid RowsEffectedCheck
+	// given
 	wi, err := s.repo.Create(
 		context.Background(), workitem.SystemBug,
 		map[string]interface{}{
 			workitem.SystemTitle: "Title",
 			workitem.SystemState: workitem.SystemStateNew,
-		}, uuid.NewV4())
+		}, s.creatorID)
 	require.Nil(s.T(), err, "Could not create workitem")
+	// when
 	wi.ID = "0"
 	_, err = s.repo.Save(context.Background(), *wi)
-	require.IsType(s.T(), errors.NotFoundError{}, errs.Cause(err))
+	// then
+	assert.IsType(s.T(), errors.NotFoundError{}, errs.Cause(err))
 }
 
 func (s *workItemRepoBlackBoxTest) TestFaiLoadZeroID() {
-	defer cleaner.DeleteCreatedEntities(s.DB)()
-
 	// Create at least 1 item to avoid RowsEffectedCheck
+	// given
 	_, err := s.repo.Create(
 		context.Background(), workitem.SystemBug,
 		map[string]interface{}{
 			workitem.SystemTitle: "Title",
 			workitem.SystemState: workitem.SystemStateNew,
-		}, uuid.NewV4())
+		}, s.creatorID)
 	require.Nil(s.T(), err, "Could not create workitem")
-
+	// when
 	_, err = s.repo.Load(context.Background(), "0")
-	require.IsType(s.T(), errors.NotFoundError{}, errs.Cause(err))
+	// then
+	assert.IsType(s.T(), errors.NotFoundError{}, errs.Cause(err))
 }
 
 func (s *workItemRepoBlackBoxTest) TestSaveAssignees() {
-	defer cleaner.DeleteCreatedEntities(s.DB)()
-
+	// given
 	wi, err := s.repo.Create(
 		context.Background(), workitem.SystemBug,
 		map[string]interface{}{
 			workitem.SystemTitle:     "Title",
 			workitem.SystemState:     workitem.SystemStateNew,
 			workitem.SystemAssignees: []string{"A", "B"},
-		}, uuid.NewV4())
+		}, s.creatorID)
 	require.Nil(s.T(), err, "Could not create workitem")
-
+	// when
 	wi, err = s.repo.Load(context.Background(), wi.ID)
+	// then
 	require.Nil(s.T(), err)
-
 	assert.Equal(s.T(), "A", wi.Fields[workitem.SystemAssignees].([]interface{})[0])
 }
 
 func (s *workItemRepoBlackBoxTest) TestSaveForUnchangedCreatedDate() {
-	defer cleaner.DeleteCreatedEntities(s.DB)()
-
+	// given
 	wi, err := s.repo.Create(
 		context.Background(), workitem.SystemBug,
 		map[string]interface{}{
 			workitem.SystemTitle: "Title",
 			workitem.SystemState: workitem.SystemStateNew,
-		}, uuid.NewV4())
+		}, s.creatorID)
 	require.Nil(s.T(), err, "Could not create workitem")
-
+	// when
 	wi, err = s.repo.Load(context.Background(), wi.ID)
 	require.Nil(s.T(), err)
-
 	wiNew, err := s.repo.Save(context.Background(), *wi)
+	// then
 	require.Nil(s.T(), err)
 	assert.Equal(s.T(), wi.Fields[workitem.SystemCreatedAt], wiNew.Fields[workitem.SystemCreatedAt])
 }
 
 func (s *workItemRepoBlackBoxTest) TestCreateWorkItemWithDescriptionNoMarkup() {
-	defer cleaner.DeleteCreatedEntities(s.DB)()
-
+	// given
 	wi, err := s.repo.Create(
 		context.Background(), workitem.SystemBug,
 		map[string]interface{}{
 			workitem.SystemTitle:       "Title",
 			workitem.SystemDescription: rendering.NewMarkupContentFromLegacy("Description"),
 			workitem.SystemState:       workitem.SystemStateNew,
-		}, uuid.NewV4())
+		}, s.creatorID)
 	require.Nil(s.T(), err, "Could not create workitem")
-
+	// when
 	wi, err = s.repo.Load(context.Background(), wi.ID)
+	// then
 	require.Nil(s.T(), err)
 	// app.WorkItem does not contain the markup associated with the description (yet)
 	assert.Equal(s.T(), rendering.NewMarkupContentFromLegacy("Description"), wi.Fields[workitem.SystemDescription])
 }
 
 func (s *workItemRepoBlackBoxTest) TestCreateWorkItemWithDescriptionMarkup() {
-	defer cleaner.DeleteCreatedEntities(s.DB)()
+	// given
 	wi, err := s.repo.Create(
 		context.Background(), workitem.SystemBug,
 		map[string]interface{}{
 			workitem.SystemTitle:       "Title",
 			workitem.SystemDescription: rendering.NewMarkupContent("Description", rendering.SystemMarkupMarkdown),
 			workitem.SystemState:       workitem.SystemStateNew,
-		}, uuid.NewV4())
+		}, s.creatorID)
 	require.Nil(s.T(), err, "Could not create workitem")
+	// when
 	wi, err = s.repo.Load(context.Background(), wi.ID)
+	// then
 	require.Nil(s.T(), err)
 	// app.WorkItem does not contain the markup associated with the description (yet)
 	assert.Equal(s.T(), rendering.NewMarkupContent("Description", rendering.SystemMarkupMarkdown), wi.Fields[workitem.SystemDescription])
@@ -176,57 +185,57 @@ func (s *workItemRepoBlackBoxTest) TestCreateWorkItemWithDescriptionMarkup() {
 // a work item. NOTE: This functionality only works on the DB layer and is not
 // exposed to REST.
 func (s *workItemRepoBlackBoxTest) TestTypeChangeIsNotProhibitedOnDBLayer() {
-	defer cleaner.DeleteCreatedEntities(s.DB)()
-
 	// Create at least 1 item to avoid RowsAffectedCheck
+	// given
 	wi, err := s.repo.Create(
 		context.Background(), "bug",
 		map[string]interface{}{
 			workitem.SystemTitle: "Title",
 			workitem.SystemState: workitem.SystemStateNew,
-		}, uuid.NewV4())
-
+		}, s.creatorID)
 	require.Nil(s.T(), err)
-
+	// when
 	wi.Type = "feature"
-
 	newWi, err := s.repo.Save(context.Background(), *wi)
+	// then
 	require.Nil(s.T(), err)
-	require.Equal(s.T(), "feature", newWi.Type)
+	assert.Equal(s.T(), "feature", newWi.Type)
 }
 
 // TestGetCountsPerIteration makes sure that the query being executed is correctly returning
 // the counts of work items
 func (s *workItemRepoBlackBoxTest) TestGetCountsPerIteration() {
-	defer cleaner.DeleteCreatedEntities(s.DB)()
 	// create seed data
+	// given
 	spaceRepo := space.NewRepository(s.DB)
 	spaceInstance := space.Space{
 		Name: "Testing space",
 	}
 	spaceRepo.Create(context.Background(), &spaceInstance)
-	fmt.Println("space id = ", spaceInstance.ID)
 	assert.NotEqual(s.T(), uuid.UUID{}, spaceInstance.ID)
-
+	// when
 	iterationRepo := iteration.NewIterationRepository(s.DB)
 	iteration1 := iteration.Iteration{
 		Name:    "Sprint 1",
 		SpaceID: spaceInstance.ID,
 	}
 	err := iterationRepo.Create(context.Background(), &iteration1)
+	// then
 	require.Nil(s.T(), err)
-	fmt.Println("iteration1 id = ", iteration1.ID)
+	s.T().Log("iteration1 id = ", iteration1.ID)
 	assert.NotEqual(s.T(), uuid.UUID{}, iteration1.ID)
-
+	// given
 	iteration2 := iteration.Iteration{
 		Name:    "Sprint 2",
 		SpaceID: spaceInstance.ID,
 	}
+	// when
 	err = iterationRepo.Create(context.Background(), &iteration2)
+	// then
 	require.Nil(s.T(), err)
-	fmt.Println("iteration2 id = ", iteration2.ID)
+	s.T().Log("iteration2 id = ", iteration2.ID)
 	assert.NotEqual(s.T(), uuid.UUID{}, iteration2.ID)
-
+	// given
 	for i := 0; i < 3; i++ {
 		_, err = s.repo.Create(
 			context.Background(), workitem.SystemBug,
@@ -234,7 +243,7 @@ func (s *workItemRepoBlackBoxTest) TestGetCountsPerIteration() {
 				workitem.SystemTitle:     fmt.Sprintf("New issue #%d", i),
 				workitem.SystemState:     workitem.SystemStateNew,
 				workitem.SystemIteration: iteration1.ID.String(),
-			}, uuid.NewV4())
+			}, s.creatorID)
 		require.Nil(s.T(), err)
 	}
 	for i := 0; i < 2; i++ {
@@ -244,11 +253,13 @@ func (s *workItemRepoBlackBoxTest) TestGetCountsPerIteration() {
 				workitem.SystemTitle:     fmt.Sprintf("Closed issue #%d", i),
 				workitem.SystemState:     workitem.SystemStateClosed,
 				workitem.SystemIteration: iteration1.ID.String(),
-			}, uuid.NewV4())
+			}, s.creatorID)
 		require.Nil(s.T(), err)
 	}
+	// when
 	countsMap, _ := s.repo.GetCountsPerIteration(context.Background(), spaceInstance.ID)
-	assert.Len(s.T(), countsMap, 1)
+	// then
+	require.Len(s.T(), countsMap, 1)
 	require.Contains(s.T(), countsMap, iteration1.ID.String())
 	assert.Equal(s.T(), 5, countsMap[iteration1.ID.String()].Total)
 	assert.Equal(s.T(), 2, countsMap[iteration1.ID.String()].Closed)

--- a/workitem/workitem_repository_blackbox_test.go
+++ b/workitem/workitem_repository_blackbox_test.go
@@ -62,7 +62,7 @@ func (s *workItemRepoBlackBoxTest) TestFailDeleteZeroID() {
 		map[string]interface{}{
 			workitem.SystemTitle: "Title",
 			workitem.SystemState: workitem.SystemStateNew,
-		}, "xx")
+		}, uuid.NewV4())
 	require.Nil(s.T(), err, "Could not create work item")
 
 	err = s.repo.Delete(context.Background(), "0")
@@ -78,7 +78,7 @@ func (s *workItemRepoBlackBoxTest) TestFailSaveZeroID() {
 		map[string]interface{}{
 			workitem.SystemTitle: "Title",
 			workitem.SystemState: workitem.SystemStateNew,
-		}, "xx")
+		}, uuid.NewV4())
 	require.Nil(s.T(), err, "Could not create workitem")
 	wi.ID = "0"
 	_, err = s.repo.Save(context.Background(), *wi)
@@ -94,7 +94,7 @@ func (s *workItemRepoBlackBoxTest) TestFaiLoadZeroID() {
 		map[string]interface{}{
 			workitem.SystemTitle: "Title",
 			workitem.SystemState: workitem.SystemStateNew,
-		}, "xx")
+		}, uuid.NewV4())
 	require.Nil(s.T(), err, "Could not create workitem")
 
 	_, err = s.repo.Load(context.Background(), "0")
@@ -110,7 +110,7 @@ func (s *workItemRepoBlackBoxTest) TestSaveAssignees() {
 			workitem.SystemTitle:     "Title",
 			workitem.SystemState:     workitem.SystemStateNew,
 			workitem.SystemAssignees: []string{"A", "B"},
-		}, "xx")
+		}, uuid.NewV4())
 	require.Nil(s.T(), err, "Could not create workitem")
 
 	wi, err = s.repo.Load(context.Background(), wi.ID)
@@ -127,7 +127,7 @@ func (s *workItemRepoBlackBoxTest) TestSaveForUnchangedCreatedDate() {
 		map[string]interface{}{
 			workitem.SystemTitle: "Title",
 			workitem.SystemState: workitem.SystemStateNew,
-		}, "xx")
+		}, uuid.NewV4())
 	require.Nil(s.T(), err, "Could not create workitem")
 
 	wi, err = s.repo.Load(context.Background(), wi.ID)
@@ -147,7 +147,7 @@ func (s *workItemRepoBlackBoxTest) TestCreateWorkItemWithDescriptionNoMarkup() {
 			workitem.SystemTitle:       "Title",
 			workitem.SystemDescription: rendering.NewMarkupContentFromLegacy("Description"),
 			workitem.SystemState:       workitem.SystemStateNew,
-		}, "xx")
+		}, uuid.NewV4())
 	require.Nil(s.T(), err, "Could not create workitem")
 
 	wi, err = s.repo.Load(context.Background(), wi.ID)
@@ -164,7 +164,7 @@ func (s *workItemRepoBlackBoxTest) TestCreateWorkItemWithDescriptionMarkup() {
 			workitem.SystemTitle:       "Title",
 			workitem.SystemDescription: rendering.NewMarkupContent("Description", rendering.SystemMarkupMarkdown),
 			workitem.SystemState:       workitem.SystemStateNew,
-		}, "xx")
+		}, uuid.NewV4())
 	require.Nil(s.T(), err, "Could not create workitem")
 	wi, err = s.repo.Load(context.Background(), wi.ID)
 	require.Nil(s.T(), err)
@@ -184,7 +184,7 @@ func (s *workItemRepoBlackBoxTest) TestTypeChangeIsNotProhibitedOnDBLayer() {
 		map[string]interface{}{
 			workitem.SystemTitle: "Title",
 			workitem.SystemState: workitem.SystemStateNew,
-		}, "xx")
+		}, uuid.NewV4())
 
 	require.Nil(s.T(), err)
 
@@ -234,7 +234,7 @@ func (s *workItemRepoBlackBoxTest) TestGetCountsPerIteration() {
 				workitem.SystemTitle:     fmt.Sprintf("New issue #%d", i),
 				workitem.SystemState:     workitem.SystemStateNew,
 				workitem.SystemIteration: iteration1.ID.String(),
-			}, "xx")
+			}, uuid.NewV4())
 		require.Nil(s.T(), err)
 	}
 	for i := 0; i < 2; i++ {
@@ -244,7 +244,7 @@ func (s *workItemRepoBlackBoxTest) TestGetCountsPerIteration() {
 				workitem.SystemTitle:     fmt.Sprintf("Closed issue #%d", i),
 				workitem.SystemState:     workitem.SystemStateClosed,
 				workitem.SystemIteration: iteration1.ID.String(),
-			}, "xx")
+			}, uuid.NewV4())
 		require.Nil(s.T(), err)
 	}
 	countsMap, _ := s.repo.GetCountsPerIteration(context.Background(), spaceInstance.ID)


### PR DESCRIPTION
Removed the `uuid.UUID` to `string` conversion and return nil if something
wrong happened.

Fixes #866
