### PR TITLE
Add configuration options for db pool max idle and max open

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,8 @@ postgres.sslmode: disable
 postgres.connection.timeout: 5
 # Duration to wait before trying to connect again
 postgres.connection.retrysleep: 1s
+postgres.connection.maxidle: -1
+postgres.connection.maxopen: -1
 
 #------------------------
 # HTTP configuration

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -74,6 +74,8 @@ const (
 	varPostgresSSLMode              = "postgres.sslmode"
 	varPostgresConnectionTimeout    = "postgres.connection.timeout"
 	varPostgresConnectionRetrySleep = "postgres.connection.retrysleep"
+	varPostgresConnectionMaxIdle    = "postgres.connection.maxidle"
+	varPostgresConnectionMaxOpen    = "postgres.connection.maxopen"
 	varPopulateCommonTypes          = "populate.commontypes"
 	varHTTPAddress                  = "http.address"
 	varDeveloperModeEnabled         = "developer.mode.enabled"
@@ -112,6 +114,8 @@ func setConfigDefaults() {
 	viper.SetDefault(varPostgresPassword, "mysecretpassword")
 	viper.SetDefault(varPostgresSSLMode, "disable")
 	viper.SetDefault(varPostgresConnectionTimeout, 5)
+	viper.SetDefault(varPostgresConnectionMaxIdle, -1)
+	viper.SetDefault(varPostgresConnectionMaxOpen, -1)
 
 	// Number of seconds to wait before trying to connect again
 	viper.SetDefault(varPostgresConnectionRetrySleep, time.Duration(time.Second))
@@ -181,6 +185,18 @@ func GetPostgresConnectionTimeout() int64 {
 // to wait before trying to connect again
 func GetPostgresConnectionRetrySleep() time.Duration {
 	return viper.GetDuration(varPostgresConnectionRetrySleep)
+}
+
+// GetPostgresConnectionMaxIdle returns the number of connections that should be keept alive in the database connection pool at
+// any given time. -1 represents no restrictions/default behavior
+func GetPostgresConnectionMaxIdle() int {
+	return viper.GetInt(varPostgresConnectionMaxIdle)
+}
+
+// GetPostgresConnectionMaxOpen returns the max number of open connections that should be open in the database connection pool.
+// -1 represents no restrictions/default behavior
+func GetPostgresConnectionMaxOpen() int {
+	return viper.GetInt(varPostgresConnectionMaxOpen)
 }
 
 // GetPostgresConfigString returns a ready to use string for usage in sql.Open()

--- a/main.go
+++ b/main.go
@@ -108,6 +108,15 @@ func main() {
 		db = db.Debug()
 	}
 
+	if configuration.GetPostgresConnectionMaxIdle() > 0 {
+		log.Logger().Infof("Configured connection pool max idle %v", configuration.GetPostgresConnectionMaxIdle())
+		db.DB().SetMaxIdleConns(configuration.GetPostgresConnectionMaxIdle())
+	}
+	if configuration.GetPostgresConnectionMaxOpen() > 0 {
+		log.Logger().Infof("Configured connection pool max open %v", configuration.GetPostgresConnectionMaxOpen())
+		db.DB().SetMaxOpenConns(configuration.GetPostgresConnectionMaxOpen())
+	}
+
 	// Migrate the schema
 	err = migration.Migrate(db.DB())
 	if err != nil {


### PR DESCRIPTION
ALMIGHTY_POSTGRES_CONNECTION_MAXIDLE
ALMIGHTY_POSTGRES_CONNECTION_MAXOPEN

A value of -1 triggers default pool behavior.