### PR TITLE
add support for update user profile

### DIFF
--- a/controller/users.go
+++ b/controller/users.go
@@ -7,6 +7,8 @@ import (
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/jsonapi"
+	"github.com/almighty/almighty-core/log"
+	"github.com/almighty/almighty-core/login"
 	"github.com/almighty/almighty-core/rest"
 	"github.com/goadesign/goa"
 	"github.com/pkg/errors"
@@ -45,6 +47,68 @@ func (c *UsersController) Show(ctx *app.ShowUsersContext) error {
 				return jsonapi.JSONErrorResponse(ctx, errors.Wrap(err, fmt.Sprintf("User ID %s not valid", userID.UUID)))
 			}
 		}
+		return ctx.OK(ConvertUser(ctx.RequestData, identity, user))
+	})
+}
+
+// Update updates the authorized user based on the provided Token
+func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
+
+	id, err := login.ContextIdentity(ctx)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(err.Error()))
+	}
+
+	return application.Transactional(c.db, func(appl application.Application) error {
+		identity, err := appl.Identities().Load(ctx, *id)
+		if err != nil || identity == nil {
+			log.Error(ctx, map[string]interface{}{
+				"identityID": id,
+			}, "auth token contains id %s of unknown Identity", *id)
+			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(fmt.Sprintf("Auth token contains id %s of unknown Identity\n", *id)))
+			return ctx.Unauthorized(jerrors)
+		}
+
+		var user *account.User
+		userID := identity.UserID
+		if userID.Valid {
+			user, err = appl.Users().Load(ctx.Context, userID.UUID)
+			if err != nil {
+				return jsonapi.JSONErrorResponse(ctx, errors.Wrap(err, fmt.Sprintf("Can't load user with id %s", userID.UUID)))
+			}
+		}
+
+		updatedEmail := ctx.Payload.Data.Attributes.Email
+		if updatedEmail != nil {
+			user.Email = *updatedEmail
+		}
+		updatedBio := ctx.Payload.Data.Attributes.Bio
+		if updatedBio != nil {
+			user.Bio = *updatedBio
+		}
+		updatedFullName := ctx.Payload.Data.Attributes.FullName
+		if updatedFullName != nil {
+			user.FullName = *updatedFullName
+		}
+		updatedImageURL := ctx.Payload.Data.Attributes.ImageURL
+		if updatedImageURL != nil {
+			user.ImageURL = *updatedImageURL
+		}
+		updateURL := ctx.Payload.Data.Attributes.URL
+		if updateURL != nil {
+			user.URL = *updateURL
+		}
+
+		err = appl.Users().Save(ctx, user)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, err)
+		}
+
+		err = appl.Identities().Save(ctx, identity)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, err)
+		}
+
 		return ctx.OK(ConvertUser(ctx.RequestData, identity, user))
 	})
 }

--- a/controller/users.go
+++ b/controller/users.go
@@ -70,11 +70,10 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		}
 
 		var user *account.User
-		userID := identity.UserID
-		if userID.Valid {
-			user, err = appl.Users().Load(ctx.Context, userID.UUID)
+		if identity.UserID.Valid {
+			user, err = appl.Users().Load(ctx.Context, identity.UserID.UUID)
 			if err != nil {
-				return jsonapi.JSONErrorResponse(ctx, errors.Wrap(err, fmt.Sprintf("Can't load user with id %s", userID.UUID)))
+				return jsonapi.JSONErrorResponse(ctx, errors.Wrap(err, fmt.Sprintf("Can't load user with id %s", identity.UserID.UUID)))
 			}
 		}
 

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -11,9 +11,12 @@ import (
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/resource"
+	testsupport "github.com/almighty/almighty-core/test"
+	almtoken "github.com/almighty/almighty-core/token"
 	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 
@@ -25,6 +28,15 @@ func createController(t *testing.T) (*UsersController, application.DB) {
 	return controller, app
 }
 
+func createSecureController(t *testing.T, identity account.Identity) (*UsersController, *goa.Service) {
+	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
+	svc := testsupport.ServiceAsUser("Users-Service", almtoken.NewManagerWithPrivateKey(priv), identity)
+	app := gormapplication.NewGormDB(DB)
+	controller := NewUsersController(svc, app)
+	assert.NotNil(t, controller)
+	return controller, svc
+}
+
 func TestShowUserOK(t *testing.T) {
 	resource.Require(t, resource.Database)
 	defer cleaner.DeleteCreatedEntities(DB)()
@@ -34,25 +46,13 @@ func TestShowUserOK(t *testing.T) {
 	userRepo := app.Users()
 	identityRepo := app.Identities()
 
-	user := account.User{
-		Email:    "primary@example.com",
-		FullName: "A test user",
-		ImageURL: "someURL",
-	}
+	user := createRandomUser()
 	err := userRepo.Create(ctx, &user)
 	if err != nil {
 		t.Fatal(err)
 	}
-	profile := "foobar.com/" + user.ID.String()
-	identity := account.Identity{
-		Username:     "TestUserIntegration123",
-		ProviderType: account.KeycloakIDP,
-		ID:           uuid.NewV4(),
-		User:         user,
-		UserID:       account.NullUUID{UUID: user.ID, Valid: true},
-		ProfileURL:   &profile,
-	}
 
+	identity := createRandomIdentity(user)
 	err = identityRepo.Create(ctx, &identity)
 	if err != nil {
 		t.Fatal(err)
@@ -64,6 +64,118 @@ func TestShowUserOK(t *testing.T) {
 	assert.Equal(t, user.ImageURL, *result.Data.Attributes.ImageURL)
 	assert.Equal(t, identity.ProviderType, *result.Data.Attributes.ProviderType)
 	assert.Equal(t, identity.Username, *result.Data.Attributes.Username)
+}
+
+func createRandomUser() account.User {
+	user := account.User{
+		Email:    uuid.NewV4().String() + "primaryForUpdat7e@example.com",
+		FullName: "A test user",
+		ImageURL: "someURLForUpdate",
+		ID:       uuid.NewV4(),
+	}
+	return user
+}
+
+func createRandomIdentity(user account.User) account.Identity {
+	profile := "foobarforupdate.com/" + user.ID.String()
+	identity := account.Identity{
+		Username:     "TestUpdateUserIntegration123" + uuid.NewV4().String(),
+		ProviderType: account.KeycloakIDP,
+		//	ID:           uuid.NewV4(),
+		User:       user,
+		UserID:     account.NullUUID{UUID: user.ID, Valid: true},
+		ProfileURL: &profile,
+	}
+	return identity
+}
+
+func TestUpdateUserOK(t *testing.T) {
+	resource.Require(t, resource.Database)
+	defer cleaner.DeleteCreatedEntities(DB)()
+	controller, app := createController(t)
+
+	ctx := context.Background()
+	userRepo := app.Users()
+	identityRepo := app.Identities()
+
+	user := createRandomUser()
+	err := userRepo.Create(ctx, &user)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	identity := createRandomIdentity(user)
+	err = identityRepo.Create(ctx, &identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, result := test.ShowUsersOK(t, nil, nil, controller, identity.ID.String())
+	assert.Equal(t, identity.ID.String(), *result.Data.ID)
+	assert.Equal(t, user.FullName, *result.Data.Attributes.FullName)
+	assert.Equal(t, user.ImageURL, *result.Data.Attributes.ImageURL)
+	assert.Equal(t, identity.ProviderType, *result.Data.Attributes.ProviderType)
+	assert.Equal(t, identity.Username, *result.Data.Attributes.Username)
+
+	newEmail := "updated@email.com"
+	newFullName := "newFull Name"
+	newImageURL := "http://new.image.io/imageurl"
+	newBio := "new bio"
+	newProfileURL := "http://new.profile.url/url"
+
+	secureController, secureService := createSecureController(t, identity)
+	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL)
+	_, result = test.UpdateUsersOK(t, secureService.Context, secureService, secureController, updateUsersPayload)
+	require.NotNil(t, result)
+
+	// let's fetch it and validate
+	_, result = test.ShowUsersOK(t, nil, nil, controller, identity.ID.String())
+	require.NotNil(t, result)
+	assert.Equal(t, identity.ID.String(), *result.Data.ID)
+	assert.Equal(t, newFullName, *result.Data.Attributes.FullName)
+	assert.Equal(t, newImageURL, *result.Data.Attributes.ImageURL)
+	assert.Equal(t, newBio, *result.Data.Attributes.Bio)
+	assert.Equal(t, newProfileURL, *result.Data.Attributes.URL)
+
+}
+
+func TestUpdateUserUnauthorized(t *testing.T) {
+	resource.Require(t, resource.Database)
+	defer cleaner.DeleteCreatedEntities(DB)()
+	controller, app := createController(t)
+
+	ctx := context.Background()
+	userRepo := app.Users()
+	identityRepo := app.Identities()
+
+	user := createRandomUser()
+	err := userRepo.Create(ctx, &user)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	identity := createRandomIdentity(user)
+	err = identityRepo.Create(ctx, &identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, result := test.ShowUsersOK(t, nil, nil, controller, identity.ID.String())
+	assert.Equal(t, identity.ID.String(), *result.Data.ID)
+	assert.Equal(t, user.FullName, *result.Data.Attributes.FullName)
+	assert.Equal(t, user.ImageURL, *result.Data.Attributes.ImageURL)
+	assert.Equal(t, identity.ProviderType, *result.Data.Attributes.ProviderType)
+	assert.Equal(t, identity.Username, *result.Data.Attributes.Username)
+
+	newEmail := "updated@email.com"
+	newFullName := "newFull Name"
+	newImageURL := "http://new.image.io/imageurl"
+	newBio := "new bio"
+	newProfileURL := "http://new.profile.url/url"
+
+	//secureController, secureService := createSecureController(t, identity)
+	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL)
+	test.UpdateUsersUnauthorized(t, ctx, nil, controller, updateUsersPayload)
 }
 
 func TestListUserOK(t *testing.T) {
@@ -152,4 +264,19 @@ func assertUser(t *testing.T, actual *app.IdentityData, expectedUser account.Use
 	assert.Equal(t, expectedUser.FullName, *actual.Attributes.FullName)
 	assert.Equal(t, expectedUser.ImageURL, *actual.Attributes.ImageURL)
 	assert.Equal(t, expectedUser.Email, *actual.Attributes.Email)
+}
+
+func createUpdateUsersPayload(email *string, fullName *string, bio *string, imageURL *string, profileURL *string) *app.UpdateUsersPayload {
+	return &app.UpdateUsersPayload{
+		Data: &app.UpdateIdentityData{
+			Type: "identities",
+			Attributes: &app.IdentityDataAttributes{
+				Email:    email,
+				FullName: fullName,
+				Bio:      bio,
+				ImageURL: imageURL,
+				URL:      profileURL,
+			},
+		},
+	}
 }

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -81,10 +81,9 @@ func createRandomIdentity(user account.User) account.Identity {
 	identity := account.Identity{
 		Username:     "TestUpdateUserIntegration123" + uuid.NewV4().String(),
 		ProviderType: account.KeycloakIDP,
-		//	ID:           uuid.NewV4(),
-		User:       user,
-		UserID:     account.NullUUID{UUID: user.ID, Valid: true},
-		ProfileURL: &profile,
+		User:         user,
+		UserID:       account.NullUUID{UUID: user.ID, Valid: true},
+		ProfileURL:   &profile,
 	}
 	return identity
 }
@@ -266,7 +265,7 @@ func assertUser(t *testing.T, actual *app.IdentityData, expectedUser account.Use
 	assert.Equal(t, expectedUser.Email, *actual.Attributes.Email)
 }
 
-func createUpdateUsersPayload(email *string, fullName *string, bio *string, imageURL *string, profileURL *string) *app.UpdateUsersPayload {
+func createUpdateUsersPayload(email, fullName, bio, imageURL, profileURL *string) *app.UpdateUsersPayload {
 	return &app.UpdateUsersPayload{
 		Data: &app.UpdateIdentityData{
 			Type: "identities",

--- a/design/account.go
+++ b/design/account.go
@@ -5,6 +5,29 @@ import (
 	a "github.com/goadesign/goa/design/apidsl"
 )
 
+var updateIdentity = a.MediaType("application/vnd.updateidentity+json", func() {
+	a.UseTrait("jsonapi-media-type")
+	a.TypeName("UpdateIdentity")
+	a.Description("ALM User Update Identity")
+	a.Attributes(func() {
+		a.Attribute("data", updateIdentityData)
+		a.Required("data")
+
+	})
+	a.View("default", func() {
+		a.Attribute("data")
+		a.Required("data")
+	})
+})
+
+// identityData represents an identified user object
+var updateIdentityData = a.Type("UpdateIdentityData", func() {
+	a.Attribute("type", d.String, "type of the user identity")
+	a.Attribute("attributes", identityDataAttributes, "Attributes of the user identity")
+	a.Attribute("links", genericLinks)
+	a.Required("type", "attributes")
+})
+
 // identity represents an identified user object
 var identity = a.MediaType("application/vnd.identity+json", func() {
 	a.UseTrait("jsonapi-media-type")
@@ -69,7 +92,6 @@ var _ = a.Resource("user", func() {
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 	})
-
 })
 
 var _ = a.Resource("identity", func() {
@@ -105,6 +127,23 @@ var _ = a.Resource("users", func() {
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)
+	})
+
+	a.Action("update", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.PATCH(""),
+		)
+		a.Description("update the authenticated user")
+		a.Payload(updateIdentity)
+		a.Response(d.OK, func() {
+			a.Media(identity)
+		})
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.Forbidden, JSONAPIErrors)
 	})
 
 	a.Action("list", func() {


### PR DESCRIPTION
fixes #878 

- payload for updating user will not contain 'ID' ,  the ID would be deduced from the context token. Hence created new payload type in `design/account.go`
- refactored existing tests by putting re-usable code into method(s).
- added controller method for Update(..) in `controller/users.go`