### PR TITLE
Added a lock for the BootstrapWorkItemLinking function

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -396,6 +396,8 @@ func NewMigrationContext(ctx context.Context) context.Context {
 
 // BootstrapWorkItemLinking makes sure the database is populated with the correct work item link stuff (e.g. category and some basic types)
 func BootstrapWorkItemLinking(ctx context.Context, linkCatRepo *link.GormWorkItemLinkCategoryRepository, spaceRepo *space.GormRepository, linkTypeRepo *link.GormWorkItemLinkTypeRepository) error {
+	populateLocker.Lock()
+	defer populateLocker.Unlock()
 	if err := createOrUpdateSpace(ctx, spaceRepo, space.SystemSpace, "The system space is reserved for spaces that can to be manipulated by the user."); err != nil {
 		return errs.WithStack(err)
 	}


### PR DESCRIPTION

BootstrapWorkItemLinking and PopulateCommonTypes launch updates over the space, and uses that space to refer it as foreign key in other creations. 

related to https://github.com/almighty/almighty-core/issues/952