### PR TITLE
Add NOT NULL only after filling a column

### DIFF
--- a/migration/sql-files/035-wit-to-use-uuid.sql
+++ b/migration/sql-files/035-wit-to-use-uuid.sql
@@ -87,8 +87,8 @@ ALTER TABLE work_item_types DROP CONSTRAINT work_item_link_types_check_name_c_lo
 -- Update work item link types
 ------------------------------
 
-ALTER TABLE work_item_link_types ADD COLUMN source_type_id uuid NOT NULL REFERENCES work_item_types(id) ON DELETE CASCADE;
-ALTER TABLE work_item_link_types ADD COLUMN target_type_id uuid NOT NULL REFERENCES work_item_types(id) ON DELETE CASCADE;
+ALTER TABLE work_item_link_types ADD COLUMN source_type_id uuid REFERENCES work_item_types(id) ON DELETE CASCADE;
+ALTER TABLE work_item_link_types ADD COLUMN target_type_id uuid REFERENCES work_item_types(id) ON DELETE CASCADE;
 
 UPDATE work_item_link_types SET source_type_id = (SELECT id FROM work_item_types WHERE name = source_type_name);
 UPDATE work_item_link_types SET target_type_id = (SELECT id FROM work_item_types WHERE name = target_type_name);
@@ -96,12 +96,19 @@ UPDATE work_item_link_types SET target_type_id = (SELECT id FROM work_item_types
 ALTER TABLE work_item_link_types DROP COLUMN source_type_name;
 ALTER TABLE work_item_link_types DROP COLUMN target_type_name;
 
+-- Add NOT NULL criteria 
+ALTER TABLE work_item_link_types ALTER COLUMN source_type_id SET NOT NULL;
+ALTER TABLE work_item_link_types ALTER COLUMN target_type_id SET NOT NULL;
+
 --------------------
 -- Update work items
 --------------------
 
 -- NOTE: The foreign key is new!
 ALTER TABLE work_items RENAME type TO type_old;
-ALTER TABLE work_items ADD COLUMN type uuid NOT NULL REFERENCES work_item_types(id) ON DELETE CASCADE;
+ALTER TABLE work_items ADD COLUMN type uuid REFERENCES work_item_types(id) ON DELETE CASCADE;
 UPDATE work_items SET type = (SELECT id FROM work_item_types WHERE name = type_old);
 ALTER TABLE work_items DROP COLUMN type_old;
+
+-- Add NOT NULL criteria
+ALTER TABLE work_items ALTER COLUMN type SET NOT NULL;


### PR DESCRIPTION
If we add a new column to a table without having a default value we **MUST NOT** use `NOT NULL` in the column definition. Add `NOT NULL` only after you have filled the column.