### PR TITLE
Support unauthorized error in ErrorToJSONAPIError

### DIFF
--- a/jsonapi/jsonapi_utility.go
+++ b/jsonapi/jsonapi_utility.go
@@ -52,6 +52,10 @@ func ErrorToJSONAPIError(err error) (app.JSONAPIError, int) {
 		code = ErrorCodeInternalError
 		title = "Internal error"
 		statusCode = http.StatusInternalServerError
+	case errors.UnauthorizedError:
+		code = ErrorCodeUnauthorizedError
+		title = "Unauthorized error"
+		statusCode = http.StatusUnauthorized
 	default:
 		code = ErrorCodeUnknownError
 		title = "Unknown error"

--- a/jsonapi/jsonapi_utility_blackbox_test.go
+++ b/jsonapi/jsonapi_utility_blackbox_test.go
@@ -1,0 +1,70 @@
+package jsonapi_test
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/almighty/almighty-core/app"
+	"github.com/almighty/almighty-core/errors"
+	"github.com/almighty/almighty-core/jsonapi"
+	"github.com/almighty/almighty-core/resource"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorToJSONAPIError(t *testing.T) {
+	t.Parallel()
+	resource.Require(t, resource.UnitTest)
+
+	var jerr app.JSONAPIError
+	var httpStatus int
+
+	// test not found error
+	jerr, httpStatus = jsonapi.ErrorToJSONAPIError(errors.NewNotFoundError("foo", "bar"))
+	require.Equal(t, http.StatusNotFound, httpStatus)
+	require.NotNil(t, jerr.Code)
+	require.NotNil(t, jerr.Status)
+	require.Equal(t, jsonapi.ErrorCodeNotFound, *jerr.Code)
+	require.Equal(t, strconv.Itoa(httpStatus), *jerr.Status)
+
+	// test not found error
+	jerr, httpStatus = jsonapi.ErrorToJSONAPIError(errors.NewConversionError("foo"))
+	require.Equal(t, http.StatusBadRequest, httpStatus)
+	require.NotNil(t, jerr.Code)
+	require.NotNil(t, jerr.Status)
+	require.Equal(t, jsonapi.ErrorCodeConversionError, *jerr.Code)
+	require.Equal(t, strconv.Itoa(httpStatus), *jerr.Status)
+
+	// test bad parameter error
+	jerr, httpStatus = jsonapi.ErrorToJSONAPIError(errors.NewBadParameterError("foo", "bar"))
+	require.Equal(t, http.StatusBadRequest, httpStatus)
+	require.NotNil(t, jerr.Code)
+	require.NotNil(t, jerr.Status)
+	require.Equal(t, jsonapi.ErrorCodeBadParameter, *jerr.Code)
+	require.Equal(t, strconv.Itoa(httpStatus), *jerr.Status)
+
+	// test internal server error
+	jerr, httpStatus = jsonapi.ErrorToJSONAPIError(errors.NewInternalError("foo"))
+	require.Equal(t, http.StatusInternalServerError, httpStatus)
+	require.NotNil(t, jerr.Code)
+	require.NotNil(t, jerr.Status)
+	require.Equal(t, jsonapi.ErrorCodeInternalError, *jerr.Code)
+	require.Equal(t, strconv.Itoa(httpStatus), *jerr.Status)
+
+	// test unauthorized error
+	jerr, httpStatus = jsonapi.ErrorToJSONAPIError(errors.NewUnauthorizedError("foo"))
+	require.Equal(t, http.StatusUnauthorized, httpStatus)
+	require.NotNil(t, jerr.Code)
+	require.NotNil(t, jerr.Status)
+	require.Equal(t, jsonapi.ErrorCodeUnauthorizedError, *jerr.Code)
+	require.Equal(t, strconv.Itoa(httpStatus), *jerr.Status)
+
+	// test unspecified error
+	jerr, httpStatus = jsonapi.ErrorToJSONAPIError(fmt.Errorf("foobar"))
+	require.Equal(t, http.StatusInternalServerError, httpStatus)
+	require.NotNil(t, jerr.Code)
+	require.NotNil(t, jerr.Status)
+	require.Equal(t, jsonapi.ErrorCodeUnknownError, *jerr.Code)
+	require.Equal(t, strconv.Itoa(httpStatus), *jerr.Status)
+}


### PR DESCRIPTION
Previously you would have to write:

```go
  jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(err.Error()))
  return ctx.Unauthorized(jerrors)
```

And now you can write:

```go
  return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
```

which is a little bit more like we have treated all the other error
causes.

I've also added some tests for this package.