### PR TITLE
Fix config.yaml entry for token keys

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -35,7 +35,7 @@ populate.commontypes: true
 # Authentication configuration
 # ----------------------------
 
-token.privatekey : >
+token.privatekey : |
                     -----BEGIN RSA PRIVATE KEY-----
                     MIIEpQIBAAKCAQEAnwrjH5iTSErw9xUptp6QSFoUfpHUXZ+PaslYSUrpLjw1q27O
                     DSFwmhV4+dAaTMO5chFv/kM36H3ZOyA146nwxBobS723okFaIkshRrf6qgtD6coT
@@ -64,7 +64,7 @@ token.privatekey : >
                     OCCAgsB8g8yTB4qntAYyfofEoDiseKrngQT5DSdxd51A/jw7B8WyBK8=
                     -----END RSA PRIVATE KEY-----
 
-token.publickey : >
+token.publickey : |
                     -----BEGIN PUBLIC KEY-----
                     MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiRd6pdNjiwQFH2xmNugn
                     TkVhkF+TdJw19Kpj3nRtsoUe4/6gIureVi7FWqcb+2t/E0dv8rAAs6vl+d7roz3R

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -152,14 +152,15 @@ func TestGetKeycloakEndpointUserInfoSetByEnvVaribaleOK(t *testing.T) {
 }
 
 func TestGetTokenPrivateKeyFromConfigFile(t *testing.T) {
-	t.Parallel()
 
 	envKey := generateEnvKey(varTokenPrivateKey)
-
 	realEnvValue := os.Getenv(envKey) // could be "" as well.
 
 	os.Unsetenv(envKey)
-	defer os.Setenv(envKey, realEnvValue) // set it back before we leave.
+	defer func() {
+		os.Setenv(envKey, realEnvValue)
+		resetConfiguration()
+	}()
 
 	// env variable NOT set, so we check with config.yaml's value
 
@@ -172,7 +173,6 @@ func TestGetTokenPrivateKeyFromConfigFile(t *testing.T) {
 }
 
 func TestGetTokenPublicKeyFromConfigFile(t *testing.T) {
-	t.Parallel()
 
 	envKey := generateEnvKey(varTokenPublicKey)
 	realEnvValue := os.Getenv(envKey) // could be "" as well.

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -17,9 +17,10 @@ import (
 )
 
 const (
-	varTokenPublicKey  = "token.publickey"
-	varTokenPrivateKey = "token.privatekey"
-	defaultConfigFile  = "config.yaml"
+	varTokenPublicKey           = "token.publickey"
+	varTokenPrivateKey          = "token.privatekey"
+	defaultConfigFilePath       = "../config.yaml"
+	defaultValuesConfigFilePath = "" // when the code defaults are to be used, the path to config file is ""
 )
 
 var reqLong *goa.RequestData
@@ -27,7 +28,7 @@ var reqShort *goa.RequestData
 var config *configuration.ConfigurationData
 
 func TestMain(m *testing.M) {
-	resetConfiguration()
+	resetConfiguration(defaultConfigFilePath)
 
 	reqLong = &goa.RequestData{
 		Request: &http.Request{Host: "api.service.domain.org"},
@@ -38,9 +39,11 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func resetConfiguration() {
+func resetConfiguration(configPath string) {
 	var err error
-	config, err = configuration.NewConfigurationData("../config.yaml")
+
+	// calling NewConfigurationData("") is same as GetConfigurationData()
+	config, err = configuration.NewConfigurationData(configPath)
 	if err != nil {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
@@ -66,11 +69,11 @@ func TestGetKeycloakEndpointAuthSetByEnvVaribaleOK(t *testing.T) {
 	env := os.Getenv("ALMIGHTY_KEYCLOAK_ENDPOINT_AUTH")
 	defer func() {
 		os.Setenv("ALMIGHTY_KEYCLOAK_ENDPOINT_AUTH", env)
-		resetConfiguration()
+		resetConfiguration(defaultValuesConfigFilePath)
 	}()
 
 	os.Setenv("ALMIGHTY_KEYCLOAK_ENDPOINT_AUTH", "authEndpoint")
-	resetConfiguration()
+	resetConfiguration(defaultValuesConfigFilePath)
 
 	url, err := config.GetKeycloakEndpointAuth(reqLong)
 	assert.Nil(t, err)
@@ -101,11 +104,11 @@ func TestGetKeycloakEndpointTokenSetByEnvVaribaleOK(t *testing.T) {
 	env := os.Getenv("ALMIGHTY_KEYCLOAK_ENDPOINT_TOKEN")
 	defer func() {
 		os.Setenv("ALMIGHTY_KEYCLOAK_ENDPOINT_TOKEN", env)
-		resetConfiguration()
+		resetConfiguration(defaultValuesConfigFilePath)
 	}()
 
 	os.Setenv("ALMIGHTY_KEYCLOAK_ENDPOINT_TOKEN", "tokenEndpoint")
-	resetConfiguration()
+	resetConfiguration(defaultValuesConfigFilePath)
 
 	url, err := config.GetKeycloakEndpointToken(reqLong)
 	assert.Nil(t, err)
@@ -136,11 +139,11 @@ func TestGetKeycloakEndpointUserInfoSetByEnvVaribaleOK(t *testing.T) {
 	env := os.Getenv("ALMIGHTY_KEYCLOAK_ENDPOINT_USERINFO")
 	defer func() {
 		os.Setenv("ALMIGHTY_KEYCLOAK_ENDPOINT_USERINFO", env)
-		resetConfiguration()
+		resetConfiguration(defaultValuesConfigFilePath)
 	}()
 
 	os.Setenv("ALMIGHTY_KEYCLOAK_ENDPOINT_USERINFO", "userinfoEndpoint")
-	resetConfiguration()
+	resetConfiguration(defaultValuesConfigFilePath)
 
 	url, err := config.GetKeycloakEndpointUserInfo(reqLong)
 	assert.Nil(t, err)
@@ -159,9 +162,10 @@ func TestGetTokenPrivateKeyFromConfigFile(t *testing.T) {
 	os.Unsetenv(envKey)
 	defer func() {
 		os.Setenv(envKey, realEnvValue)
-		resetConfiguration()
+		resetConfiguration(defaultValuesConfigFilePath)
 	}()
 
+	resetConfiguration(defaultConfigFilePath)
 	// env variable NOT set, so we check with config.yaml's value
 
 	viperValue := config.GetTokenPrivateKey()
@@ -180,8 +184,10 @@ func TestGetTokenPublicKeyFromConfigFile(t *testing.T) {
 	os.Unsetenv(envKey)
 	defer func() {
 		os.Setenv(envKey, realEnvValue)
-		resetConfiguration()
+		resetConfiguration(defaultValuesConfigFilePath)
 	}()
+
+	resetConfiguration(defaultConfigFilePath)
 
 	// env variable is now unset for sure, this will lead to the test looking up for
 	// value in config.yaml


### PR DESCRIPTION
The format in which the private and public keys were entered in config.yaml leads to failures when the key is parsed from the file. This fixes #883 

---------

The private and public keys in the config.yaml need to be passed
in a specific way so that the parsing doesnt remove the newlines needed for the key
to be parsed correctly into a valid PEM format

http://stackoverflow.com/questions/3790454/in-yaml-how-do-i-break-a-string-over-multiple-lines/21699210#21699210

fixes #883