### PR TITLE
WILC, WILT, and WIL use UUIDs from REST to DB/Repo

### DIFF
--- a/design/work_item_link.go
+++ b/design/work_item_link.go
@@ -40,9 +40,7 @@ See also http://jsonapi.org/format/#document-resource-object`)
 	a.Attribute("type", d.String, func() {
 		a.Enum("workitemlinks")
 	})
-	a.Attribute("id", d.String, "ID of work item link (optional during creation)", func() {
-		a.Example("40bbdd3d-8b5d-4fd6-ac90-7236b669af04")
-	})
+	a.Attribute("id", d.UUID, "ID of work item link (optional during creation)")
 	a.Attribute("attributes", workItemLinkAttributes)
 	a.Attribute("relationships", workItemLinkRelationships)
 	a.Attribute("links", genericLinks)
@@ -164,7 +162,7 @@ func showWorkItemLink() {
 		a.GET("/:linkId"),
 	)
 	a.Params(func() {
-		a.Param("linkId", d.String, "ID of the work item link to show")
+		a.Param("linkId", d.UUID, "ID of the work item link to show")
 	})
 	a.Response(d.OK, func() {
 		a.Media(workItemLink)
@@ -196,7 +194,7 @@ func deleteWorkItemLink() {
 		a.DELETE("/:linkId"),
 	)
 	a.Params(func() {
-		a.Param("linkId", d.String, "ID of the work item link to be deleted")
+		a.Param("linkId", d.UUID, "ID of the work item link to be deleted")
 	})
 	a.Response(d.OK)
 	a.Response(d.BadRequest, JSONAPIErrors)
@@ -212,7 +210,7 @@ func updateWorkItemLink() {
 		a.PATCH("/:linkId"),
 	)
 	a.Params(func() {
-		a.Param("linkId", d.String, "ID of the work item link to be updated")
+		a.Param("linkId", d.UUID, "ID of the work item link to be updated")
 	})
 	a.Payload(updateWorkItemLinkPayload)
 	a.Response(d.OK, func() {

--- a/design/work_item_link_category.go
+++ b/design/work_item_link_category.go
@@ -40,7 +40,7 @@ See also http://jsonapi.org/format/#document-resource-object`)
 	a.Attribute("type", d.String, func() {
 		a.Enum("workitemlinkcategories")
 	})
-	a.Attribute("id", d.String, "ID of work item link category (optional during creation)", func() {
+	a.Attribute("id", d.UUID, "ID of work item link category (optional during creation)", func() {
 		a.Example("6c5610be-30b2-4880-9fec-81e4f8e4fd76")
 	})
 	a.Attribute("attributes", workItemLinkCategoryAttributes)
@@ -79,9 +79,7 @@ var relationWorkItemLinkCategoryData = a.Type("RelationWorkItemLinkCategoryData"
 	a.Attribute("type", d.String, "The type of the related source", func() {
 		a.Enum("workitemlinkcategories")
 	})
-	a.Attribute("id", d.String, "ID of work item link category", func() {
-		a.Example("6c5610be-30b2-4880-9fec-81e4f8e4fd76")
-	})
+	a.Attribute("id", d.UUID, "ID of work item link category")
 	a.Required("type", "id")
 })
 
@@ -126,7 +124,7 @@ var _ = a.Resource("work-item-link-category", func() {
 		)
 		a.Description("Retrieve work item link category (as JSONAPI) for the given ID.")
 		a.Params(func() {
-			a.Param("id", d.String, "ID of the work item link category")
+			a.Param("id", d.UUID, "ID of the work item link category")
 		})
 		a.Response(d.OK, func() {
 			a.Media(workItemLinkCategory)
@@ -170,7 +168,7 @@ var _ = a.Resource("work-item-link-category", func() {
 		)
 		a.Description("Delete work item link category with given id.")
 		a.Params(func() {
-			a.Param("id", d.String, "id")
+			a.Param("id", d.UUID, "id")
 		})
 		a.Response(d.OK)
 		a.Response(d.BadRequest, JSONAPIErrors)
@@ -186,7 +184,7 @@ var _ = a.Resource("work-item-link-category", func() {
 		)
 		a.Description("Update the given work item link category with given id.")
 		a.Params(func() {
-			a.Param("id", d.String, "id")
+			a.Param("id", d.UUID, "id")
 		})
 		a.Payload(updateWorkItemLinkCategoryPayload)
 		a.Response(d.OK, func() {

--- a/design/work_item_link_type.go
+++ b/design/work_item_link_type.go
@@ -32,9 +32,7 @@ See also http://jsonapi.org/format/#document-resource-object`)
 	a.Attribute("type", d.String, func() {
 		a.Enum("workitemlinktypes")
 	})
-	a.Attribute("id", d.String, "ID of work item link type (optional during creation)", func() {
-		a.Example("40bbdd3d-8b5d-4fd6-ac90-7236b669af04")
-	})
+	a.Attribute("id", d.UUID, "ID of work item link type (optional during creation)")
 	a.Attribute("attributes", workItemLinkTypeAttributes)
 	a.Attribute("relationships", workItemLinkTypeRelationships)
 	a.Attribute("links", genericLinks)
@@ -108,9 +106,7 @@ var relationWorkItemLinkTypeData = a.Type("RelationWorkItemLinkTypeData", func()
 	a.Attribute("type", d.String, "The type of the related source", func() {
 		a.Enum("workitemlinktypes")
 	})
-	a.Attribute("id", d.String, "ID of work item link type", func() {
-		a.Example("6c5610be-30b2-4880-9fec-81e4f8e4fd76")
-	})
+	a.Attribute("id", d.UUID, "ID of work item link type")
 	a.Required("type", "id")
 })
 
@@ -160,7 +156,7 @@ var _ = a.Resource("work-item-link-type", func() {
 		)
 		a.Description("Retrieve work item link type (as JSONAPI) for the given link ID.")
 		a.Params(func() {
-			a.Param("id", d.String, "ID of the work item link type")
+			a.Param("id", d.UUID, "ID of the work item link type")
 		})
 		a.Response(d.OK, func() {
 			a.Media(workItemLinkType)
@@ -204,7 +200,7 @@ var _ = a.Resource("work-item-link-type", func() {
 		)
 		a.Description("Delete work item link type with given id.")
 		a.Params(func() {
-			a.Param("id", d.String, "id")
+			a.Param("id", d.UUID, "id")
 		})
 		a.Response(d.OK)
 		a.Response(d.BadRequest, JSONAPIErrors)
@@ -220,7 +216,7 @@ var _ = a.Resource("work-item-link-type", func() {
 		)
 		a.Description("Update the given work item link type with given id.")
 		a.Params(func() {
-			a.Param("id", d.String, "id")
+			a.Param("id", d.UUID, "id")
 		})
 		a.Payload(updateWorkItemLinkTypePayload)
 		a.Response(d.OK, func() {

--- a/work-item-link-category-blackbox_test.go
+++ b/work-item-link-category-blackbox_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	satoriuuid "github.com/satori/go.uuid"
 )
 
 //-----------------------------------------------------------------------------
@@ -101,7 +103,7 @@ func (s *workItemLinkCategorySuite) TearDownTest() {
 func (s *workItemLinkCategorySuite) createWorkItemLinkCategorySystem() (http.ResponseWriter, *app.WorkItemLinkCategorySingle) {
 	name := "test-system"
 	description := "This work item link category is reserved for the core system."
-	id := "0e671e36-871b-43a6-9166-0c4bd573e231"
+	id := satoriuuid.FromStringOrNil("0e671e36-871b-43a6-9166-0c4bd573e231")
 
 	// Use the goa generated code to create a work item link category
 	payload := app.CreateWorkItemLinkCategoryPayload{
@@ -122,7 +124,7 @@ func (s *workItemLinkCategorySuite) createWorkItemLinkCategorySystem() (http.Res
 func (s *workItemLinkCategorySuite) createWorkItemLinkCategoryUser() (http.ResponseWriter, *app.WorkItemLinkCategorySingle) {
 	name := "test-user"
 	description := "This work item link category is managed by an admin user."
-	id := "bf30167a-9446-42de-82be-6b3815152051"
+	id := satoriuuid.FromStringOrNil("bf30167a-9446-42de-82be-6b3815152051")
 
 	// Use the goa generated code to create a work item link category
 	payload := app.CreateWorkItemLinkCategoryPayload{
@@ -157,7 +159,7 @@ func (s *workItemLinkCategorySuite) TestCreateAndDeleteWorkItemLinkCategory() {
 func (s *workItemLinkCategorySuite) TestCreateWorkItemLinkCategoryBadRequest() {
 	description := "New description for work item link category."
 	name := "" // This will lead to a bad parameter error
-	id := "88727441-4a21-4b35-aabe-007f8273cdBB"
+	id := satoriuuid.FromStringOrNil("88727441-4a21-4b35-aabe-007f8273cdBB")
 	payload := &app.CreateWorkItemLinkCategoryPayload{
 		Data: &app.WorkItemLinkCategoryData{
 			ID:   &id,
@@ -172,16 +174,12 @@ func (s *workItemLinkCategorySuite) TestCreateWorkItemLinkCategoryBadRequest() {
 }
 
 func (s *workItemLinkCategorySuite) TestDeleteWorkItemLinkCategoryNotFound() {
-	test.DeleteWorkItemLinkCategoryNotFound(s.T(), nil, nil, s.linkCatCtrl, "01f6c751-53f3-401f-be9b-6a9a230db8AA")
-}
-
-func (s *workItemLinkCategorySuite) TestDeleteWorkItemLinkCategoryNotFoundDueToBadID() {
-	test.DeleteWorkItemLinkCategoryNotFound(s.T(), nil, nil, s.linkCatCtrl, "something that is not a UUID")
+	test.DeleteWorkItemLinkCategoryNotFound(s.T(), nil, nil, s.linkCatCtrl, satoriuuid.FromStringOrNil("01f6c751-53f3-401f-be9b-6a9a230db8AA"))
 }
 
 func (s *workItemLinkCategorySuite) TestUpdateWorkItemLinkCategoryNotFound() {
 	description := "New description for work item link category."
-	id := "88727441-4a21-4b35-aabe-007f8273cd19"
+	id := satoriuuid.FromStringOrNil("88727441-4a21-4b35-aabe-007f8273cd19")
 	payload := &app.UpdateWorkItemLinkCategoryPayload{
 		Data: &app.WorkItemLinkCategoryData{
 			ID:   &id,
@@ -211,7 +209,7 @@ func (s *workItemLinkCategorySuite) TestUpdateWorkItemLinkCategoryNotFound() {
 
 func (s *workItemLinkCategorySuite) UpdateWorkItemLinkCategoryBadRequestDueToBadType() {
 	description := "New description for work item link category."
-	id := "88727441-4a21-4b35-aabe-007f8273cd19"
+	id := satoriuuid.FromStringOrNil("88727441-4a21-4b35-aabe-007f8273cd19")
 	payload := &app.UpdateWorkItemLinkCategoryPayload{
 		Data: &app.WorkItemLinkCategoryData{
 			ID:   &id,
@@ -226,7 +224,7 @@ func (s *workItemLinkCategorySuite) UpdateWorkItemLinkCategoryBadRequestDueToBad
 
 func (s *workItemLinkCategorySuite) UpdateWorkItemLinkCategoryBadRequestDueToEmptyName() {
 	name := "" // When updating the name, it must not be empty
-	id := "88727441-4a21-4b35-aabe-007f8273cd19"
+	id := satoriuuid.FromStringOrNil("88727441-4a21-4b35-aabe-007f8273cd19")
 	payload := &app.UpdateWorkItemLinkCategoryPayload{
 		Data: &app.WorkItemLinkCategoryData{
 			ID:   &id,
@@ -298,13 +296,9 @@ func (s *workItemLinkCategorySuite) TestShowWorkItemLinkCategoryOK() {
 	require.EqualValues(s.T(), linkCat.Data, linkCat2.Data)
 }
 
-func (s *workItemLinkCategorySuite) TestShowWorkItemLinkCategoryNotFoundDueToBadID() {
-	test.ShowWorkItemLinkCategoryNotFound(s.T(), nil, nil, s.linkCatCtrl, "something that is not a UUID")
-}
-
 // TestShowWorkItemLinkCategoryNotFound tests if we can fetch a non existing work item link category
 func (s *workItemLinkCategorySuite) TestShowWorkItemLinkCategoryNotFound() {
-	test.ShowWorkItemLinkCategoryNotFound(s.T(), nil, nil, s.linkCatCtrl, "88727441-4a21-4b35-aabe-007f8273cd19")
+	test.ShowWorkItemLinkCategoryNotFound(s.T(), nil, nil, s.linkCatCtrl, satoriuuid.FromStringOrNil("88727441-4a21-4b35-aabe-007f8273cd19"))
 }
 
 // TestListWorkItemLinkCategoryOK tests if we can find the work item link categories

--- a/work-item-link-type-blackbox_test.go
+++ b/work-item-link-type-blackbox_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	satoriuuid "github.com/satori/go.uuid"
 )
 
 //-----------------------------------------------------------------------------
@@ -170,16 +172,12 @@ func (s *workItemLinkTypeSuite) TestCreateAndDeleteWorkItemLinkType() {
 //}
 
 func (s *workItemLinkTypeSuite) TestDeleteWorkItemLinkTypeNotFound() {
-	test.DeleteWorkItemLinkTypeNotFound(s.T(), nil, nil, s.linkTypeCtrl, "1e9a8b53-73a6-40de-b028-5177add79ffa")
-}
-
-func (s *workItemLinkTypeSuite) TestDeleteWorkItemLinkTypeNotFoundDueToBadID() {
-	_, _ = test.DeleteWorkItemLinkTypeNotFound(s.T(), nil, nil, s.linkTypeCtrl, "something that is not a UUID")
+	test.DeleteWorkItemLinkTypeNotFound(s.T(), nil, nil, s.linkTypeCtrl, satoriuuid.FromStringOrNil("1e9a8b53-73a6-40de-b028-5177add79ffa"))
 }
 
 func (s *workItemLinkTypeSuite) TestUpdateWorkItemLinkTypeNotFound() {
 	createPayload := s.createDemoLinkType("test-bug-blocker")
-	notExistingId := "46bbce9c-8219-4364-a450-dfd1b501654e" // This ID does not exist
+	notExistingId := satoriuuid.FromStringOrNil("46bbce9c-8219-4364-a450-dfd1b501654e") // This ID does not exist
 	createPayload.Data.ID = &notExistingId
 	// Wrap data portion in an update payload instead of a create payload
 	updateLinkTypePayload := &app.UpdateWorkItemLinkTypePayload{
@@ -254,13 +252,9 @@ func (s *workItemLinkTypeSuite) TestShowWorkItemLinkTypeOK() {
 	require.NotEmpty(s.T(), readIn.Data.Links.Self, "The link type MUST include a self link that's not empty")
 }
 
-func (s *workItemLinkTypeSuite) TestShowWorkItemLinkTypeNotFoundDueToBadID() {
-	test.ShowWorkItemLinkTypeNotFound(s.T(), nil, nil, s.linkTypeCtrl, "something that is not a UUID")
-}
-
 // TestShowWorkItemLinkTypeNotFound tests if we can fetch a non existing work item link type
 func (s *workItemLinkTypeSuite) TestShowWorkItemLinkTypeNotFound() {
-	test.ShowWorkItemLinkTypeNotFound(s.T(), nil, nil, s.linkTypeCtrl, "88727441-4a21-4b35-aabe-007f8273cd19")
+	test.ShowWorkItemLinkTypeNotFound(s.T(), nil, nil, s.linkTypeCtrl, satoriuuid.FromStringOrNil("88727441-4a21-4b35-aabe-007f8273cd19"))
 }
 
 // TestListWorkItemLinkTypeOK tests if we can find the work item link types

--- a/work-item-link-type.go
+++ b/work-item-link-type.go
@@ -7,6 +7,7 @@ import (
 	"github.com/almighty/almighty-core/rest"
 	"github.com/almighty/almighty-core/workitem/link"
 	"github.com/goadesign/goa"
+	satoriuuid "github.com/satori/go.uuid"
 )
 
 // WorkItemLinkTypeController implements the work-item-link-type resource.
@@ -56,7 +57,7 @@ func enrichLinkTypeList(ctx *workItemLinkContext, list *app.WorkItemLinkTypeList
 		}
 	}
 	// Build our "set" of distinct category IDs already converted as strings
-	categoryIDMap := map[string]bool{}
+	categoryIDMap := map[satoriuuid.UUID]bool{}
 	for _, typeData := range list.Data {
 		categoryIDMap[typeData.Relationships.LinkCategory.Data.ID] = true
 	}

--- a/work-item-link.go
+++ b/work-item-link.go
@@ -11,6 +11,7 @@ import (
 	"github.com/almighty/almighty-core/workitem/link"
 	"github.com/goadesign/goa"
 	errs "github.com/pkg/errors"
+	satoriuuid "github.com/satori/go.uuid"
 )
 
 // WorkItemLinkController implements the work-item-link resource.
@@ -63,7 +64,7 @@ func newWorkItemLinkContext(ctx context.Context, appl application.Application, d
 // given work item links
 func getTypesOfLinks(ctx *workItemLinkContext, linksDataArr []*app.WorkItemLinkData) ([]*app.WorkItemLinkTypeData, error) {
 	// Build our "set" of distinct type IDs already converted as strings
-	typeIDMap := map[string]bool{}
+	typeIDMap := map[satoriuuid.UUID]bool{}
 	for _, linkData := range linksDataArr {
 		typeIDMap[linkData.Relationships.LinkType.Data.ID] = true
 	}
@@ -104,7 +105,7 @@ func getWorkItemsOfLinks(ctx *workItemLinkContext, linksDataArr []*app.WorkItemL
 // categories for the given work item link types
 func getCategoriesOfLinkTypes(ctx *workItemLinkContext, linkTypeDataArr []*app.WorkItemLinkTypeData) ([]*app.WorkItemLinkCategoryData, error) {
 	// Build our "set" of distinct category IDs already converted as strings
-	catIDMap := map[string]bool{}
+	catIDMap := map[satoriuuid.UUID]bool{}
 	for _, linkTypeData := range linkTypeDataArr {
 		catIDMap[linkTypeData.Relationships.LinkCategory.Data.ID] = true
 	}
@@ -275,7 +276,7 @@ type deleteWorkItemLinkFuncs interface {
 	OK(resp []byte) error
 }
 
-func deleteWorkItemLink(ctx *workItemLinkContext, funcs deleteWorkItemLinkFuncs, linkID string) error {
+func deleteWorkItemLink(ctx *workItemLinkContext, funcs deleteWorkItemLinkFuncs, linkID satoriuuid.UUID) error {
 	err := ctx.Application.WorkItemLinks().Delete(ctx.Context, linkID)
 	if err != nil {
 		jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(err)
@@ -326,7 +327,7 @@ type showWorkItemLinkFuncs interface {
 	OK(r *app.WorkItemLinkSingle) error
 }
 
-func showWorkItemLink(ctx *workItemLinkContext, funcs showWorkItemLinkFuncs, linkID string) error {
+func showWorkItemLink(ctx *workItemLinkContext, funcs showWorkItemLinkFuncs, linkID satoriuuid.UUID) error {
 	link, err := ctx.Application.WorkItemLinks().Load(ctx.Context, linkID)
 	if err != nil {
 		jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(err)

--- a/workitem/link/category.go
+++ b/workitem/link/category.go
@@ -60,11 +60,10 @@ func (c WorkItemLinkCategory) TableName() string {
 
 // ConvertLinkCategoryFromModel converts work item link category from model to app representation
 func ConvertLinkCategoryFromModel(t WorkItemLinkCategory) app.WorkItemLinkCategorySingle {
-	id := t.ID.String()
 	var converted = app.WorkItemLinkCategorySingle{
 		Data: &app.WorkItemLinkCategoryData{
 			Type: EndpointWorkItemLinkCategories,
-			ID:   &id,
+			ID:   &t.ID,
 			Attributes: &app.WorkItemLinkCategoryAttributes{
 				Name:        &t.Name,
 				Description: t.Description,

--- a/workitem/link/category_blackbox_test.go
+++ b/workitem/link/category_blackbox_test.go
@@ -79,11 +79,10 @@ func TestWorkItemLinkCategory_ConvertLinkCategoryFromModel(t *testing.T) {
 		Version:     0,
 	}
 
-	id := m.ID.String()
 	expected := app.WorkItemLinkCategorySingle{
 		Data: &app.WorkItemLinkCategoryData{
 			Type: link.EndpointWorkItemLinkCategories,
-			ID:   &id,
+			ID:   &m.ID,
 			Attributes: &app.WorkItemLinkCategoryAttributes{
 				Name:        &m.Name,
 				Description: m.Description,

--- a/workitem/link/category_repository.go
+++ b/workitem/link/category_repository.go
@@ -13,9 +13,9 @@ import (
 // WorkItemLinkCategoryRepository encapsulates storage & retrieval of work item link categories
 type WorkItemLinkCategoryRepository interface {
 	Create(ctx context.Context, name *string, description *string) (*app.WorkItemLinkCategorySingle, error)
-	Load(ctx context.Context, ID string) (*app.WorkItemLinkCategorySingle, error)
+	Load(ctx context.Context, ID satoriuuid.UUID) (*app.WorkItemLinkCategorySingle, error)
 	List(ctx context.Context) (*app.WorkItemLinkCategoryList, error)
-	Delete(ctx context.Context, ID string) error
+	Delete(ctx context.Context, ID satoriuuid.UUID) error
 	Save(ctx context.Context, linkCat app.WorkItemLinkCategorySingle) (*app.WorkItemLinkCategorySingle, error)
 }
 
@@ -51,12 +51,7 @@ func (r *GormWorkItemLinkCategoryRepository) Create(ctx context.Context, name *s
 
 // Load returns the work item link category for the given ID.
 // Returns NotFoundError, ConversionError or InternalError
-func (r *GormWorkItemLinkCategoryRepository) Load(ctx context.Context, ID string) (*app.WorkItemLinkCategorySingle, error) {
-	id, err := satoriuuid.FromString(ID)
-	if err != nil {
-		// treat as not found: clients don't know it must be a UUID
-		return nil, errors.NewNotFoundError("work item link category", ID)
-	}
+func (r *GormWorkItemLinkCategoryRepository) Load(ctx context.Context, ID satoriuuid.UUID) (*app.WorkItemLinkCategorySingle, error) {
 	log.Info(ctx, map[string]interface{}{
 		"wilcID": ID,
 	}, "Loading work item link category")
@@ -67,7 +62,7 @@ func (r *GormWorkItemLinkCategoryRepository) Load(ctx context.Context, ID string
 		log.Error(ctx, map[string]interface{}{
 			"wilcID": ID,
 		}, "work item link category not found by id ", ID)
-		return nil, errors.NewNotFoundError("work item link category", id.String())
+		return nil, errors.NewNotFoundError("work item link category", ID.String())
 	}
 	if db.Error != nil {
 		return nil, errors.NewInternalError(db.Error.Error())
@@ -122,15 +117,9 @@ func (r *GormWorkItemLinkCategoryRepository) List(ctx context.Context) (*app.Wor
 
 // Delete deletes the work item link category with the given id
 // returns NotFoundError or InternalError
-func (r *GormWorkItemLinkCategoryRepository) Delete(ctx context.Context, ID string) error {
-	id, err := satoriuuid.FromString(ID)
-	if err != nil {
-		// treat as not found: clients don't know it must be a UUID
-		return errors.NewNotFoundError("work item link category", ID)
-	}
-
+func (r *GormWorkItemLinkCategoryRepository) Delete(ctx context.Context, ID satoriuuid.UUID) error {
 	var cat = WorkItemLinkCategory{
-		ID: id,
+		ID: ID,
 	}
 
 	log.Info(ctx, map[string]interface{}{
@@ -141,9 +130,8 @@ func (r *GormWorkItemLinkCategoryRepository) Delete(ctx context.Context, ID stri
 	if db.Error != nil {
 		return errors.NewInternalError(db.Error.Error())
 	}
-
 	if db.RowsAffected == 0 {
-		return errors.NewNotFoundError("work item link category", id.String())
+		return errors.NewNotFoundError("work item link category", ID.String())
 	}
 	return nil
 }
@@ -155,35 +143,23 @@ func (r *GormWorkItemLinkCategoryRepository) Save(ctx context.Context, linkCat a
 	if linkCat.Data.ID == nil {
 		return nil, errors.NewBadParameterError("data.id", linkCat.Data.ID)
 	}
-	id, err := satoriuuid.FromString(*linkCat.Data.ID)
-	if err != nil {
-		log.Error(ctx, map[string]interface{}{
-			"wilcID": *linkCat.Data.ID,
-			"err":    err,
-		}, "error when converting %s to UUID: %s", *linkCat.Data.ID, err.Error())
-		// treat as not found: clients don't know it must be a UUID
-		return nil, errors.NewNotFoundError("work item link category", id.String())
-	}
-
-	if linkCat.Data.Type != EndpointWorkItemLinkCategories {
-		return nil, errors.NewBadParameterError("data.type", linkCat.Data.Type).Expected(EndpointWorkItemLinkCategories)
-	}
+	ID := *linkCat.Data.ID
 
 	// If the name is not nil, it MUST NOT be empty
 	if linkCat.Data.Attributes.Name != nil && *linkCat.Data.Attributes.Name == "" {
 		return nil, errors.NewBadParameterError("data.attributes.name", *linkCat.Data.Attributes.Name)
 	}
 
-	db := r.db.Model(&res).Where("id=?", *linkCat.Data.ID).First(&res)
+	db := r.db.Model(&res).Where("id=?", ID).First(&res)
 	if db.RecordNotFound() {
 		log.Error(ctx, map[string]interface{}{
-			"wilcID": *linkCat.Data.ID,
+			"wilcID": ID,
 		}, "work item link category not found")
-		return nil, errors.NewNotFoundError("work item link category", id.String())
+		return nil, errors.NewNotFoundError("work item link category", ID.String())
 	}
 	if db.Error != nil {
 		log.Error(ctx, map[string]interface{}{
-			"wilcID": *linkCat.Data.ID,
+			"wilcID": ID,
 			"err":    db.Error,
 		}, "unable to find work item link category")
 		return nil, errors.NewInternalError(db.Error.Error())
@@ -193,7 +169,7 @@ func (r *GormWorkItemLinkCategoryRepository) Save(ctx context.Context, linkCat a
 	}
 
 	newLinkCat := WorkItemLinkCategory{
-		ID:      id,
+		ID:      ID,
 		Version: *linkCat.Data.Attributes.Version + 1,
 	}
 

--- a/workitem/link/doc.go
+++ b/workitem/link/doc.go
@@ -1,3 +1,3 @@
 // Package link contains the code that provides all the required operations to
-// manage work item link, work item link types and work item link catergories.
+// manage work item link, work item link types and work item link categories.
 package link

--- a/workitem/link/link_repository.go
+++ b/workitem/link/link_repository.go
@@ -26,11 +26,11 @@ const (
 // WorkItemLinkRepository encapsulates storage & retrieval of work item links
 type WorkItemLinkRepository interface {
 	Create(ctx context.Context, sourceID, targetID uint64, linkTypeID satoriuuid.UUID) (*app.WorkItemLinkSingle, error)
-	Load(ctx context.Context, ID string) (*app.WorkItemLinkSingle, error)
+	Load(ctx context.Context, ID satoriuuid.UUID) (*app.WorkItemLinkSingle, error)
 	List(ctx context.Context) (*app.WorkItemLinkList, error)
 	ListByWorkItemID(ctx context.Context, wiIDStr string) (*app.WorkItemLinkList, error)
 	DeleteRelatedLinks(ctx context.Context, wiIDStr string) error
-	Delete(ctx context.Context, ID string) error
+	Delete(ctx context.Context, ID satoriuuid.UUID) error
 	Save(ctx context.Context, linkCat app.WorkItemLinkSingle) (*app.WorkItemLinkSingle, error)
 }
 
@@ -118,22 +118,17 @@ func (r *GormWorkItemLinkRepository) Create(ctx context.Context, sourceID, targe
 
 // Load returns the work item link for the given ID.
 // Returns NotFoundError, ConversionError or InternalError
-func (r *GormWorkItemLinkRepository) Load(ctx context.Context, ID string) (*app.WorkItemLinkSingle, error) {
-	id, err := satoriuuid.FromString(ID)
-	if err != nil {
-		// treat as not found: clients don't know it must be a UUID
-		return nil, errors.NewNotFoundError("work item link", ID)
-	}
+func (r *GormWorkItemLinkRepository) Load(ctx context.Context, ID satoriuuid.UUID) (*app.WorkItemLinkSingle, error) {
 	log.Info(ctx, map[string]interface{}{
 		"wilID": ID,
 	}, "Loading work item link")
 	res := WorkItemLink{}
-	db := r.db.Where("id=?", id).Find(&res)
+	db := r.db.Where("id=?", ID).Find(&res)
 	if db.RecordNotFound() {
 		log.Error(ctx, map[string]interface{}{
 			"wilID": ID,
 		}, "work item link not found")
-		return nil, errors.NewNotFoundError("work item link", id.String())
+		return nil, errors.NewNotFoundError("work item link", ID.String())
 	}
 	if db.Error != nil {
 		return nil, errors.NewInternalError(db.Error.Error())
@@ -200,14 +195,9 @@ func (r *GormWorkItemLinkRepository) List(ctx context.Context) (*app.WorkItemLin
 
 // Delete deletes the work item link with the given id
 // returns NotFoundError or InternalError
-func (r *GormWorkItemLinkRepository) Delete(ctx context.Context, ID string) error {
-	id, err := satoriuuid.FromString(ID)
-	if err != nil {
-		// treat as not found: clients don't know it must be a UUID
-		return errors.NewNotFoundError("work item link", ID)
-	}
+func (r *GormWorkItemLinkRepository) Delete(ctx context.Context, ID satoriuuid.UUID) error {
 	var link = WorkItemLink{
-		ID: id,
+		ID: ID,
 	}
 	log.Info(ctx, map[string]interface{}{
 		"wilID": ID,
@@ -222,7 +212,7 @@ func (r *GormWorkItemLinkRepository) Delete(ctx context.Context, ID string) erro
 		return errors.NewInternalError(db.Error.Error())
 	}
 	if db.RowsAffected == 0 {
-		return errors.NewNotFoundError("work item link", id.String())
+		return errors.NewNotFoundError("work item link", ID.String())
 	}
 	return nil
 }
@@ -249,16 +239,17 @@ func (r *GormWorkItemLinkRepository) Save(ctx context.Context, lt app.WorkItemLi
 	if lt.Data.ID == nil {
 		return nil, errors.NewBadParameterError("work item link", nil)
 	}
-	db := r.db.Model(&res).Where("id=?", *lt.Data.ID).First(&res)
+	ID := *lt.Data.ID
+	db := r.db.Model(&res).Where("id=?", ID).First(&res)
 	if db.RecordNotFound() {
 		log.Error(ctx, map[string]interface{}{
-			"wilID": *lt.Data.ID,
+			"wilID": ID,
 		}, "work item link not found")
-		return nil, errors.NewNotFoundError("work item link", *lt.Data.ID)
+		return nil, errors.NewNotFoundError("work item link", ID.String())
 	}
 	if db.Error != nil {
 		log.Error(ctx, map[string]interface{}{
-			"wilID": *lt.Data.ID,
+			"wilID": ID,
 			"err":   db.Error,
 		}, "unable to find work item link")
 		return nil, errors.NewInternalError(db.Error.Error())

--- a/workitem/link/type_repository.go
+++ b/workitem/link/type_repository.go
@@ -17,9 +17,9 @@ import (
 // WorkItemLinkTypeRepository encapsulates storage & retrieval of work item link types
 type WorkItemLinkTypeRepository interface {
 	Create(ctx context.Context, name string, description *string, sourceTypeName, targetTypeName, forwardName, reverseName, topology string, linkCategory satoriuuid.UUID) (*app.WorkItemLinkTypeSingle, error)
-	Load(ctx context.Context, ID string) (*app.WorkItemLinkTypeSingle, error)
+	Load(ctx context.Context, ID satoriuuid.UUID) (*app.WorkItemLinkTypeSingle, error)
 	List(ctx context.Context) (*app.WorkItemLinkTypeList, error)
-	Delete(ctx context.Context, ID string) error
+	Delete(ctx context.Context, ID satoriuuid.UUID) error
 	Save(ctx context.Context, linkCat app.WorkItemLinkTypeSingle) (*app.WorkItemLinkTypeSingle, error)
 	// ListSourceLinkTypes returns the possible link types for where the given
 	// WIT can be used in the source.
@@ -76,12 +76,7 @@ func (r *GormWorkItemLinkTypeRepository) Create(ctx context.Context, name string
 
 // Load returns the work item link type for the given ID.
 // Returns NotFoundError, ConversionError or InternalError
-func (r *GormWorkItemLinkTypeRepository) Load(ctx context.Context, ID string) (*app.WorkItemLinkTypeSingle, error) {
-	id, err := satoriuuid.FromString(ID)
-	if err != nil {
-		// treat as not found: clients don't know it must be a UUID
-		return nil, errors.NewNotFoundError("work item link type", ID)
-	}
+func (r *GormWorkItemLinkTypeRepository) Load(ctx context.Context, ID satoriuuid.UUID) (*app.WorkItemLinkTypeSingle, error) {
 	log.Info(ctx, map[string]interface{}{
 		"wiltID": ID,
 	}, "Loading work item link type")
@@ -91,7 +86,7 @@ func (r *GormWorkItemLinkTypeRepository) Load(ctx context.Context, ID string) (*
 		log.Error(ctx, map[string]interface{}{
 			"wiltID": ID,
 		}, "work item link type not found")
-		return nil, errors.NewNotFoundError("work item link type", id.String())
+		return nil, errors.NewNotFoundError("work item link type", ID.String())
 	}
 	if db.Error != nil {
 		return nil, errors.NewInternalError(db.Error.Error())
@@ -170,14 +165,9 @@ func (r *GormWorkItemLinkTypeRepository) List(ctx context.Context) (*app.WorkIte
 
 // Delete deletes the work item link type with the given id
 // returns NotFoundError or InternalError
-func (r *GormWorkItemLinkTypeRepository) Delete(ctx context.Context, ID string) error {
-	id, err := satoriuuid.FromString(ID)
-	if err != nil {
-		// treat as not found: clients don't know it must be a UUID
-		return errors.NewNotFoundError("work item link type", ID)
-	}
+func (r *GormWorkItemLinkTypeRepository) Delete(ctx context.Context, ID satoriuuid.UUID) error {
 	var cat = WorkItemLinkType{
-		ID: id,
+		ID: ID,
 	}
 	log.Info(ctx, map[string]interface{}{
 		"wiltID": ID,
@@ -188,7 +178,7 @@ func (r *GormWorkItemLinkTypeRepository) Delete(ctx context.Context, ID string) 
 		return errors.NewInternalError(db.Error.Error())
 	}
 	if db.RowsAffected == 0 {
-		return errors.NewNotFoundError("work item link type", id.String())
+		return errors.NewNotFoundError("work item link type", ID.String())
 	}
 	return nil
 }
@@ -205,7 +195,7 @@ func (r *GormWorkItemLinkTypeRepository) Save(ctx context.Context, lt app.WorkIt
 		log.Error(ctx, map[string]interface{}{
 			"wiltID": *lt.Data.ID,
 		}, "work item link type not found")
-		return nil, errors.NewNotFoundError("work item link type", *lt.Data.ID)
+		return nil, errors.NewNotFoundError("work item link type", lt.Data.ID.String())
 	}
 	if db.Error != nil {
 		log.Error(ctx, map[string]interface{}{


### PR DESCRIPTION
Greatly simplify the handling of IDs in linking

UUIDs can be passed through most of the time and don't have to be
checked for type conversion errors.

Also the "type" field in relations is not checked for WILs, WILTs, and
WILCs because it is defined as an enum in the design folder. So REST
calls will not get through that have something different in the "type"
field anyway.
