### PR TITLE
Allow for placeholders in migration.executeSQLFile

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -218,14 +218,15 @@ func getMigrations() migrations {
 }
 
 // executeSQLFile loads the given filename from the packaged SQL files and
-// executes it on the given database
-func executeSQLFile(filename string) fn {
+// executes it on the given database. fmt.Sprintf is used to handle all the
+// optional arguments
+func executeSQLFile(filename string, args ...interface{}) fn {
 	return func(db *sql.Tx) error {
 		data, err := Asset(filename)
 		if err != nil {
 			return errs.WithStack(err)
 		}
-		_, err = db.Exec(string(data))
+		_, err = db.Exec(fmt.Sprintf(string(data), args))
 		return errs.WithStack(err)
 	}
 }

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -224,8 +224,8 @@ func getMigrations() migrations {
 }
 
 // executeSQLFile loads the given filename from the packaged SQL files and
-// executes it on the given database. fmt.Sprintf is used to handle all the
-// optional arguments
+// executes it on the given database. Golang text/template module is used 
+// to handle all the optional arguments passed to the sql files
 func executeSQLFile(filename string, args ...string) fn {
 	return func(db *sql.Tx) error {
 		data, err := Asset(filename)

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"fmt"
 	"database/sql"
 
 	"github.com/almighty/almighty-core/app"

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -1,8 +1,10 @@
 package migration
 
 import (
-	"fmt"
+	"bufio"
+	"bytes"
 	"database/sql"
+	"text/template"
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/errors"
@@ -224,13 +226,31 @@ func getMigrations() migrations {
 // executeSQLFile loads the given filename from the packaged SQL files and
 // executes it on the given database. fmt.Sprintf is used to handle all the
 // optional arguments
-func executeSQLFile(filename string, args ...interface{}) fn {
+func executeSQLFile(filename string, args ...string) fn {
 	return func(db *sql.Tx) error {
 		data, err := Asset(filename)
 		if err != nil {
 			return errs.WithStack(err)
 		}
-		_, err = db.Exec(fmt.Sprintf(string(data), args))
+
+		if len(args) > 0 {
+			tmpl, err := template.New("sql").Parse(string(data))
+			if err != nil {
+				return errs.WithStack(err)
+			}
+			var sqlScript bytes.Buffer
+			writer := bufio.NewWriter(&sqlScript)
+			err = tmpl.Execute(writer, args)
+			if err != nil {
+				return errs.WithStack(err)
+			}
+			// We need to flush the content of the writer
+			writer.Flush()
+			_, err = db.Exec(sqlScript.String())
+		} else {
+			_, err = db.Exec(string(data))
+		}
+
 		return errs.WithStack(err)
 	}
 }

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -224,7 +224,7 @@ func getMigrations() migrations {
 }
 
 // executeSQLFile loads the given filename from the packaged SQL files and
-// executes it on the given database. Golang text/template module is used 
+// executes it on the given database. Golang text/template module is used
 // to handle all the optional arguments passed to the sql files
 func executeSQLFile(filename string, args ...string) fn {
 	return func(db *sql.Tx) error {


### PR DESCRIPTION
This would allow us to pass static IDs to a SQL migration file that has placeholders (e.t. `"%[1]s"`) in it.

Here's a discussion on why me might want to have this: https://github.com/almighty/almighty-core/pull/852#discussion_r103242104

I wonder if we need to take special care when doing the replacements because the `%` symbol in SQL is a reserved symbol. Maybe https://golang.org/pkg/text/template/ is a better choice for doing the replacement?

This essentially allows you to write: 

```go
// Version XY
m = append(m, steps{executeSQLFile("0XY-foobar.sql", workitem.SystemSpace, 123)})
```

where `workitem.SystemSpace, 123` are used as placeholder replacements for the file `0XY-foobar.sql`.