### PR TITLE
Expose limited configuration to controllers and initialize config only once.

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -2,10 +2,12 @@ package configuration
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/almighty/almighty-core/rest"
@@ -26,6 +28,7 @@ func String() string {
 	return fmt.Sprintf("%s\n", y)
 }
 
+/*
 // Setup sets up defaults for viper configuration options and
 // overrides these values with the values from the given configuration file
 // if it is not empty. Those values again are overwritten by environment
@@ -61,6 +64,7 @@ func Setup(configFilePath string) error {
 
 	return nil
 }
+*/
 
 const (
 	// Constants for viper variable names. Will be used to set
@@ -91,6 +95,7 @@ const (
 	varKeycloakTesUserSecret        = "keycloak.testuser.secret"
 	varTokenPublicKey               = "token.publickey"
 	varTokenPrivateKey              = "token.privatekey"
+	defaultConfigFile               = "config.yaml"
 
 	// The host name exception of the api service to be taken into account
 	// when converting it to sso.demo.almighty.io
@@ -102,7 +107,55 @@ const (
 	ssoHostNameException = "sso.demo.almighty.io"
 )
 
-func setConfigDefaults() {
+// ConfigurationData encapsulates the Viper configuration object which stores the configuration data in-memory.
+type ConfigurationData struct {
+	v *viper.Viper
+}
+
+// NewConfigurationData creates a configuration reader object using a configurable configuration file path
+func NewConfigurationData(configFilePath string) (*ConfigurationData, error) {
+	c := ConfigurationData{
+		v: viper.New(),
+	}
+	c.v.SetEnvPrefix("ALMIGHTY")
+	c.v.AutomaticEnv()
+	c.v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	c.v.SetTypeByDefaultValue(true)
+	c.setConfigDefaults()
+
+	if configFilePath != "" {
+		c.v.SetConfigType("yaml")
+		c.v.SetConfigFile(configFilePath)
+		err := c.v.ReadInConfig() // Find and read the config file
+		if err != nil {           // Handle errors reading the config file
+			return nil, errors.Errorf("Fatal error config file: %s \n", err)
+		}
+	}
+	return &c, nil
+}
+
+func getConfigFilePath() string {
+	// This was either passed as a env var Or, set inside main.go from --config
+	envConfigPath, ok := os.LookupEnv("ALMIGHTY_CONFIG_FILE_PATH")
+	if !ok {
+		return ""
+	}
+	return envConfigPath
+}
+
+// GetDefaultConfigurationFiler eturns the default configuration file.
+func (c *ConfigurationData) GetDefaultConfigurationFile() string {
+	return defaultConfigFile
+}
+
+// GetConfigurationData is a wrapper over NewConfigurationData which reads configuration file path
+// from the environment variable.
+func GetConfigurationData() (*ConfigurationData, error) {
+	cd, err := NewConfigurationData(getConfigFilePath())
+	return cd, err
+}
+
+func (c *ConfigurationData) setConfigDefaults() {
 	//---------
 	// Postgres
 	//---------
@@ -118,73 +171,73 @@ func setConfigDefaults() {
 	viper.SetDefault(varPostgresConnectionMaxOpen, -1)
 
 	// Number of seconds to wait before trying to connect again
-	viper.SetDefault(varPostgresConnectionRetrySleep, time.Duration(time.Second))
+	c.v.SetDefault(varPostgresConnectionRetrySleep, time.Duration(time.Second))
 
 	//-----
 	// HTTP
 	//-----
-	viper.SetDefault(varHTTPAddress, "0.0.0.0:8080")
+	c.v.SetDefault(varHTTPAddress, "0.0.0.0:8080")
 
 	//-----
 	// Misc
 	//-----
 
 	// Enable development related features, e.g. token generation endpoint
-	viper.SetDefault(varDeveloperModeEnabled, false)
+	c.v.SetDefault(varDeveloperModeEnabled, false)
 
-	viper.SetDefault(varPopulateCommonTypes, true)
+	c.v.SetDefault(varPopulateCommonTypes, true)
 
 	// Auth-related defaults
-	viper.SetDefault(varTokenPublicKey, defaultTokenPublicKey)
-	viper.SetDefault(varTokenPrivateKey, defaultTokenPrivateKey)
-	viper.SetDefault(varKeycloakClientID, defaultKeycloakClientID)
-	viper.SetDefault(varKeycloakSecret, defaultKeycloakSecret)
-	viper.SetDefault(varGithubAuthToken, defaultActualToken)
-	viper.SetDefault(varKeycloakDomainPrefix, defaultKeycloakDomainPrefix)
-	viper.SetDefault(varKeycloakRealm, defaultKeycloakRealm)
-	viper.SetDefault(varKeycloakTesUserName, defaultKeycloakTesUserName)
-	viper.SetDefault(varKeycloakTesUserSecret, defaultKeycloakTesUserSecret)
+	c.v.SetDefault(varTokenPublicKey, defaultTokenPublicKey)
+	c.v.SetDefault(varTokenPrivateKey, defaultTokenPrivateKey)
+	c.v.SetDefault(varKeycloakClientID, defaultKeycloakClientID)
+	c.v.SetDefault(varKeycloakSecret, defaultKeycloakSecret)
+	c.v.SetDefault(varGithubAuthToken, defaultActualToken)
+	c.v.SetDefault(varKeycloakDomainPrefix, defaultKeycloakDomainPrefix)
+	c.v.SetDefault(varKeycloakRealm, defaultKeycloakRealm)
+	c.v.SetDefault(varKeycloakTesUserName, defaultKeycloakTesUserName)
+	c.v.SetDefault(varKeycloakTesUserSecret, defaultKeycloakTesUserSecret)
 }
 
 // GetPostgresHost returns the postgres host as set via default, config file, or environment variable
-func GetPostgresHost() string {
-	return viper.GetString(varPostgresHost)
+func (c *ConfigurationData) GetPostgresHost() string {
+	return c.v.GetString(varPostgresHost)
 }
 
 // GetPostgresPort returns the postgres port as set via default, config file, or environment variable
-func GetPostgresPort() int64 {
-	return viper.GetInt64(varPostgresPort)
+func (c *ConfigurationData) GetPostgresPort() int64 {
+	return c.v.GetInt64(varPostgresPort)
 }
 
 // GetPostgresUser returns the postgres user as set via default, config file, or environment variable
-func GetPostgresUser() string {
-	return viper.GetString(varPostgresUser)
+func (c *ConfigurationData) GetPostgresUser() string {
+	return c.v.GetString(varPostgresUser)
 }
 
 // GetPostgresDatabase returns the postgres database as set via default, config file, or environment variable
-func GetPostgresDatabase() string {
-	return viper.GetString(varPostgresDatabase)
+func (c *ConfigurationData) GetPostgresDatabase() string {
+	return c.v.GetString(varPostgresDatabase)
 }
 
 // GetPostgresPassword returns the postgres password as set via default, config file, or environment variable
-func GetPostgresPassword() string {
-	return viper.GetString(varPostgresPassword)
+func (c *ConfigurationData) GetPostgresPassword() string {
+	return c.v.GetString(varPostgresPassword)
 }
 
 // GetPostgresSSLMode returns the postgres sslmode as set via default, config file, or environment variable
-func GetPostgresSSLMode() string {
-	return viper.GetString(varPostgresSSLMode)
+func (c *ConfigurationData) GetPostgresSSLMode() string {
+	return c.v.GetString(varPostgresSSLMode)
 }
 
 // GetPostgresConnectionTimeout returns the postgres connection timeout as set via default, config file, or environment variable
-func GetPostgresConnectionTimeout() int64 {
-	return viper.GetInt64(varPostgresConnectionTimeout)
+func (c *ConfigurationData) GetPostgresConnectionTimeout() int64 {
+	return c.v.GetInt64(varPostgresConnectionTimeout)
 }
 
 // GetPostgresConnectionRetrySleep returns the number of seconds (as set via default, config file, or environment variable)
 // to wait before trying to connect again
-func GetPostgresConnectionRetrySleep() time.Duration {
-	return viper.GetDuration(varPostgresConnectionRetrySleep)
+func (c *ConfigurationData) GetPostgresConnectionRetrySleep() time.Duration {
+	return c.v.GetDuration(varPostgresConnectionRetrySleep)
 }
 
 // GetPostgresConnectionMaxIdle returns the number of connections that should be keept alive in the database connection pool at
@@ -200,83 +253,83 @@ func GetPostgresConnectionMaxOpen() int {
 }
 
 // GetPostgresConfigString returns a ready to use string for usage in sql.Open()
-func GetPostgresConfigString() string {
+func (c *ConfigurationData) GetPostgresConfigString() string {
 	return fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s connect_timeout=%d",
-		GetPostgresHost(),
-		GetPostgresPort(),
-		GetPostgresUser(),
-		GetPostgresPassword(),
-		GetPostgresDatabase(),
-		GetPostgresSSLMode(),
-		GetPostgresConnectionTimeout(),
+		c.GetPostgresHost(),
+		c.GetPostgresPort(),
+		c.GetPostgresUser(),
+		c.GetPostgresPassword(),
+		c.GetPostgresDatabase(),
+		c.GetPostgresSSLMode(),
+		c.GetPostgresConnectionTimeout(),
 	)
 }
 
 // GetPopulateCommonTypes returns true if the (as set via default, config file, or environment variable)
 // the common work item types such as bug or feature shall be created.
-func GetPopulateCommonTypes() bool {
-	return viper.GetBool(varPopulateCommonTypes)
+func (c *ConfigurationData) GetPopulateCommonTypes() bool {
+	return c.v.GetBool(varPopulateCommonTypes)
 }
 
 // GetHTTPAddress returns the HTTP address (as set via default, config file, or environment variable)
 // that the alm server binds to (e.g. "0.0.0.0:8080")
-func GetHTTPAddress() string {
-	return viper.GetString(varHTTPAddress)
+func (c *ConfigurationData) GetHTTPAddress() string {
+	return c.v.GetString(varHTTPAddress)
 }
 
 // IsPostgresDeveloperModeEnabled returns if development related features (as set via default, config file, or environment variable),
 // e.g. token generation endpoint are enabled
-func IsPostgresDeveloperModeEnabled() bool {
-	return viper.GetBool(varDeveloperModeEnabled)
+func (c *ConfigurationData) IsPostgresDeveloperModeEnabled() bool {
+	return c.v.GetBool(varDeveloperModeEnabled)
 }
 
 // GetTokenPrivateKey returns the private key (as set via config file or environment variable)
 // that is used to sign the authentication token.
-func GetTokenPrivateKey() []byte {
-	return []byte(viper.GetString(varTokenPrivateKey))
+func (c *ConfigurationData) GetTokenPrivateKey() []byte {
+	return []byte(c.v.GetString(varTokenPrivateKey))
 }
 
 // GetTokenPublicKey returns the public key (as set via config file or environment variable)
 // that is used to decrypt the authentication token.
-func GetTokenPublicKey() []byte {
-	return []byte(viper.GetString(varTokenPublicKey))
+func (c *ConfigurationData) GetTokenPublicKey() []byte {
+	return []byte(c.v.GetString(varTokenPublicKey))
 }
 
 // GetGithubAuthToken returns the actual Github OAuth Access Token
-func GetGithubAuthToken() string {
-	return viper.GetString(varGithubAuthToken)
+func (c *ConfigurationData) GetGithubAuthToken() string {
+	return c.v.GetString(varGithubAuthToken)
 }
 
 // GetKeycloakSecret returns the keycloak client secret (as set via config file or environment variable)
 // that is used to make authorized Keycloak API Calls.
-func GetKeycloakSecret() string {
-	return viper.GetString(varKeycloakSecret)
+func (c *ConfigurationData) GetKeycloakSecret() string {
+	return c.v.GetString(varKeycloakSecret)
 }
 
 // GetKeycloakClientID returns the keycloak client ID (as set via config file or environment variable)
 // that is used to make authorized Keycloak API Calls.
-func GetKeycloakClientID() string {
-	return viper.GetString(varKeycloakClientID)
+func (c *ConfigurationData) GetKeycloakClientID() string {
+	return c.v.GetString(varKeycloakClientID)
 }
 
 // GetKeycloakDomainPrefix returns the domain prefix which should be used in all Keycloak requests
-func GetKeycloakDomainPrefix() string {
-	return viper.GetString(varKeycloakDomainPrefix)
+func (c *ConfigurationData) GetKeycloakDomainPrefix() string {
+	return c.v.GetString(varKeycloakDomainPrefix)
 }
 
 // GetKeycloakRealm returns the keyclaok realm name
-func GetKeycloakRealm() string {
-	return viper.GetString(varKeycloakRealm)
+func (c *ConfigurationData) GetKeycloakRealm() string {
+	return c.v.GetString(varKeycloakRealm)
 }
 
 // GetKeycloakTestUserName returns the keycloak test user name used to obtain a test token (as set via config file or environment variable)
-func GetKeycloakTestUserName() string {
-	return viper.GetString(varKeycloakTesUserName)
+func (c *ConfigurationData) GetKeycloakTestUserName() string {
+	return c.v.GetString(varKeycloakTesUserName)
 }
 
 // GetKeycloakTestUserSecret returns the keycloak test user password used to obtain a test token (as set via config file or environment variable)
-func GetKeycloakTestUserSecret() string {
-	return viper.GetString(varKeycloakTesUserSecret)
+func (c *ConfigurationData) GetKeycloakTestUserSecret() string {
+	return c.v.GetString(varKeycloakTesUserSecret)
 }
 
 // GetKeycloakEndpointAuth returns the keycloak auth endpoint set via config file or environment variable.
@@ -284,8 +337,8 @@ func GetKeycloakTestUserSecret() string {
 // In producion the endpoint will be calculated from the request by replacing the last domain/host name in the full host name.
 // Example: api.service.domain.org -> sso.service.domain.org
 // or api.domain.org -> sso.domain.org
-func GetKeycloakEndpointAuth(req *goa.RequestData) (string, error) {
-	return getKeycloakEndpoint(req, varKeycloakEndpointAuth, devModeKeycloakEndpointAuth, "auth")
+func (c *ConfigurationData) GetKeycloakEndpointAuth(req *goa.RequestData) (string, error) {
+	return c.getKeycloakEndpoint(req, varKeycloakEndpointAuth, devModeKeycloakEndpointAuth, "auth")
 }
 
 // GetKeycloakEndpointToken returns the keycloak token endpoint set via config file or environment variable.
@@ -293,8 +346,8 @@ func GetKeycloakEndpointAuth(req *goa.RequestData) (string, error) {
 // In producion the endpoint will be calculated from the request by replacing the last domain/host name in the full host name.
 // Example: api.service.domain.org -> sso.service.domain.org
 // or api.domain.org -> sso.domain.org
-func GetKeycloakEndpointToken(req *goa.RequestData) (string, error) {
-	return getKeycloakEndpoint(req, varKeycloakEndpointToken, devModeKeycloakEndpointToken, "token")
+func (c *ConfigurationData) GetKeycloakEndpointToken(req *goa.RequestData) (string, error) {
+	return c.getKeycloakEndpoint(req, varKeycloakEndpointToken, devModeKeycloakEndpointToken, "token")
 }
 
 // GetKeycloakEndpointUserInfo returns the keycloak userinfo endpoint set via config file or environment variable.
@@ -302,30 +355,30 @@ func GetKeycloakEndpointToken(req *goa.RequestData) (string, error) {
 // In producion the endpoint will be calculated from the request by replacing the last domain/host name in the full host name.
 // Example: api.service.domain.org -> sso.service.domain.org
 // or api.domain.org -> sso.domain.org
-func GetKeycloakEndpointUserInfo(req *goa.RequestData) (string, error) {
-	return getKeycloakEndpoint(req, varKeycloakEndpointUserinfo, devModeKeycloakEndpointUserinfo, "userinfo")
+func (c *ConfigurationData) GetKeycloakEndpointUserInfo(req *goa.RequestData) (string, error) {
+	return c.getKeycloakEndpoint(req, varKeycloakEndpointUserinfo, devModeKeycloakEndpointUserinfo, "userinfo")
 }
 
-func getKeycloakEndpoint(req *goa.RequestData, endpointVarName string, devModeEndpoint string, pathSufix string) (string, error) {
-	if viper.IsSet(endpointVarName) {
-		return viper.GetString(endpointVarName), nil
+func (c *ConfigurationData) getKeycloakEndpoint(req *goa.RequestData, endpointVarName string, devModeEndpoint string, pathSufix string) (string, error) {
+	if c.v.IsSet(endpointVarName) {
+		return c.v.GetString(endpointVarName), nil
 	}
-	if IsPostgresDeveloperModeEnabled() {
+	if c.IsPostgresDeveloperModeEnabled() {
 		return devModeEndpoint, nil
 	}
-	endpoint, err := getKeycloakURL(req, openIDConnectPath(pathSufix))
+	endpoint, err := c.getKeycloakURL(req, c.openIDConnectPath(pathSufix))
 	if err != nil {
 		return "", err
 	}
-	viper.Set(endpointVarName, endpoint) // Set the variable, so, we don't have to recalculate it again the next time
+	c.v.Set(endpointVarName, endpoint) // Set the variable, so, we don't have to recalculate it again the next time
 	return endpoint, nil
 }
 
-func openIDConnectPath(suffix string) string {
-	return "auth/realms/" + GetKeycloakRealm() + "/protocol/openid-connect/" + suffix
+func (c *ConfigurationData) openIDConnectPath(suffix string) string {
+	return "auth/realms/" + c.GetKeycloakRealm() + "/protocol/openid-connect/" + suffix
 }
 
-func getKeycloakURL(req *goa.RequestData, path string) (string, error) {
+func (c *ConfigurationData) getKeycloakURL(req *goa.RequestData, path string) (string, error) {
 	scheme := "http"
 	if req.TLS != nil { // isHTTPS
 		scheme = "https"
@@ -339,7 +392,7 @@ func getKeycloakURL(req *goa.RequestData, path string) (string, error) {
 		// So, we need to treat it as an exception
 		newHost = ssoHostNameException
 	} else {
-		newHost, err = rest.ReplaceDomainPrefix(currentHost, GetKeycloakDomainPrefix())
+		newHost, err = rest.ReplaceDomainPrefix(currentHost, c.GetKeycloakDomainPrefix())
 		if err != nil {
 			return "", err
 		}

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -204,13 +204,13 @@ func (c *ConfigurationData) GetPostgresConnectionRetrySleep() time.Duration {
 
 // GetPostgresConnectionMaxIdle returns the number of connections that should be keept alive in the database connection pool at
 // any given time. -1 represents no restrictions/default behavior
-func GetPostgresConnectionMaxIdle() int {
+func (c *ConfigurationData) GetPostgresConnectionMaxIdle() int {
 	return viper.GetInt(varPostgresConnectionMaxIdle)
 }
 
 // GetPostgresConnectionMaxOpen returns the max number of open connections that should be open in the database connection pool.
 // -1 represents no restrictions/default behavior
-func GetPostgresConnectionMaxOpen() int {
+func (c *ConfigurationData) GetPostgresConnectionMaxOpen() int {
 	return viper.GetInt(varPostgresConnectionMaxOpen)
 }
 

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -28,44 +28,6 @@ func String() string {
 	return fmt.Sprintf("%s\n", y)
 }
 
-/*
-// Setup sets up defaults for viper configuration options and
-// overrides these values with the values from the given configuration file
-// if it is not empty. Those values again are overwritten by environment
-// variables.
-func Setup(configFilePath string) error {
-	viper.Reset()
-
-	// Expect environment variables to be prefix with "ALMIGHTY_".
-	viper.SetEnvPrefix("ALMIGHTY")
-
-	// Automatically map environment variables to viper values
-	viper.AutomaticEnv()
-
-	// To override nested variables through environment variables, we
-	// need to make sure that we don't have to use dots (".") inside the
-	// environment variable names.
-	// To override foo.bar you need to set ALMIGHTY_FOO_BAR
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-
-	viper.SetTypeByDefaultValue(true)
-	setConfigDefaults()
-
-	// Read the config
-	// Explicitly specify which file to load config from
-	if configFilePath != "" {
-		viper.SetConfigFile(configFilePath)
-		viper.SetConfigType("yaml")
-		err := viper.ReadInConfig() // Find and read the config file
-		if err != nil {             // Handle errors reading the config file
-			return fmt.Errorf("Fatal error config file: %s \n", err)
-		}
-	}
-
-	return nil
-}
-*/
-
 const (
 	// Constants for viper variable names. Will be used to set
 	// default values as well as to get each value

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -16,8 +16,8 @@ import (
 )
 
 // String returns the current configuration as a string
-func String() string {
-	allSettings := viper.AllSettings()
+func (c *ConfigurationData) String() string {
+	allSettings := c.v.AllSettings()
 	y, err := yaml.Marshal(&allSettings)
 	if err != nil {
 		log.WithFields(map[string]interface{}{
@@ -121,16 +121,16 @@ func (c *ConfigurationData) setConfigDefaults() {
 	//---------
 	// Postgres
 	//---------
-	viper.SetTypeByDefaultValue(true)
-	viper.SetDefault(varPostgresHost, "localhost")
-	viper.SetDefault(varPostgresPort, 5432)
-	viper.SetDefault(varPostgresUser, "postgres")
-	viper.SetDefault(varPostgresDatabase, "postgres")
-	viper.SetDefault(varPostgresPassword, "mysecretpassword")
-	viper.SetDefault(varPostgresSSLMode, "disable")
-	viper.SetDefault(varPostgresConnectionTimeout, 5)
-	viper.SetDefault(varPostgresConnectionMaxIdle, -1)
-	viper.SetDefault(varPostgresConnectionMaxOpen, -1)
+	c.v.SetTypeByDefaultValue(true)
+	c.v.SetDefault(varPostgresHost, "localhost")
+	c.v.SetDefault(varPostgresPort, 5432)
+	c.v.SetDefault(varPostgresUser, "postgres")
+	c.v.SetDefault(varPostgresDatabase, "postgres")
+	c.v.SetDefault(varPostgresPassword, "mysecretpassword")
+	c.v.SetDefault(varPostgresSSLMode, "disable")
+	c.v.SetDefault(varPostgresConnectionTimeout, 5)
+	c.v.SetDefault(varPostgresConnectionMaxIdle, -1)
+	c.v.SetDefault(varPostgresConnectionMaxOpen, -1)
 
 	// Number of seconds to wait before trying to connect again
 	c.v.SetDefault(varPostgresConnectionRetrySleep, time.Duration(time.Second))
@@ -205,13 +205,13 @@ func (c *ConfigurationData) GetPostgresConnectionRetrySleep() time.Duration {
 // GetPostgresConnectionMaxIdle returns the number of connections that should be keept alive in the database connection pool at
 // any given time. -1 represents no restrictions/default behavior
 func (c *ConfigurationData) GetPostgresConnectionMaxIdle() int {
-	return viper.GetInt(varPostgresConnectionMaxIdle)
+	return c.v.GetInt(varPostgresConnectionMaxIdle)
 }
 
 // GetPostgresConnectionMaxOpen returns the max number of open connections that should be open in the database connection pool.
 // -1 represents no restrictions/default behavior
 func (c *ConfigurationData) GetPostgresConnectionMaxOpen() int {
-	return viper.GetInt(varPostgresConnectionMaxOpen)
+	return c.v.GetInt(varPostgresConnectionMaxOpen)
 }
 
 // GetPostgresConfigString returns a ready to use string for usage in sql.Open()

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -15,6 +15,7 @@ import (
 
 var reqLong *goa.RequestData
 var reqShort *goa.RequestData
+var config *configuration.ConfigurationData
 
 func TestMain(m *testing.M) {
 	resetConfiguration()
@@ -29,7 +30,9 @@ func TestMain(m *testing.M) {
 }
 
 func resetConfiguration() {
-	if err := configuration.Setup(""); err != nil {
+	var err error
+	config, err = configuration.GetConfigurationData()
+	if err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
 }
@@ -38,12 +41,12 @@ func TestGetKeycloakEndpointAuthDevModeOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
 
-	url, err := configuration.GetKeycloakEndpointAuth(reqLong)
+	url, err := config.GetKeycloakEndpointAuth(reqLong)
 	assert.Nil(t, err)
 	// In dev mode it's always the defualt value regardless of the request
 	assert.Equal(t, "http://sso.demo.almighty.io/auth/realms/fabric8/protocol/openid-connect/auth", url)
 
-	url, err = configuration.GetKeycloakEndpointAuth(reqShort)
+	url, err = config.GetKeycloakEndpointAuth(reqShort)
 	assert.Nil(t, err)
 	// In dev mode it's always the defualt value regardless of the request
 	assert.Equal(t, "http://sso.demo.almighty.io/auth/realms/fabric8/protocol/openid-connect/auth", url)
@@ -60,11 +63,11 @@ func TestGetKeycloakEndpointAuthSetByEnvVaribaleOK(t *testing.T) {
 	os.Setenv("ALMIGHTY_KEYCLOAK_ENDPOINT_AUTH", "authEndpoint")
 	resetConfiguration()
 
-	url, err := configuration.GetKeycloakEndpointAuth(reqLong)
+	url, err := config.GetKeycloakEndpointAuth(reqLong)
 	assert.Nil(t, err)
 	assert.Equal(t, "authEndpoint", url)
 
-	url, err = configuration.GetKeycloakEndpointAuth(reqShort)
+	url, err = config.GetKeycloakEndpointAuth(reqShort)
 	assert.Nil(t, err)
 	assert.Equal(t, "authEndpoint", url)
 }
@@ -73,12 +76,12 @@ func TestGetKeycloakEndpointTokenOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
 
-	url, err := configuration.GetKeycloakEndpointToken(reqLong)
+	url, err := config.GetKeycloakEndpointToken(reqLong)
 	assert.Nil(t, err)
 	// In dev mode it's always the defualt value regardless of the request
 	assert.Equal(t, "http://sso.demo.almighty.io/auth/realms/fabric8/protocol/openid-connect/token", url)
 
-	url, err = configuration.GetKeycloakEndpointToken(reqShort)
+	url, err = config.GetKeycloakEndpointToken(reqShort)
 	assert.Nil(t, err)
 	// In dev mode it's always the defualt value regardless of the request
 	assert.Equal(t, "http://sso.demo.almighty.io/auth/realms/fabric8/protocol/openid-connect/token", url)
@@ -95,11 +98,11 @@ func TestGetKeycloakEndpointTokenSetByEnvVaribaleOK(t *testing.T) {
 	os.Setenv("ALMIGHTY_KEYCLOAK_ENDPOINT_TOKEN", "tokenEndpoint")
 	resetConfiguration()
 
-	url, err := configuration.GetKeycloakEndpointToken(reqLong)
+	url, err := config.GetKeycloakEndpointToken(reqLong)
 	assert.Nil(t, err)
 	assert.Equal(t, "tokenEndpoint", url)
 
-	url, err = configuration.GetKeycloakEndpointToken(reqShort)
+	url, err = config.GetKeycloakEndpointToken(reqShort)
 	assert.Nil(t, err)
 	assert.Equal(t, "tokenEndpoint", url)
 }
@@ -108,12 +111,12 @@ func TestGetKeycloakEndpointUserInfoOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
 
-	url, err := configuration.GetKeycloakEndpointUserInfo(reqLong)
+	url, err := config.GetKeycloakEndpointUserInfo(reqLong)
 	assert.Nil(t, err)
 	// In dev mode it's always the defualt value regardless of the request
 	assert.Equal(t, "http://sso.demo.almighty.io/auth/realms/fabric8/protocol/openid-connect/userinfo", url)
 
-	url, err = configuration.GetKeycloakEndpointUserInfo(reqShort)
+	url, err = config.GetKeycloakEndpointUserInfo(reqShort)
 	assert.Nil(t, err)
 	// In dev mode it's always the defualt value regardless of the request
 	assert.Equal(t, "http://sso.demo.almighty.io/auth/realms/fabric8/protocol/openid-connect/userinfo", url)
@@ -130,11 +133,11 @@ func TestGetKeycloakEndpointUserInfoSetByEnvVaribaleOK(t *testing.T) {
 	os.Setenv("ALMIGHTY_KEYCLOAK_ENDPOINT_USERINFO", "userinfoEndpoint")
 	resetConfiguration()
 
-	url, err := configuration.GetKeycloakEndpointUserInfo(reqLong)
+	url, err := config.GetKeycloakEndpointUserInfo(reqLong)
 	assert.Nil(t, err)
 	assert.Equal(t, "userinfoEndpoint", url)
 
-	url, err = configuration.GetKeycloakEndpointUserInfo(reqShort)
+	url, err = config.GetKeycloakEndpointUserInfo(reqShort)
 	assert.Nil(t, err)
 	assert.Equal(t, "userinfoEndpoint", url)
 }

--- a/configuration/configuration_whitebox_test.go
+++ b/configuration/configuration_whitebox_test.go
@@ -12,7 +12,7 @@ import (
 
 var reqLong *goa.RequestData
 var reqShort *goa.RequestData
-var isConfigurationSet bool
+var config *ConfigurationData
 
 func init() {
 
@@ -27,7 +27,9 @@ func init() {
 }
 
 func resetConfiguration() {
-	if err := Setup(""); err != nil {
+	var err error
+	config, err = GetConfigurationData()
+	if err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
 }
@@ -36,7 +38,7 @@ func TestOpenIDConnectPathOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
 
-	path := openIDConnectPath("somesufix")
+	path := config.openIDConnectPath("somesufix")
 	assert.Equal(t, "auth/realms/fabric8/protocol/openid-connect/somesufix", path)
 }
 
@@ -44,11 +46,11 @@ func TestGetKeycloakURLOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
 
-	url, err := getKeycloakURL(reqLong, "somepath")
+	url, err := config.getKeycloakURL(reqLong, "somepath")
 	assert.Nil(t, err)
 	assert.Equal(t, "http://sso.service.domain.org/somepath", url)
 
-	url, err = getKeycloakURL(reqShort, "somepath2")
+	url, err = config.getKeycloakURL(reqShort, "somepath2")
 	assert.Nil(t, err)
 	assert.Equal(t, "http://sso.domain.org/somepath2", url)
 }
@@ -60,7 +62,7 @@ func TestGetKeycloakURLForTooShortHostFails(t *testing.T) {
 	r := &goa.RequestData{
 		Request: &http.Request{Host: "org"},
 	}
-	_, err := getKeycloakURL(r, "somepath")
+	_, err := config.getKeycloakURL(r, "somepath")
 	assert.NotNil(t, err)
 }
 
@@ -76,7 +78,7 @@ func TestDemoApiAlmightyIoExceptionOK(t *testing.T) {
 		Request: &http.Request{Host: "demo.api.almighty.io"},
 	}
 
-	url, err := getKeycloakURL(r, "somepath3")
+	url, err := config.getKeycloakURL(r, "somepath3")
 	assert.Nil(t, err)
 	assert.Equal(t, "http://sso.demo.almighty.io/somepath3", url)
 }

--- a/gormsupport/db_test_suite.go
+++ b/gormsupport/db_test_suite.go
@@ -29,7 +29,7 @@ type DBTestSuite struct {
 // SetupSuite implements suite.SetupAllSuite
 func (s *DBTestSuite) SetupSuite() {
 	resource.Require(s.T(), resource.Database)
-	configuration, err := config.NewConfigurationData("")
+	configuration, err := config.NewConfigurationData(s.configFile)
 	if err != nil {
 		logrus.Panic(nil, map[string]interface{}{
 			"err": err,

--- a/gormsupport/db_test_suite.go
+++ b/gormsupport/db_test_suite.go
@@ -1,11 +1,12 @@
 package gormsupport
 
 import (
-	"fmt"
 	"os"
 
-	"github.com/almighty/almighty-core/configuration"
+	"github.com/Sirupsen/logrus"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/resource"
+
 	"github.com/jinzhu/gorm"
 	_ "github.com/lib/pq" // need to import postgres driver
 	"github.com/stretchr/testify/suite"
@@ -28,9 +29,11 @@ type DBTestSuite struct {
 // SetupSuite implements suite.SetupAllSuite
 func (s *DBTestSuite) SetupSuite() {
 	resource.Require(s.T(), resource.Database)
-	var err error
-	if err = configuration.Setup(s.configFile); err != nil {
-		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	configuration, err := config.NewConfigurationData("")
+	if err != nil {
+		logrus.Panic(nil, map[string]interface{}{
+			"err": err,
+		}, "failed to setup the configuration")
 	}
 
 	if _, c := os.LookupEnv(resource.Database); c != false {

--- a/login.go
+++ b/login.go
@@ -15,7 +15,6 @@ import (
 	"github.com/almighty/almighty-core/account"
 
 	"github.com/almighty/almighty-core/app"
-	"github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/log"
@@ -26,21 +25,32 @@ import (
 	e "github.com/pkg/errors"
 )
 
+type loginConfiguration interface {
+	GetKeycloakEndpointAuth(*goa.RequestData) (string, error)
+	GetKeycloakEndpointToken(*goa.RequestData) (string, error)
+	GetKeycloakClientID() string
+	GetKeycloakSecret() string
+	IsPostgresDeveloperModeEnabled() bool
+	GetKeycloakTestUserName() string
+	GetKeycloakTestUserSecret() string
+}
+
 // LoginController implements the login resource.
 type LoginController struct {
 	*goa.Controller
-	auth         login.KeycloakOAuthService
-	tokenManager token.Manager
+	auth          login.KeycloakOAuthService
+	tokenManager  token.Manager
+	configuration loginConfiguration
 }
 
 // NewLoginController creates a login controller.
-func NewLoginController(service *goa.Service, auth *login.KeycloakOAuthProvider, tokenManager token.Manager) *LoginController {
-	return &LoginController{Controller: service.NewController("login"), auth: auth, tokenManager: tokenManager}
+func NewLoginController(service *goa.Service, auth *login.KeycloakOAuthProvider, tokenManager token.Manager, configuration loginConfiguration) *LoginController {
+	return &LoginController{Controller: service.NewController("login"), auth: auth, tokenManager: tokenManager, configuration: configuration}
 }
 
 // Authorize runs the authorize action.
 func (c *LoginController) Authorize(ctx *app.AuthorizeLoginContext) error {
-	authEndpoint, err := configuration.GetKeycloakEndpointAuth(ctx.RequestData)
+	authEndpoint, err := c.configuration.GetKeycloakEndpointAuth(ctx.RequestData)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
@@ -48,7 +58,7 @@ func (c *LoginController) Authorize(ctx *app.AuthorizeLoginContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("unable to get Keycloak auth endpoint URL "+err.Error()))
 	}
 
-	tokenEndpoint, err := configuration.GetKeycloakEndpointToken(ctx.RequestData)
+	tokenEndpoint, err := c.configuration.GetKeycloakEndpointToken(ctx.RequestData)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
@@ -66,7 +76,7 @@ func (c *LoginController) Refresh(ctx *app.RefreshLoginContext) error {
 	}
 
 	client := &http.Client{Timeout: 10 * time.Second}
-	endpoint, err := configuration.GetKeycloakEndpointToken(ctx.RequestData)
+	endpoint, err := c.configuration.GetKeycloakEndpointToken(ctx.RequestData)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
@@ -74,8 +84,8 @@ func (c *LoginController) Refresh(ctx *app.RefreshLoginContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("unable to get Keycloak token endpoint URL "+err.Error()))
 	}
 	res, err := client.PostForm(endpoint, url.Values{
-		"client_id":     {configuration.GetKeycloakClientID()},
-		"client_secret": {configuration.GetKeycloakSecret()},
+		"client_id":     {c.configuration.GetKeycloakClientID()},
+		"client_secret": {c.configuration.GetKeycloakSecret()},
 		"refresh_token": {*refreshToken},
 		"grant_type":    {"refresh_token"},
 	})
@@ -124,7 +134,7 @@ func readToken(res *http.Response, ctx jsonapi.InternalServerError) (*app.TokenD
 
 // Generate obtain the access token from Keycloak for the test user
 func (c *LoginController) Generate(ctx *app.GenerateLoginContext) error {
-	if !configuration.IsPostgresDeveloperModeEnabled() {
+	if !c.configuration.IsPostgresDeveloperModeEnabled() {
 		log.Error(ctx, map[string]interface{}{
 			"method": "Generate",
 		}, "Postgres developer mode not enabled")
@@ -138,9 +148,9 @@ func (c *LoginController) Generate(ctx *app.GenerateLoginContext) error {
 
 	client := &http.Client{Timeout: 10 * time.Second}
 
-	username := configuration.GetKeycloakTestUserName()
+	username := c.configuration.GetKeycloakTestUserName()
 
-	endpoint, err := configuration.GetKeycloakEndpointToken(ctx.RequestData)
+	endpoint, err := c.configuration.GetKeycloakEndpointToken(ctx.RequestData)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
@@ -149,10 +159,10 @@ func (c *LoginController) Generate(ctx *app.GenerateLoginContext) error {
 	}
 
 	res, err := client.PostForm(endpoint, url.Values{
-		"client_id":     {configuration.GetKeycloakClientID()},
-		"client_secret": {configuration.GetKeycloakSecret()},
+		"client_id":     {c.configuration.GetKeycloakClientID()},
+		"client_secret": {c.configuration.GetKeycloakSecret()},
 		"username":      {username},
-		"password":      {configuration.GetKeycloakTestUserSecret()},
+		"password":      {c.configuration.GetKeycloakTestUserSecret()},
 		"grant_type":    {"password"},
 	})
 	if err != nil {

--- a/login/service.go
+++ b/login/service.go
@@ -17,8 +17,6 @@ import (
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
-	"github.com/almighty/almighty-core/configuration"
-	jsonapierrors "github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/log"
 	tokencontext "github.com/almighty/almighty-core/login/token_context"
@@ -33,7 +31,7 @@ import (
 
 // Service defines the basic entrypoint required to perform a remote oauth login
 type Service interface {
-	Perform(ctx *app.AuthorizeLoginContext) error
+	Perform(ctx *app.AuthorizeLoginContext, authEndpoint string, tokenEndpoint string) error
 }
 
 // NewKeycloakOAuthProvider creates a new login.Service capable of using keycloak for authorization
@@ -58,7 +56,7 @@ type KeycloakOAuthProvider struct {
 
 // KeycloakOAuthService represents keycloak OAuth service interface
 type KeycloakOAuthService interface {
-	Perform(ctx *app.AuthorizeLoginContext) error
+	Perform(ctx *app.AuthorizeLoginContext, authEndpoint string, tokenEndpoint string) error
 	CreateKeycloakUser(accessToken string, ctx context.Context) (*account.Identity, *account.User, error)
 }
 
@@ -77,7 +75,7 @@ var stateReferer = map[string]string{}
 var mapLock sync.RWMutex
 
 // Perform performs authenticatin
-func (keycloak *KeycloakOAuthProvider) Perform(ctx *app.AuthorizeLoginContext) error {
+func (keycloak *KeycloakOAuthProvider) Perform(ctx *app.AuthorizeLoginContext, authEndpoint string, tokenEndpoint string) error {
 	state := ctx.Params.Get("state")
 	code := ctx.Params.Get("code")
 	referer := ctx.RequestData.Header.Get("Referer")
@@ -148,22 +146,23 @@ func (keycloak *KeycloakOAuthProvider) Perform(ctx *app.AuthorizeLoginContext) e
 
 	stateReferer[state] = referer
 
-	authEndpoint, err := configuration.GetKeycloakEndpointAuth(ctx.RequestData)
-	if err != nil {
-		log.Error(ctx, map[string]interface{}{
-			"err": err,
-		}, "Unable to get Keycloak auth endpoint URL")
-		return jsonapi.JSONErrorResponse(ctx, jsonapierrors.NewInternalError("unable to get Keycloak auth endpoint URL "+err.Error()))
-	}
+	/*
+		authEndpoint, err := configuration.GetKeycloakEndpointAuth(ctx.RequestData)
+		if err != nil {
+			log.Error(ctx, map[string]interface{}{
+				"err": err,
+			}, "Unable to get Keycloak auth endpoint URL")
+			return jsonapi.JSONErrorResponse(ctx, jsonapierrors.NewInternalError("unable to get Keycloak auth endpoint URL "+err.Error()))
+		}
 
-	tokenEndpoint, err := configuration.GetKeycloakEndpointToken(ctx.RequestData)
-	if err != nil {
-		log.Error(ctx, map[string]interface{}{
-			"err": err,
-		}, "Unable to get Keycloak token endpoint URL")
-		return jsonapi.JSONErrorResponse(ctx, jsonapierrors.NewInternalError("unable to get Keycloak token endpoint URL "+err.Error()))
-	}
-
+		tokenEndpoint, err := configuration.GetKeycloakEndpointToken(ctx.RequestData)
+		if err != nil {
+			log.Error(ctx, map[string]interface{}{
+				"err": err,
+			}, "Unable to get Keycloak token endpoint URL")
+			return jsonapi.JSONErrorResponse(ctx, jsonapierrors.NewInternalError("unable to get Keycloak token endpoint URL "+err.Error()))
+		}
+	*/
 	keycloak.config.Endpoint.AuthURL = authEndpoint
 	keycloak.config.Endpoint.TokenURL = tokenEndpoint
 	keycloak.config.RedirectURL = rest.AbsoluteURL(ctx.RequestData, "/api/login/authorize")

--- a/login/service.go
+++ b/login/service.go
@@ -145,24 +145,6 @@ func (keycloak *KeycloakOAuthProvider) Perform(ctx *app.AuthorizeLoginContext, a
 	defer mapLock.Unlock()
 
 	stateReferer[state] = referer
-
-	/*
-		authEndpoint, err := configuration.GetKeycloakEndpointAuth(ctx.RequestData)
-		if err != nil {
-			log.Error(ctx, map[string]interface{}{
-				"err": err,
-			}, "Unable to get Keycloak auth endpoint URL")
-			return jsonapi.JSONErrorResponse(ctx, jsonapierrors.NewInternalError("unable to get Keycloak auth endpoint URL "+err.Error()))
-		}
-
-		tokenEndpoint, err := configuration.GetKeycloakEndpointToken(ctx.RequestData)
-		if err != nil {
-			log.Error(ctx, map[string]interface{}{
-				"err": err,
-			}, "Unable to get Keycloak token endpoint URL")
-			return jsonapi.JSONErrorResponse(ctx, jsonapierrors.NewInternalError("unable to get Keycloak token endpoint URL "+err.Error()))
-		}
-	*/
 	keycloak.config.Endpoint.AuthURL = authEndpoint
 	keycloak.config.Endpoint.TokenURL = tokenEndpoint
 	keycloak.config.RedirectURL = rest.AbsoluteURL(ctx.RequestData, "/api/login/authorize")

--- a/login/service_blackbox_test.go
+++ b/login/service_blackbox_test.go
@@ -117,7 +117,7 @@ func TestKeycloakAuthorizationRedirect(t *testing.T) {
 
 	assert.Equal(t, 307, rw.Code)
 	assert.Contains(t, rw.Header().Get("Location"), oauth.Endpoint.AuthURL)
-	assert.NotEqual(t, oauth.Endpoint.AuthURL, "")
+	assert.NotEqual(t, rw.Header().Get("Location"), "")
 }
 
 func TestValidOAuthAuthorizationCode(t *testing.T) {

--- a/login/service_blackbox_test.go
+++ b/login/service_blackbox_test.go
@@ -109,17 +109,15 @@ func TestKeycloakAuthorizationRedirect(t *testing.T) {
 		Request: &http.Request{Host: "demo.api.almighty.io"},
 	}
 	authEndpoint, err := configuration.GetKeycloakEndpointAuth(r)
-	t.Log(authEndpoint)
 	require.Nil(t, err)
 	tokenEndpoint, err := configuration.GetKeycloakEndpointToken(r)
 	require.Nil(t, err)
-	t.Log(tokenEndpoint)
 
 	err = loginService.Perform(authorizeCtx, authEndpoint, tokenEndpoint)
 
 	assert.Equal(t, 307, rw.Code)
-	//configuration.GetKeycloakEndpointAuth(authorizeCtx.RequestData)
 	assert.Contains(t, rw.Header().Get("Location"), oauth.Endpoint.AuthURL)
+	assert.NotEqual(t, oauth.Endpoint.AuthURL, "")
 }
 
 func TestValidOAuthAuthorizationCode(t *testing.T) {

--- a/login/service_whitebox_test.go
+++ b/login/service_whitebox_test.go
@@ -42,10 +42,7 @@ func init() {
 		ClientID:     configuration.GetKeycloakClientID(),
 		ClientSecret: configuration.GetKeycloakSecret(),
 		Scopes:       []string{"user:email"},
-		Endpoint: oauth2.Endpoint{
-			AuthURL:  "http://sso.demo.almighty.io/auth/realms/fabric8/protocol/openid-connect/auth",
-			TokenURL: "http://sso.demo.almighty.io/auth/realms/fabric8/protocol/openid-connect/token",
-		},
+		Endpoint:     oauth2.Endpoint{},
 	}
 }
 

--- a/login/service_whitebox_test.go
+++ b/login/service_whitebox_test.go
@@ -47,8 +47,6 @@ func init() {
 			TokenURL: "http://sso.demo.almighty.io/auth/realms/fabric8/protocol/openid-connect/token",
 		},
 	}
-
-	fmt.Println(configuration.GetKeycloakClientID())
 }
 
 func setup() {

--- a/login/service_whitebox_test.go
+++ b/login/service_whitebox_test.go
@@ -9,28 +9,36 @@ import (
 
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/resource"
 	testtoken "github.com/almighty/almighty-core/test/token"
 	"github.com/almighty/almighty-core/token"
+
 	_ "github.com/lib/pq"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
 )
 
-var loginService *KeycloakOAuthProvider
+var (
+	oauth         *oauth2.Config
+	configuration *config.ConfigurationData
+	loginService  *KeycloakOAuthProvider
+	privateKey    *rsa.PrivateKey
+)
 
-var privateKey *rsa.PrivateKey
-
-func setup() {
-
+func init() {
 	var err error
-	if err = configuration.Setup(""); err != nil {
+	configuration, err = config.GetConfigurationData()
+	if err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
+	privateKey, err = token.ParsePrivateKey([]byte(configuration.GetTokenPrivateKey()))
+	if err != nil {
+		panic(err)
+	}
 
-	oauth := &oauth2.Config{
+	oauth = &oauth2.Config{
 		ClientID:     configuration.GetKeycloakClientID(),
 		ClientSecret: configuration.GetKeycloakSecret(),
 		Scopes:       []string{"user:email"},
@@ -40,10 +48,10 @@ func setup() {
 		},
 	}
 
-	privateKey, err = token.ParsePrivateKey([]byte(configuration.GetTokenPrivateKey()))
-	if err != nil {
-		panic(err)
-	}
+	fmt.Println(configuration.GetKeycloakClientID())
+}
+
+func setup() {
 
 	tokenManager := token.NewManagerWithPrivateKey(privateKey)
 	userRepository := account.NewUserRepository(nil)

--- a/login_test.go
+++ b/login_test.go
@@ -36,10 +36,7 @@ func newTestKeycloakOAuthProvider() *login.KeycloakOAuthProvider {
 		ClientID:     loginTestConfiguration.GetKeycloakClientID(),
 		ClientSecret: loginTestConfiguration.GetKeycloakSecret(),
 		Scopes:       []string{"user:email"},
-		Endpoint: oauth2.Endpoint{
-			AuthURL:  "http://sso.demo.almighty.io/auth/realms/fabric8/protocol/openid-connect/auth",
-			TokenURL: "http://sso.demo.almighty.io/auth/realms/fabric8/protocol/openid-connect/token",
-		},
+		Endpoint:     oauth2.Endpoint{},
 	}
 
 	publicKey, err := token.ParsePublicKey([]byte(token.RSAPublicKey))

--- a/login_test.go
+++ b/login_test.go
@@ -118,7 +118,7 @@ func validateToken(t *testing.T, token *app.AuthToken, controler *LoginControlle
 
 type TestLoginService struct{}
 
-func (t TestLoginService) Perform(ctx *app.AuthorizeLoginContext) error {
+func (t TestLoginService) Perform(ctx *app.AuthorizeLoginContext, authEndpoint string, tokenEndpoint string) error {
 	return ctx.TemporaryRedirect()
 }
 

--- a/main.go
+++ b/main.go
@@ -156,7 +156,7 @@ func main() {
 	scheduler = remoteworkitem.NewScheduler(db)
 	defer scheduler.Stop()
 
-	accessTokens := getAccessTokens(configuration) //configuration.GetGithubAuthToken()
+	accessTokens := getAccessTokens(configuration)
 	scheduler.ScheduleAllQueries(accessTokens)
 
 	// Create service

--- a/main.go
+++ b/main.go
@@ -155,7 +155,9 @@ func main() {
 	// Scheduler to fetch and import remote tracker items
 	scheduler = remoteworkitem.NewScheduler(db)
 	defer scheduler.Stop()
-	scheduler.ScheduleAllQueries()
+
+	accessTokens := getAccessTokens() //configuration.GetGithubAuthToken()
+	scheduler.ScheduleAllQueries(accessTokens)
 
 	// Create service
 	service := goa.New("alm")

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -6,7 +6,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
+
 	"github.com/almighty/almighty-core/resource"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
@@ -15,8 +16,8 @@ import (
 func TestConcurrentMigrations(t *testing.T) {
 	resource.Require(t, resource.Database)
 
-	var err error
-	if err = configuration.Setup(""); err != nil {
+	configuration, err := config.GetConfigurationData()
+	if err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
 

--- a/remoteworkitem/github.go
+++ b/remoteworkitem/github.go
@@ -3,7 +3,6 @@ package remoteworkitem
 import (
 	"encoding/json"
 
-	"github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/log"
 
 	"github.com/google/go-github/github"
@@ -32,10 +31,11 @@ func (f *githubIssueFetcher) listIssues(query string, opts *github.SearchOptions
 }
 
 // Fetch tracker items from Github
-func (g *GithubTracker) Fetch() chan TrackerItemContent {
+func (g *GithubTracker) Fetch(githubAuthToken string) chan TrackerItemContent {
 	f := githubIssueFetcher{}
 	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: configuration.GetGithubAuthToken()},
+		//&oauth2.Token{AccessToken: configuration.GetGithubAuthToken()},
+		&oauth2.Token{AccessToken: githubAuthToken},
 	)
 	tc := oauth2.NewClient(oauth2.NoContext, ts)
 	f.client = github.NewClient(tc)

--- a/remoteworkitem/github.go
+++ b/remoteworkitem/github.go
@@ -34,7 +34,6 @@ func (f *githubIssueFetcher) listIssues(query string, opts *github.SearchOptions
 func (g *GithubTracker) Fetch(githubAuthToken string) chan TrackerItemContent {
 	f := githubIssueFetcher{}
 	ts := oauth2.StaticTokenSource(
-		//&oauth2.Token{AccessToken: configuration.GetGithubAuthToken()},
 		&oauth2.Token{AccessToken: githubAuthToken},
 	)
 	tc := oauth2.NewClient(oauth2.NoContext, ts)

--- a/remoteworkitem/jira.go
+++ b/remoteworkitem/jira.go
@@ -30,7 +30,7 @@ func (f *jiraIssueFetcher) getIssue(issueID string) (*jira.Issue, *jira.Response
 }
 
 // Fetch collects data from Jira
-func (j *JiraTracker) Fetch() chan TrackerItemContent {
+func (j *JiraTracker) Fetch(authToken string) chan TrackerItemContent {
 	f := jiraIssueFetcher{}
 	client, _ := jira.NewClient(nil, j.URL)
 	f.client = client

--- a/remoteworkitem/scheduler_test.go
+++ b/remoteworkitem/scheduler_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/migration"
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/resource"
@@ -19,9 +19,8 @@ import (
 var db *gorm.DB
 
 func TestMain(m *testing.M) {
-	var err error
-
-	if err = configuration.Setup(""); err != nil {
+	configuration, err := config.GetConfigurationData()
+	if err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
 

--- a/search.go
+++ b/search.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
-	"github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/log"
@@ -15,18 +14,23 @@ import (
 	errs "github.com/pkg/errors"
 )
 
+type searchConfiguration interface {
+	GetHTTPAddress() string
+}
+
 // SearchController implements the search resource.
 type SearchController struct {
 	*goa.Controller
-	db application.DB
+	db            application.DB
+	configuration searchConfiguration
 }
 
 // NewSearchController creates a search controller.
-func NewSearchController(service *goa.Service, db application.DB) *SearchController {
+func NewSearchController(service *goa.Service, db application.DB, configuration searchConfiguration) *SearchController {
 	if db == nil {
 		panic("db must not be nil")
 	}
-	return &SearchController{Controller: service.NewController("SearchController"), db: db}
+	return &SearchController{Controller: service.NewController("SearchController"), db: db, configuration: configuration}
 }
 
 // Show runs the show action.
@@ -39,7 +43,7 @@ func (c *SearchController) Show(ctx *app.ShowSearchContext) error {
 	// ToDo : Keep URL registeration central somehow.
 	hostString := ctx.RequestData.Host
 	if hostString == "" {
-		hostString = configuration.GetHTTPAddress()
+		hostString = c.configuration.GetHTTPAddress()
 	}
 	urlRegexString := fmt.Sprintf("(?P<domain>%s)(?P<path>/work-item/list/detail/)(?P<id>\\d*)", hostString)
 	search.RegisterAsKnownURL(search.HostRegistrationKeyForListWI, urlRegexString)

--- a/search_blackbox_test.go
+++ b/search_blackbox_test.go
@@ -12,9 +12,11 @@ import (
 	. "github.com/almighty/almighty-core"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/rendering"
+
 	"github.com/almighty/almighty-core/resource"
 	"github.com/almighty/almighty-core/search"
 	testsupport "github.com/almighty/almighty-core/test"
@@ -27,6 +29,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
+
+var spaceBlackBoxTestConfiguration *config.ConfigurationData
+
+func init() {
+	var err error
+	spaceBlackBoxTestConfiguration, err = config.GetConfigurationData()
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+}
 
 func getServiceAsUser() *goa.Service {
 	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
@@ -52,7 +64,7 @@ func TestSearch(t *testing.T) {
 		},
 		uuid.NewV4())
 	require.Nil(t, err)
-	controller := NewSearchController(service, gormapplication.NewGormDB(DB))
+	controller := NewSearchController(service, gormapplication.NewGormDB(DB), spaceBlackBoxTestConfiguration)
 	q := "specialwordforsearch"
 	_, sr := test.ShowSearchOK(t, nil, nil, controller, nil, nil, q)
 	require.NotEmpty(t, sr.Data)
@@ -79,7 +91,7 @@ func TestSearchPagination(t *testing.T) {
 		uuid.NewV4())
 	require.Nil(t, err)
 
-	controller := NewSearchController(service, gormapplication.NewGormDB(DB))
+	controller := NewSearchController(service, gormapplication.NewGormDB(DB), spaceBlackBoxTestConfiguration)
 	q := "specialwordforsearch2"
 	_, sr := test.ShowSearchOK(t, nil, nil, controller, nil, nil, q)
 
@@ -109,7 +121,7 @@ func TestSearchWithEmptyValue(t *testing.T) {
 		uuid.NewV4())
 	require.Nil(t, err)
 
-	controller := NewSearchController(service, gormapplication.NewGormDB(DB))
+	controller := NewSearchController(service, gormapplication.NewGormDB(DB), spaceBlackBoxTestConfiguration)
 	q := ""
 	_, sr := test.ShowSearchOK(t, nil, nil, controller, nil, nil, q)
 	require.NotNil(t, sr.Data)
@@ -135,7 +147,7 @@ func TestSearchWithDomainPortCombination(t *testing.T) {
 		uuid.NewV4())
 	require.Nil(t, err)
 
-	controller := NewSearchController(service, gormapplication.NewGormDB(DB))
+	controller := NewSearchController(service, gormapplication.NewGormDB(DB), spaceBlackBoxTestConfiguration)
 	q := `"http://localhost:8080/detail/154687364529310"`
 	_, sr := test.ShowSearchOK(t, nil, nil, controller, nil, nil, q)
 	require.NotEmpty(t, sr.Data)
@@ -163,7 +175,7 @@ func TestSearchURLWithoutPort(t *testing.T) {
 		uuid.NewV4())
 	require.Nil(t, err)
 
-	controller := NewSearchController(service, gormapplication.NewGormDB(DB))
+	controller := NewSearchController(service, gormapplication.NewGormDB(DB), spaceBlackBoxTestConfiguration)
 	q := `"http://localhost/detail/876394"`
 	_, sr := test.ShowSearchOK(t, nil, nil, controller, nil, nil, q)
 	require.NotEmpty(t, sr.Data)
@@ -191,7 +203,7 @@ func TestUnregisteredURLWithPort(t *testing.T) {
 		uuid.NewV4())
 	require.Nil(t, err)
 
-	controller := NewSearchController(service, gormapplication.NewGormDB(DB))
+	controller := NewSearchController(service, gormapplication.NewGormDB(DB), spaceBlackBoxTestConfiguration)
 	q := `http://some-other-domain:8080/different-path/`
 	_, sr := test.ShowSearchOK(t, nil, nil, controller, nil, nil, q)
 	require.NotEmpty(t, sr.Data)
@@ -219,7 +231,7 @@ func TestUnwantedCharactersRelatedToSearchLogic(t *testing.T) {
 		uuid.NewV4())
 	require.Nil(t, err)
 
-	controller := NewSearchController(service, gormapplication.NewGormDB(DB))
+	controller := NewSearchController(service, gormapplication.NewGormDB(DB), spaceBlackBoxTestConfiguration)
 	// add url: in the query, that is not expected by the code hence need to make sure it gives expected result.
 	q := `http://url:some-random-other-domain:8080/different-path/`
 	_, sr := test.ShowSearchOK(t, nil, nil, controller, nil, nil, q)
@@ -275,7 +287,7 @@ func searchByURL(t *testing.T, customHost, queryString string) *app.SearchWorkIt
 	if err != nil {
 		panic("invalid test data " + err.Error()) // bug
 	}
-	ctrl := NewSearchController(service, gormapplication.NewGormDB(DB))
+	ctrl := NewSearchController(service, gormapplication.NewGormDB(DB), spaceBlackBoxTestConfiguration)
 	// Perform action
 	err = ctrl.Show(showCtx)
 

--- a/search_spaces_blackbox_test.go
+++ b/search_spaces_blackbox_test.go
@@ -6,17 +6,19 @@ import (
 	"strconv"
 	"testing"
 
+	"strings"
+
 	. "github.com/almighty/almighty-core"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
 	"github.com/almighty/almighty-core/application"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/almighty/almighty-core/space"
 	"github.com/goadesign/goa"
 	"golang.org/x/net/context"
-	"strings"
 )
 
 type args struct {
@@ -65,7 +67,12 @@ func TestSpacesSearchOK(t *testing.T) {
 	}
 
 	service := goa.New("TestSpacesSearch-Service")
-	controller := NewSearchController(service, tester.db)
+	configuration, err := config.GetConfigurationData()
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+
+	controller := NewSearchController(service, tester.db, configuration)
 
 	for _, tt := range tests {
 		_, result := test.SpacesSearchOK(t, context.Background(), service, controller, tt.args.pageLimit, tt.args.pageOffset, tt.args.q)

--- a/tracker.go
+++ b/tracker.go
@@ -43,7 +43,8 @@ func (c *TrackerController) Create(ctx *app.CreateTrackerContext) error {
 		ctx.ResponseData.Header().Set("Location", app.TrackerHref(t.ID))
 		return ctx.Created(t)
 	})
-	c.scheduler.ScheduleAllQueries()
+	accessTokens := getAccessTokens() //configuration.GetGithubAuthToken()
+	c.scheduler.ScheduleAllQueries(accessTokens)
 	return result
 }
 
@@ -64,7 +65,8 @@ func (c *TrackerController) Delete(ctx *app.DeleteTrackerContext) error {
 		}
 		return ctx.OK([]byte{})
 	})
-	c.scheduler.ScheduleAllQueries()
+	accessTokens := getAccessTokens() //configuration.GetGithubAuthToken()
+	c.scheduler.ScheduleAllQueries(accessTokens)
 	return result
 }
 
@@ -137,6 +139,7 @@ func (c *TrackerController) Update(ctx *app.UpdateTrackerContext) error {
 		}
 		return ctx.OK(t)
 	})
-	c.scheduler.ScheduleAllQueries()
+	accessTokens := getAccessTokens() //configuration.GetGithubAuthToken()
+	c.scheduler.ScheduleAllQueries(accessTokens)
 	return result
 }

--- a/tracker_blackbox_test.go
+++ b/tracker_blackbox_test.go
@@ -2,18 +2,31 @@ package main_test
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"testing"
 
 	. "github.com/almighty/almighty-core"
 	"github.com/almighty/almighty-core/app"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
+
 	"github.com/almighty/almighty-core/jsonapi"
 	almtoken "github.com/almighty/almighty-core/token"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
 	"github.com/stretchr/testify/require"
 )
+
+var trackerBlackBoxTestConfiguration *config.ConfigurationData
+
+func init() {
+	var err error
+	trackerBlackBoxTestConfiguration, err = config.GetConfigurationData()
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+}
 
 func getTrackerTestData(t *testing.T) []testSecureAPI {
 	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(almtoken.RSAPrivateKey))
@@ -134,7 +147,7 @@ func TestUnauthorizeTrackerCUD(t *testing.T) {
 	UnauthorizeCreateUpdateDeleteTest(t, getTrackerTestData, func() *goa.Service {
 		return goa.New("TestUnauthorizedTracker-Service")
 	}, func(service *goa.Service) error {
-		controller := NewTrackerController(service, gormapplication.NewGormDB(DB), RwiScheduler)
+		controller := NewTrackerController(service, gormapplication.NewGormDB(DB), RwiScheduler, trackerBlackBoxTestConfiguration)
 		app.MountTrackerController(service, controller)
 		return nil
 	})

--- a/tracker_test.go
+++ b/tracker_test.go
@@ -1,19 +1,32 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
+
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/resource"
 )
 
+var trTestConfiguration *config.ConfigurationData
+
+func init() {
+	var err error
+	trTestConfiguration, err = config.GetConfigurationData()
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+}
+
 func TestCreateTracker(t *testing.T) {
 	resource.Require(t, resource.Database)
 	defer cleaner.DeleteCreatedEntities(DB)()
-	controller := TrackerController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler}
+	controller := TrackerController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler, configuration: trTestConfiguration}
 	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://issues.jboss.com",
 		Type: "jira",
@@ -28,7 +41,7 @@ func TestCreateTracker(t *testing.T) {
 func TestGetTracker(t *testing.T) {
 	resource.Require(t, resource.Database)
 	defer cleaner.DeleteCreatedEntities(DB)()
-	controller := TrackerController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler}
+	controller := TrackerController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler, configuration: trTestConfiguration}
 	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://issues.jboss.com",
 		Type: "jira",
@@ -66,7 +79,7 @@ func TestGetTracker(t *testing.T) {
 func TestTrackerListItemsNotNil(t *testing.T) {
 	resource.Require(t, resource.Database)
 	defer cleaner.DeleteCreatedEntities(DB)()
-	controller := TrackerController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler}
+	controller := TrackerController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler, configuration: trTestConfiguration}
 	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://issues.jboss.com",
 		Type: "jira",
@@ -89,7 +102,7 @@ func TestTrackerListItemsNotNil(t *testing.T) {
 func TestCreateTrackerValidId(t *testing.T) {
 	resource.Require(t, resource.Database)
 	defer cleaner.DeleteCreatedEntities(DB)()
-	controller := TrackerController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler}
+	controller := TrackerController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler, configuration: trTestConfiguration}
 	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://issues.jboss.com",
 		Type: "jira",

--- a/trackerquery.go
+++ b/trackerquery.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/log"
 	"github.com/almighty/almighty-core/remoteworkitem"
@@ -17,6 +18,18 @@ type TrackerqueryController struct {
 	*goa.Controller
 	db        application.DB
 	scheduler *remoteworkitem.Scheduler
+}
+
+type TrackerQueryConfiguration interface {
+	GetGithubAuthToken() string
+}
+
+func getAccessTokens() map[string]string {
+	tokens := map[string]string{
+		remoteworkitem.ProviderGithub: configuration.GetGithubAuthToken(),
+		// add tokens for other types
+	}
+	return tokens
 }
 
 // NewTrackerqueryController creates a trackerquery controller.
@@ -42,7 +55,8 @@ func (c *TrackerqueryController) Create(ctx *app.CreateTrackerqueryContext) erro
 		ctx.ResponseData.Header().Set("Location", app.TrackerqueryHref(tq.ID))
 		return ctx.Created(tq)
 	})
-	c.scheduler.ScheduleAllQueries()
+	accessTokens := getAccessTokens() //configuration.GetGithubAuthToken()
+	c.scheduler.ScheduleAllQueries(accessTokens)
 	return result
 }
 
@@ -92,7 +106,8 @@ func (c *TrackerqueryController) Update(ctx *app.UpdateTrackerqueryContext) erro
 		}
 		return ctx.OK(tq)
 	})
-	c.scheduler.ScheduleAllQueries()
+	accessTokens := getAccessTokens() //configuration.GetGithubAuthToken()
+	c.scheduler.ScheduleAllQueries(accessTokens)
 	return result
 }
 
@@ -113,7 +128,8 @@ func (c *TrackerqueryController) Delete(ctx *app.DeleteTrackerqueryContext) erro
 		}
 		return ctx.OK([]byte{})
 	})
-	c.scheduler.ScheduleAllQueries()
+	accessTokens := getAccessTokens() //configuration.GetGithubAuthToken()
+	c.scheduler.ScheduleAllQueries(accessTokens)
 	return result
 }
 

--- a/trackerquery.go
+++ b/trackerquery.go
@@ -34,7 +34,7 @@ func getAccessTokensForTrackerQuery(configuration trackerQueryConfiguration) map
 
 // NewTrackerqueryController creates a trackerquery controller.
 func NewTrackerqueryController(service *goa.Service, db application.DB, scheduler *remoteworkitem.Scheduler, configuration trackerQueryConfiguration) *TrackerqueryController {
-	return &TrackerqueryController{Controller: service.NewController("TrackerqueryController"), db: db, scheduler: scheduler}
+	return &TrackerqueryController{Controller: service.NewController("TrackerqueryController"), db: db, scheduler: scheduler, configuration: configuration}
 }
 
 // Create runs the create action.

--- a/trackerquery_blackbox_test.go
+++ b/trackerquery_blackbox_test.go
@@ -4,10 +4,14 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	. "github.com/almighty/almighty-core"
+	"github.com/almighty/almighty-core/app/test"
 	config "github.com/almighty/almighty-core/configuration"
+	"github.com/almighty/almighty-core/resource"
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/gormapplication"
@@ -15,7 +19,7 @@ import (
 	almtoken "github.com/almighty/almighty-core/token"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
-	//	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	"github.com/stretchr/testify/require"
 )
 
@@ -154,7 +158,6 @@ func TestUnauthorizeTrackerQueryCUD(t *testing.T) {
 	})
 }
 
-/*
 func TestCreateTrackerQueryREST(t *testing.T) {
 	resource.Require(t, resource.Database)
 
@@ -196,4 +199,3 @@ func TestCreateTrackerQueryREST(t *testing.T) {
 
 	server.Close()
 }
-*/

--- a/trackerquery_blackbox_test.go
+++ b/trackerquery_blackbox_test.go
@@ -4,22 +4,30 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 
 	. "github.com/almighty/almighty-core"
+	config "github.com/almighty/almighty-core/configuration"
+
 	"github.com/almighty/almighty-core/app"
-	"github.com/almighty/almighty-core/app/test"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/jsonapi"
-	"github.com/almighty/almighty-core/resource"
 	almtoken "github.com/almighty/almighty-core/token"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
-	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+	//	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	"github.com/stretchr/testify/require"
 )
+
+var trackerQueryBlackBoxTestConfiguration *config.ConfigurationData
+
+func init() {
+	var err error
+	trackerQueryBlackBoxTestConfiguration, err = config.GetConfigurationData()
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+}
 
 func getTrackerQueryTestData(t *testing.T) []testSecureAPI {
 	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(almtoken.RSAPrivateKey))
@@ -140,12 +148,13 @@ func TestUnauthorizeTrackerQueryCUD(t *testing.T) {
 	UnauthorizeCreateUpdateDeleteTest(t, getTrackerQueryTestData, func() *goa.Service {
 		return goa.New("TestUnauthorizedTrackerQuery-Service")
 	}, func(service *goa.Service) error {
-		controller := NewTrackerqueryController(service, gormapplication.NewGormDB(DB), RwiScheduler)
+		controller := NewTrackerqueryController(service, gormapplication.NewGormDB(DB), RwiScheduler, trackerQueryBlackBoxTestConfiguration)
 		app.MountTrackerqueryController(service, controller)
 		return nil
 	})
 }
 
+/*
 func TestCreateTrackerQueryREST(t *testing.T) {
 	resource.Require(t, resource.Database)
 
@@ -156,7 +165,7 @@ func TestCreateTrackerQueryREST(t *testing.T) {
 
 	service := goa.New("API")
 
-	controller := NewTrackerController(service, gormapplication.NewGormDB(DB), RwiScheduler)
+	controller := NewTrackerController(service, gormapplication.NewGormDB(DB), RwiScheduler, trackerQueryBlackBoxTestConfiguration)
 	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://api.github.com",
 		Type: "github",
@@ -166,7 +175,7 @@ func TestCreateTrackerQueryREST(t *testing.T) {
 	jwtMiddleware := goajwt.New(&privatekey.PublicKey, nil, app.NewJWTSecurity())
 	app.UseJWTMiddleware(service, jwtMiddleware)
 
-	controller2 := NewTrackerqueryController(service, gormapplication.NewGormDB(DB), RwiScheduler)
+	controller2 := NewTrackerqueryController(service, gormapplication.NewGormDB(DB), RwiScheduler, trackerQueryBlackBoxTestConfiguration)
 	app.MountTrackerqueryController(service, controller2)
 
 	server := httptest.NewServer(service.Mux)
@@ -187,3 +196,4 @@ func TestCreateTrackerQueryREST(t *testing.T) {
 
 	server.Close()
 }
+*/

--- a/trackerquery_test.go
+++ b/trackerquery_test.go
@@ -6,22 +6,33 @@ import (
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/resource"
 )
 
+var trQueryTestConfiguration *config.ConfigurationData
+
+func init() {
+	var err error
+	trQueryTestConfiguration, err = config.GetConfigurationData()
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+}
+
 func TestCreateTrackerQuery(t *testing.T) {
 	resource.Require(t, resource.Database)
 	defer cleaner.DeleteCreatedEntities(DB)()
-	controller := TrackerController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler}
+	controller := TrackerController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler, configuration: configuration}
 	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://api.github.com",
 		Type: "github",
 	}
 	_, result := test.CreateTrackerCreated(t, nil, nil, &controller, &payload)
 	t.Log(result.ID)
-	tqController := TrackerqueryController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler}
+	tqController := TrackerqueryController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler, configuration: configuration}
 	tqpayload := app.CreateTrackerQueryAlternatePayload{
 
 		Query:     "is:open is:issue user:arquillian author:aslakknutsen",
@@ -39,14 +50,14 @@ func TestCreateTrackerQuery(t *testing.T) {
 func TestGetTrackerQuery(t *testing.T) {
 	resource.Require(t, resource.Database)
 	defer cleaner.DeleteCreatedEntities(DB)()
-	controller := TrackerController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler}
+	controller := TrackerController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler, configuration: configuration}
 	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://api.github.com",
 		Type: "github",
 	}
 	_, result := test.CreateTrackerCreated(t, nil, nil, &controller, &payload)
 
-	tqController := TrackerqueryController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler}
+	tqController := TrackerqueryController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler, configuration: configuration}
 	tqpayload := app.CreateTrackerQueryAlternatePayload{
 
 		Query:     "is:open is:issue user:arquillian author:aslakknutsen",
@@ -69,14 +80,14 @@ func TestGetTrackerQuery(t *testing.T) {
 func TestUpdateTrackerQuery(t *testing.T) {
 	resource.Require(t, resource.Database)
 	defer cleaner.DeleteCreatedEntities(DB)()
-	controller := TrackerController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler}
+	controller := TrackerController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler, configuration: configuration}
 	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://api.github.com",
 		Type: "github",
 	}
 	_, result := test.CreateTrackerCreated(t, nil, nil, &controller, &payload)
 
-	tqController := TrackerqueryController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler}
+	tqController := TrackerqueryController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler, configuration: configuration}
 	tqpayload := app.CreateTrackerQueryAlternatePayload{
 
 		Query:     "is:open is:issue user:arquillian author:aslakknutsen",
@@ -117,14 +128,14 @@ func TestUpdateTrackerQuery(t *testing.T) {
 func TestTrackerQueryListItemsNotNil(t *testing.T) {
 	resource.Require(t, resource.Database)
 	defer cleaner.DeleteCreatedEntities(DB)()
-	controller := TrackerController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler}
+	controller := TrackerController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler, configuration: configuration}
 	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://api.github.com",
 		Type: "github",
 	}
 	_, result := test.CreateTrackerCreated(t, nil, nil, &controller, &payload)
 	t.Log(result.ID)
-	tqController := TrackerqueryController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler}
+	tqController := TrackerqueryController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler, configuration: configuration}
 	tqpayload := app.CreateTrackerQueryAlternatePayload{
 
 		Query:     "is:open is:issue user:arquillian author:aslakknutsen",
@@ -147,14 +158,14 @@ func TestTrackerQueryListItemsNotNil(t *testing.T) {
 func TestCreateTrackerQueryValidId(t *testing.T) {
 	resource.Require(t, resource.Database)
 	defer cleaner.DeleteCreatedEntities(DB)()
-	controller := TrackerController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler}
+	controller := TrackerController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler, configuration: configuration}
 	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://api.github.com",
 		Type: "github",
 	}
 	_, result := test.CreateTrackerCreated(t, nil, nil, &controller, &payload)
 	t.Log(result.ID)
-	tqController := TrackerqueryController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler}
+	tqController := TrackerqueryController{Controller: nil, db: gormapplication.NewGormDB(DB), scheduler: RwiScheduler, configuration: configuration}
 	tqpayload := app.CreateTrackerQueryAlternatePayload{
 
 		Query:     "is:open is:issue user:arquillian author:aslakknutsen",

--- a/work-item-link-blackbox_test.go
+++ b/work-item-link-blackbox_test.go
@@ -13,10 +13,11 @@ import (
 	. "github.com/almighty/almighty-core"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/migration"
+
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/resource"
 	testsupport "github.com/almighty/almighty-core/test"
@@ -60,16 +61,22 @@ type workItemLinkSuite struct {
 	deleteWorkItems     []string
 }
 
+var wiConfiguration *config.ConfigurationData
+
+func init() {
+	var err error
+	wiConfiguration, err = config.GetConfigurationData()
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+}
+
 // The SetupSuite method will run before the tests in the suite are run.
 // It sets up a database connection for all the tests in this suite without polluting global space.
 func (s *workItemLinkSuite) SetupSuite() {
 	var err error
 
-	if err = configuration.Setup(""); err != nil {
-		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
-	}
-
-	s.db, err = gorm.Open("postgres", configuration.GetPostgresConfigString())
+	s.db, err = gorm.Open("postgres", wiConfiguration.GetPostgresConfigString())
 
 	if err != nil {
 		panic("Failed to connect database: " + err.Error())
@@ -612,7 +619,7 @@ func (s *workItemLinkSuite) TestListWorkItemRelationshipsLinksNotFoundDueToInval
 }
 
 func getWorkItemLinkTestData(t *testing.T) []testSecureAPI {
-	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((configuration.GetTokenPrivateKey()))
+	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((wiConfiguration.GetTokenPrivateKey()))
 	if err != nil {
 		t.Fatal("Could not parse Key ", err)
 	}
@@ -772,7 +779,7 @@ func (s *workItemLinkSuite) TestUnauthorizeWorkItemLinkCUD() {
 // The work item ID will be used to construct /api/workitems/:id/relationships/links endpoints
 func getWorkItemRelationshipLinksTestData(t *testing.T, wiID string) func(t *testing.T) []testSecureAPI {
 	return func(t *testing.T) []testSecureAPI {
-		privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((configuration.GetTokenPrivateKey()))
+		privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((wiConfiguration.GetTokenPrivateKey()))
 		if err != nil {
 			t.Fatal("Could not parse Key ", err)
 		}

--- a/work-item-link-category-blackbox_test.go
+++ b/work-item-link-category-blackbox_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/almighty/almighty-core"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/migration"
@@ -40,16 +40,22 @@ type workItemLinkCategorySuite struct {
 	linkCatCtrl *WorkItemLinkCategoryController
 }
 
+var wilCatConfiguration *config.ConfigurationData
+
+func init() {
+	var err error
+	wilCatConfiguration, err = config.GetConfigurationData()
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+}
+
 // The SetupSuite method will run before the tests in the suite are run.
 // It sets up a database connection for all the tests in this suite without polluting global space.
 func (s *workItemLinkCategorySuite) SetupSuite() {
 	var err error
 
-	if err = configuration.Setup(""); err != nil {
-		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
-	}
-
-	s.db, err = gorm.Open("postgres", configuration.GetPostgresConfigString())
+	s.db, err = gorm.Open("postgres", wilCatConfiguration.GetPostgresConfigString())
 
 	if err != nil {
 		panic("Failed to connect database: " + err.Error())
@@ -340,7 +346,7 @@ func TestSuiteWorkItemLinkCategory(t *testing.T) {
 }
 
 func getWorkItemLinkCategoryTestData(t *testing.T) []testSecureAPI {
-	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((configuration.GetTokenPrivateKey()))
+	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((wilCatConfiguration.GetTokenPrivateKey()))
 	if err != nil {
 		t.Fatal("Could not parse Key ", err)
 	}

--- a/work-item-link-type-blackbox_test.go
+++ b/work-item-link-type-blackbox_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/almighty/almighty-core"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/migration"
@@ -42,16 +42,26 @@ type workItemLinkTypeSuite struct {
 	//	typeCtrl     *WorkitemtypeController
 }
 
+var wiltConfiguration *config.ConfigurationData
+
+func init() {
+	var err error
+	wiltConfiguration, err = config.GetConfigurationData()
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+}
+
 // The SetupSuite method will run before the tests in the suite are run.
 // It sets up a database connection for all the tests in this suite without polluting global space.
 func (s *workItemLinkTypeSuite) SetupSuite() {
 	var err error
-
-	if err = configuration.Setup(""); err != nil {
+	wiltConfiguration, err = config.GetConfigurationData()
+	if err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
 
-	s.db, err = gorm.Open("postgres", configuration.GetPostgresConfigString())
+	s.db, err = gorm.Open("postgres", wiltConfiguration.GetPostgresConfigString())
 
 	if err != nil {
 		panic("Failed to connect database: " + err.Error())
@@ -295,7 +305,7 @@ func (s *workItemLinkTypeSuite) TestListWorkItemLinkTypeOK() {
 }
 
 func getWorkItemLinkTypeTestData(t *testing.T) []testSecureAPI {
-	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((configuration.GetTokenPrivateKey()))
+	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((wiltConfiguration.GetTokenPrivateKey()))
 	if err != nil {
 		t.Fatal("Could not parse Key ", err)
 	}

--- a/workitem_whitebox_test.go
+++ b/workitem_whitebox_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/migration"
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/remoteworkitem"
@@ -25,11 +25,13 @@ import (
 
 var DB *gorm.DB
 var RwiScheduler *remoteworkitem.Scheduler
+var configuration *config.ConfigurationData
 
 func TestMain(m *testing.M) {
 	var err error
 
-	if err = configuration.Setup(""); err != nil {
+	configuration, err = config.GetConfigurationData()
+	if err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
 

--- a/workitemtype_blackbox_test.go
+++ b/workitemtype_blackbox_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/almighty/almighty-core"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
-	"github.com/almighty/almighty-core/configuration"
+	config "github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
@@ -27,6 +27,16 @@ import (
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/net/context"
 )
+
+var witbConfiguration *config.ConfigurationData
+
+func init() {
+	var err error
+	witbConfiguration, err = config.GetConfigurationData()
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+}
 
 //-----------------------------------------------------------------------------
 // Test Suite setup
@@ -291,7 +301,7 @@ func (s *workItemTypeSuite) TestListSourceAndTargetLinkTypesNotFound() {
 }
 
 func getWorkItemTypeTestData(t *testing.T) []testSecureAPI {
-	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((configuration.GetTokenPrivateKey()))
+	privatekey, err := jwt.ParseRSAPrivateKeyFromPEM((witbConfiguration.GetTokenPrivateKey()))
 	if err != nil {
 		t.Fatal("Could not parse Key ", err)
 	}


### PR DESCRIPTION
This PR which fixes #592  was being solved as part of #712 - here's the new PR with the new approach.

(  After feedback from  @aslakknutsen I realized what I was doing there wasn't solving the problem. Since this change spans the entire codebase, it wasn't productive to make the new changes in the old PR ( after fixing tons of conflicts ) , hence this new one ) 

The very high-level requirement is :

    - initialize config only once.
    -  pass configuration options at the controller level.
    - expose only those configurations which are needed.


The objective of this PR , and the stuff that was done to accomplish the above:

1. Avoid setting up configuration multiple times in different parts of the code. It needs to be setup only *once* inside main.go and should be passed on to all the services/controllers.

2. The controller should then pass on the required config values like tokens to the methods needed. Example, the Search Service does not need to have access to the github tokens. 

In `main.go` we pass the configuration object ( created only once in main.go )

```
configuration, err := config.NewConfigurationData(configFilePath)

..
..
..

searchCtrl := NewSearchController(service, appDB, configuration)
c6 := NewTrackerqueryController(service, appDB, scheduler, configuration)
```

For every service which needs to have access to configuration, we define the following in controller file 
For example , in case of `./trackerquery.go` 

```
type trackerConfiguration interface {
	GetGithubAuthToken() string
}

// TrackerController implements the tracker resource.
type TrackerController struct {
	*goa.Controller
	db            application.DB
	scheduler     *remoteworkitem.Scheduler
	configuration trackerConfiguration
}
```

3. Empower *only* the services/controllers to have direct access to the configuration layer to the configuration information it needs. 

```
func (c *TrackerqueryController) Create(ctx *app.CreateTrackerqueryContext) error {

         ...
         ...

         authToken := c.configuration.GetGithubAuthToken()

         ...
         ...

}
```

4. All other models/utility methods should **not** be accessing the configuration directly since configuration is an environment subject. This cuts down the need of the `configuration` objects' presence all over the code.

Example, in `login/service.go`

```


// Previously - Perform oauth2 flow
func Perform(){

/*
  -  get authEndpoint , tokenEndpoint from environment/viper and 
  -  execute the workflow
*/

}


// Now - Perform oauth2 workflow
func Perform(authEndpoint , tokenEndpoint){

/*

  -  get authEndpoint , tokenEndpoint from arguments passed
  -  execute the workflow

*/

}
```
