### PR TITLE
This should fix the ever occurring test failure with duplicate keys

### DIFF
--- a/search/search_repository_blackbox_test.go
+++ b/search/search_repository_blackbox_test.go
@@ -37,7 +37,7 @@ func (s *searchRepositoryBlackboxTest) SetupSuite() {
 	}
 }
 
-func TestRunSearchRepositoryWhiteboxTest(t *testing.T) {
+func TestRunSearchRepositoryBlackboxTest(t *testing.T) {
 	suite.Run(t, &searchRepositoryBlackboxTest{DBTestSuite: gormsupport.NewDBTestSuite("../config.yaml")})
 }
 

--- a/status_test.go
+++ b/status_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestShowStatusOK(t *testing.T) {
-	t.Parallel()
 	resource.Require(t, resource.Database)
 	controller := StatusController{db: DB}
 	_, res := test.ShowStatusOK(t, nil, nil, &controller)


### PR DESCRIPTION
For example in this [CI run](https://ci.centos.org/job/devtools-almighty-core/1925/console) we experienced this issue (and in many more):

```
--- FAIL: TestRunSearchRepositoryWhiteboxTest (0.03s)
panic: pq: duplicate key value violates unique constraint "work_item_types_pkey" [recovered]
	panic: pq: duplicate key value violates unique constraint "work_item_types_pkey"
```

I found that function `TestRunSearchRepositoryWhiteboxTest` existed twice in the `search` package:

```sh
$ grep "TestRunSearchRepositoryWhiteboxTest" . -r
./search/search_repository_whitebox_test.go:func TestRunSearchRepositoryWhiteboxTest(t *testing.T) {
./search/search_repository_blackbox_test.go:func TestRunSearchRepositoryWhiteboxTest(t *testing.T) {
```

Also, there was a test that wanted to run in parallel but required the database to be present. This is considered bad practice.

See also #819