### PR TITLE
Change type of iteration.path to path.Path

### DIFF
--- a/controller/iteration.go
+++ b/controller/iteration.go
@@ -51,10 +51,6 @@ func (c *IterationController) CreateChild(ctx *app.CreateChildIterationContext) 
 			return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("data.attributes.name", nil).Expected("not nil"))
 		}
 
-		// parentPath := iteration.ConvertToLtreeFormat(parentID.String())
-		// if parent.Path != "" {
-		// 	parentPath = parent.Path + iteration.PathSepInDatabase + parentPath
-		// }
 		childPath := append(parent.Path, parent.ID)
 
 		newItr := iteration.Iteration{
@@ -74,12 +70,7 @@ func (c *IterationController) CreateChild(ctx *app.CreateChildIterationContext) 
 		wiCounts := make(map[string]workitem.WICountsPerIteration)
 		var responseData *app.Iteration
 		if newItr.Path.IsEmpty() == false {
-			// allParents := strings.Split(iteration.ConvertFromLtreeFormat(newItr.Path), iteration.PathSepInDatabase)
 			allParentsUUIDs := newItr.Path
-			// for _, x := range allParents {
-			// 	id, _ := uuid.FromString(x) // we can safely ignore this error.
-			// 	allParentsUUIDs = append(allParentsUUIDs, id)
-			// }
 			iterations, error := appl.Iterations().LoadMultiple(ctx, allParentsUUIDs)
 			if error != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)
@@ -199,7 +190,6 @@ func ConvertIteration(request *goa.RequestData, itr *iteration.Iteration, additi
 	selfURL := rest.AbsoluteURL(request, app.IterationHref(itr.ID))
 	spaceSelfURL := rest.AbsoluteURL(request, app.SpaceHref(spaceID))
 	workitemsRelatedURL := rest.AbsoluteURL(request, app.WorkitemHref("?filter[iteration]="+itr.ID.String()))
-	// pathToTopMostParent := iteration.PathSepInService + iteration.ConvertFromLtreeFormat(itr.Path) // /uuid1/uuid2/uuid3s
 	pathToTopMostParent := itr.Path.String()
 	i := &app.Iteration{
 		Type: iterationType,
@@ -233,8 +223,6 @@ func ConvertIteration(request *goa.RequestData, itr *iteration.Iteration, additi
 		},
 	}
 	if itr.Path.IsEmpty() == false {
-		// allParents := strings.Split(iteration.ConvertFromLtreeFormat(itr.Path), iteration.PathSepInService)
-		// parentID := allParents[len(allParents)-1]
 		parentID := itr.Path.This().String()
 		parentSelfURL := rest.AbsoluteURL(request, app.IterationHref(parentID))
 		i.Relationships.Parent = &app.RelationGeneric{
@@ -276,8 +264,6 @@ type iterationIDMap map[uuid.UUID]*iteration.Iteration
 
 func parentPathResolver(itrMap iterationIDMap) IterationConvertFunc {
 	return func(request *goa.RequestData, itr *iteration.Iteration, appIteration *app.Iteration) {
-		// parentUUIDStrings := strings.Split(iteration.ConvertFromLtreeFormat(itr.Path), iteration.PathSepInService)
-		// parentUUIDs := convertToUUID(parentUUIDStrings)
 		parentUUIDs := itr.Path
 		pathResolved := ""
 		for _, id := range parentUUIDs {

--- a/controller/space_iterations.go
+++ b/controller/space_iterations.go
@@ -68,12 +68,6 @@ func (c *SpaceIterationsController) Create(ctx *app.CreateSpaceIterationsContext
 		wiCounts := make(map[string]workitem.WICountsPerIteration)
 		var responseData *app.Iteration
 		if newItr.Path.IsEmpty() == false {
-			// allParents := strings.Split(iteration.ConvertFromLtreeFormat(newItr.Path), iteration.PathSepInDatabase)
-			// allParentsUUIDs := []uuid.UUID{}
-			// for _, x := range allParents {
-			// 	id, _ := uuid.FromString(x) // we can safely ignore this error.
-			// 	allParentsUUIDs = append(allParentsUUIDs, id)
-			// }
 			allParentsUUIDs := newItr.Path
 			iterations, error := appl.Iterations().LoadMultiple(ctx, allParentsUUIDs)
 			if error != nil {

--- a/controller/space_iterations.go
+++ b/controller/space_iterations.go
@@ -1,8 +1,6 @@
 package controller
 
 import (
-	"strings"
-
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/errors"
@@ -69,13 +67,14 @@ func (c *SpaceIterationsController) Create(ctx *app.CreateSpaceIterationsContext
 		// by passing empty map, updateIterationsWithCounts will be able to put zero values
 		wiCounts := make(map[string]workitem.WICountsPerIteration)
 		var responseData *app.Iteration
-		if newItr.Path != "" {
-			allParents := strings.Split(iteration.ConvertFromLtreeFormat(newItr.Path), iteration.PathSepInDatabase)
-			allParentsUUIDs := []uuid.UUID{}
-			for _, x := range allParents {
-				id, _ := uuid.FromString(x) // we can safely ignore this error.
-				allParentsUUIDs = append(allParentsUUIDs, id)
-			}
+		if newItr.Path.IsEmpty() == false {
+			// allParents := strings.Split(iteration.ConvertFromLtreeFormat(newItr.Path), iteration.PathSepInDatabase)
+			// allParentsUUIDs := []uuid.UUID{}
+			// for _, x := range allParents {
+			// 	id, _ := uuid.FromString(x) // we can safely ignore this error.
+			// 	allParentsUUIDs = append(allParentsUUIDs, id)
+			// }
+			allParentsUUIDs := newItr.Path
 			iterations, error := appl.Iterations().LoadMultiple(ctx, allParentsUUIDs)
 			if error != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)

--- a/controller/space_iterations_test.go
+++ b/controller/space_iterations_test.go
@@ -171,16 +171,14 @@ func (rest *TestSpaceIterationREST) TestListIterationsBySpace() {
 		childIteration = &iteration.Iteration{
 			Name:    "Child Iteration",
 			SpaceID: spaceID,
-			// Path:    iteration.ConvertToLtreeFormat(fatherIteration.ID.String()),
-			Path: append(fatherIteration.Path, fatherIteration.ID),
+			Path:    append(fatherIteration.Path, fatherIteration.ID),
 		}
 		repo.Create(rest.ctx, childIteration)
 
 		grandChildIteration = &iteration.Iteration{
 			Name:    "Grand Child Iteration",
 			SpaceID: spaceID,
-			// Path:    iteration.ConvertToLtreeFormat(fatherIteration.ID.String() + iteration.PathSepInDatabase + childIteration.ID.String()),
-			Path: append(childIteration.Path, childIteration.ID),
+			Path:    append(childIteration.Path, childIteration.ID),
 		}
 		repo.Create(rest.ctx, grandChildIteration)
 

--- a/controller/space_iterations_test.go
+++ b/controller/space_iterations_test.go
@@ -171,14 +171,16 @@ func (rest *TestSpaceIterationREST) TestListIterationsBySpace() {
 		childIteration = &iteration.Iteration{
 			Name:    "Child Iteration",
 			SpaceID: spaceID,
-			Path:    iteration.ConvertToLtreeFormat(fatherIteration.ID.String()),
+			// Path:    iteration.ConvertToLtreeFormat(fatherIteration.ID.String()),
+			Path: append(fatherIteration.Path, fatherIteration.ID),
 		}
 		repo.Create(rest.ctx, childIteration)
 
 		grandChildIteration = &iteration.Iteration{
 			Name:    "Grand Child Iteration",
 			SpaceID: spaceID,
-			Path:    iteration.ConvertToLtreeFormat(fatherIteration.ID.String() + iteration.PathSepInDatabase + childIteration.ID.String()),
+			// Path:    iteration.ConvertToLtreeFormat(fatherIteration.ID.String() + iteration.PathSepInDatabase + childIteration.ID.String()),
+			Path: append(childIteration.Path, childIteration.ID),
 		}
 		repo.Create(rest.ctx, grandChildIteration)
 

--- a/iteration/iteration.go
+++ b/iteration/iteration.go
@@ -1,7 +1,6 @@
 package iteration
 
 import (
-	"strings"
 	"time"
 
 	"github.com/almighty/almighty-core/errors"
@@ -63,20 +62,6 @@ func NewIterationRepository(db *gorm.DB) Repository {
 // GormIterationRepository is the implementation of the storage interface for Iterations.
 type GormIterationRepository struct {
 	db *gorm.DB
-}
-
-// ConvertToLtreeFormat returns LTREE valid string
-func ConvertToLtreeFormat(uuid string) string {
-	//Ltree allows only "_" as a special character.
-	return strings.Replace(uuid, "-", "_", -1)
-}
-
-// ConvertFromLtreeFormat returns UUID in form of string
-func ConvertFromLtreeFormat(uuid string) string {
-	// Ltree allows only "_" as a special character.
-	converted := strings.Replace(uuid, "_", "-", -1)
-	converted = strings.Replace(converted, PathSepInDatabase, PathSepInService, -1)
-	return converted
 }
 
 // LoadMultiple returns multiple instances of iteration.Iteration

--- a/iteration/iteration.go
+++ b/iteration/iteration.go
@@ -7,6 +7,7 @@ import (
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/log"
+	"github.com/almighty/almighty-core/path"
 
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
@@ -30,7 +31,7 @@ type Iteration struct {
 	gormsupport.Lifecycle
 	ID          uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"` // This is the ID PK field
 	SpaceID     uuid.UUID `sql:"type:uuid"`
-	Path        string
+	Path        path.Path
 	StartAt     *time.Time
 	EndAt       *time.Time
 	Name        string

--- a/iteration/iteration_test.go
+++ b/iteration/iteration_test.go
@@ -101,7 +101,6 @@ func (test *TestIterationRepository) TestCreateChildIteration() {
 	}
 	repo.Create(context.Background(), &i)
 
-	// parentPath := iteration.ConvertToLtreeFormat(i.ID.String())
 	parentPath := append(i.Path, i.ID)
 	require.NotNil(t, parentPath)
 	i2 := iteration.Iteration{
@@ -117,7 +116,6 @@ func (test *TestIterationRepository) TestCreateChildIteration() {
 	require.Nil(t, err)
 	assert.NotEmpty(t, i2.Path)
 	i2.Path.Convert()
-	// expectedPath := iteration.ConvertToLtreeFormat(i.ID.String())
 	expectedPath := i2.Path.Convert()
 	require.NotNil(t, i2L)
 	assert.Equal(t, expectedPath, i2L.Path.Convert())

--- a/iteration/iteration_test.go
+++ b/iteration/iteration_test.go
@@ -101,7 +101,8 @@ func (test *TestIterationRepository) TestCreateChildIteration() {
 	}
 	repo.Create(context.Background(), &i)
 
-	parentPath := iteration.ConvertToLtreeFormat(i.ID.String())
+	// parentPath := iteration.ConvertToLtreeFormat(i.ID.String())
+	parentPath := append(i.Path, i.ID)
 	require.NotNil(t, parentPath)
 	i2 := iteration.Iteration{
 		Name:    name2,
@@ -115,9 +116,11 @@ func (test *TestIterationRepository) TestCreateChildIteration() {
 	i2L, err := repo.Load(context.Background(), i2.ID)
 	require.Nil(t, err)
 	assert.NotEmpty(t, i2.Path)
-	expectedPath := iteration.ConvertToLtreeFormat(i.ID.String())
+	i2.Path.Convert()
+	// expectedPath := iteration.ConvertToLtreeFormat(i.ID.String())
+	expectedPath := i2.Path.Convert()
 	require.NotNil(t, i2L)
-	assert.Equal(t, expectedPath, i2L.Path)
+	assert.Equal(t, expectedPath, i2L.Path.Convert())
 }
 
 func (test *TestIterationRepository) TestListIterationBySpace() {
@@ -130,7 +133,7 @@ func (test *TestIterationRepository) TestListIterationBySpace() {
 		Name: "Space 1",
 	}
 	repoSpace := space.NewRepository(test.DB)
-	space, err := repoSpace.Create(context.Background(), &newSpace)
+	spaceInstance, err := repoSpace.Create(context.Background(), &newSpace)
 	assert.Nil(t, err)
 
 	for i := 0; i < 3; i++ {
@@ -140,18 +143,26 @@ func (test *TestIterationRepository) TestListIterationBySpace() {
 
 		i := iteration.Iteration{
 			Name:    name,
-			SpaceID: space.ID,
+			SpaceID: spaceInstance.ID,
 			StartAt: &start,
 			EndAt:   &end,
 		}
-		repo.Create(context.Background(), &i)
+		e := repo.Create(context.Background(), &i)
+		require.Nil(t, e)
 	}
-	repo.Create(context.Background(), &iteration.Iteration{
+	// create another space and add iteration to another space
+	anotherSpace := space.Space{
+		Name: "Space 2",
+	}
+	anotherSpaceCreated, err := repoSpace.Create(context.Background(), &anotherSpace)
+	assert.Nil(t, err)
+	e := repo.Create(context.Background(), &iteration.Iteration{
 		Name:    "Other Spring #2",
-		SpaceID: uuid.NewV4(),
+		SpaceID: anotherSpaceCreated.ID,
 	})
+	require.Nil(t, e)
 
-	its, err := repo.List(context.Background(), space.ID)
+	its, err := repo.List(context.Background(), spaceInstance.ID)
 	assert.Nil(t, err)
 	assert.Len(t, its, 3)
 }


### PR DESCRIPTION
Fixes https://github.com/almighty/almighty-core/issues/971

Removed `ConvertToLtreeFormat` and `ConvertFromLtreeFormat` from iterations package.
Make use of `path.Path` for iteration.Path
Tests updated.

No change in representation for database layer. It is still a valid ltree sting like `218172e8_a797_49f8_b3f3_b96e5ac6f0f4.3574fb25_45db_4397_87ca_8690529328be` 

But `iteration.Path` is a slice of UUIDs(path.Path) now instead of string.
