### PR TITLE
Add syntax highlight parsing to Markdown Code blocks

### DIFF
--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -301,7 +301,7 @@ func (s *searchBlackBoxTest) searchByURL(customHost, queryString string) *app.Se
 	prms := url.Values{}
 	prms["q"] = []string{queryString} // any value will do
 	goaCtx := goa.NewContext(goa.WithAction(s.svc.Context, "SearchTest"), rw, req, prms)
-	showCtx, err := app.NewShowSearchContext(goaCtx, req, s.svc)
+	showCtx, err := app.NewShowSearchContext(goaCtx, s.svc)
 	require.Nil(s.T(), err)
 	// Perform action
 	err = s.controller.Show(showCtx)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 4fedc69e9b8036526541c1d96fca46442a62be55eb9a0978f6a79afeee6835ef
-updated: 2017-01-06T11:31:36.85633711+01:00
+hash: 2a169f03a0cb6842708fa61ee7be28abc174b2a1f6cdc0ad528a71f441f01eaf
+updated: 2017-03-11T22:29:26.961341809+01:00
 imports:
 - name: bitbucket.org/pkg/inflect
   version: 8961c3750a47b8c0b3e118d52513b97adf85a7e8
@@ -22,12 +22,12 @@ imports:
 - name: github.com/dimfeld/httppath
   version: c8e499c3ef3c3e272ed8bdcc1ccf39f73c88debc
 - name: github.com/dimfeld/httptreemux
-  version: a12c89c2c0f23f880dfd74af4832a23bae6e837a
+  version: 86f7c217d9043ebc6adfd8e2ed04a0bb1e1db651
 - name: github.com/dnaeon/go-vcr
   version: 9d71b8a6df86e00127f96bc8dabc09856ab8afdb
   subpackages:
-  - cassette
   - recorder
+  - cassette
 - name: github.com/elazarl/go-bindata-assetfs
   version: 9a6736ed45b44bf3835afeebb3034b57ed329f3e
   subpackages:
@@ -36,24 +36,32 @@ imports:
   version: dc3312cb1a4513a366c4c9e622ad55c32df12ed3
 - name: github.com/fsnotify/fsnotify
   version: 629574ca2a5df945712d3079857300b5e4da0236
+- name: github.com/fzipp/gocyclo
+  version: 6acd4345c835499920e8426c7e4e8d7a34f1bb83
 - name: github.com/goadesign/goa
-  version: 9eda81168b626a13825cd0e9c0d607411fb0b5b5
+  version: 8f0fdca409904318050f9e03579c3878f8928826
   vcs: git
   subpackages:
   - client
   - cors
   - design
   - design/apidsl
-  - dslengine
   - goagen
   - goagen/codegen
   - goagen/gen_app
+  - goagen/gen_controllers
   - goagen/utils
   - goatest
   - middleware
-  - middleware/gzip
   - middleware/security/jwt
+  - logging/logrus
+  - middleware/gzip
   - uuid
+  - dslengine
+- name: github.com/golang/lint
+  version: c7bacac2b21ca01afa1dee0acf64df3ce047c28f
+  subpackages:
+  - golint
 - name: github.com/golang/protobuf
   version: 8ee79997227bf9b34611aee7946ae64735e6fd93
   subpackages:
@@ -71,10 +79,10 @@ imports:
   subpackages:
   - hcl/ast
   - hcl/parser
-  - hcl/scanner
-  - hcl/strconv
   - hcl/token
   - json/parser
+  - hcl/scanner
+  - hcl/strconv
   - json/scanner
   - json/token
 - name: github.com/howeyc/fsnotify
@@ -112,15 +120,15 @@ imports:
 - name: github.com/mitchellh/mapstructure
   version: 5a0325d7fafaac12dda6e7fb8bd222ec1b69875e
 - name: github.com/pelletier/go-buffruneio
-  version: df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d
+  version: c37440a7cf42ac63b919c752ca73a85067e05992
 - name: github.com/pelletier/go-toml
-  version: d464759235b8fd59f8ab4c44807d7c36e1678add
+  version: 13d49d4606eb801b8f01ae542b4afc4c6ee3d84a
 - name: github.com/pilu/config
   version: 3eb99e6c0b9a2dae0f56f05552c06ca5a643919b
 - name: github.com/pilu/fresh
   version: 315385b584ff3845a255844aeb2b7d14a26648b0
 - name: github.com/pkg/errors
-  version: 248dadf4e9068a0b3e79f02ed0a610d935de5302
+  version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -133,6 +141,12 @@ imports:
   version: b061729afc07e77a8aa4fad0a2fd840958f1942a
 - name: github.com/shurcooL/sanitized_anchor_name
   version: 1dba4b3954bc059efc3991ec364f9f9a35f597d2
+- name: github.com/Sirupsen/logrus
+  version: c078b1e43f58d563c74cebe63c85789e76ddb627
+- name: github.com/sourcegraph/annotate
+  version: f4cad6c6324d3f584e1743d8b3e0e017a5f3a636
+- name: github.com/sourcegraph/syntaxhighlight
+  version: c95ac474b7cb9c711f4591b553a2caaa24ea3d37
 - name: github.com/spf13/afero
   version: 2f30b2a92c0e5700bcfe4715891adb1f2a7a406d
   subpackages:
@@ -151,8 +165,8 @@ imports:
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
-  - require
   - suite
+  - require
 - name: github.com/trivago/tgo
   version: 4a656addb20609ba4cb4d20219a2f6c27aeb142c
   subpackages:
@@ -166,10 +180,11 @@ imports:
   subpackages:
   - context
   - websocket
+  - html
+  - html/atom
 - name: golang.org/x/oauth2
   version: da3ce8d62a7f77aadfda06cb82bd604d6469c645
   subpackages:
-  - github
   - internal
 - name: golang.org/x/sys
   version: 478fcf54317e52ab69f40bb4c7a1520288d7f7ea
@@ -187,23 +202,15 @@ imports:
 - name: google.golang.org/appengine
   version: ca59ef35f409df61fa4a5f8290ff289b37eccfb8
   subpackages:
+  - urlfetch
   - internal
+  - internal/urlfetch
   - internal/base
   - internal/datastore
   - internal/log
   - internal/remote_api
-  - internal/urlfetch
-  - urlfetch
 - name: gopkg.in/asaskevich/govalidator.v4
   version: 7664702784775e51966f0885f5cd27435916517b
 - name: gopkg.in/yaml.v2
   version: a5b47d31c556af34a302ce5d659e6fea44d90de0
-- name: github.com/golang/lint
-  version: c7bacac2b21ca01afa1dee0acf64df3ce047c28f
-  subpackages:
-  - golint
-- name: github.com/fzipp/gocyclo
-  version: 6acd4345c835499920e8426c7e4e8d7a34f1bb83
-- name: github.com/Sirupsen/logrus
-  version: c078b1e43f58d563c74cebe63c85789e76ddb627
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -77,7 +77,7 @@ import:
   version: ^1.7.0
 - package: github.com/mitchellh/mapstructure
 - package: github.com/pelletier/go-toml
-  version: ^0.3.5
+  version: ^0.5.0
 - package: github.com/pkg/errors
   version: ^0.8.0
 - package: github.com/spf13/afero
@@ -91,6 +91,10 @@ import:
 - package: github.com/russross/blackfriday
 - package: github.com/microcosm-cc/bluemonday
 - package: github.com/shurcooL/sanitized_anchor_name
-- package: github.com/golang/lint/golint
-- package: github.com/golang/fzipp/gocyclo
+- package: github.com/golang/lint
+  subpackages:
+  - golint
+- package: github.com/fzipp/gocyclo
 - package: github.com/Sirupsen/logrus
+- package: github.com/sourcegraph/syntaxhighlight
+- package: github.com/sourcegraph/annotate

--- a/login/service_blackbox_test.go
+++ b/login/service_blackbox_test.go
@@ -100,7 +100,7 @@ func TestKeycloakAuthorizationRedirect(t *testing.T) {
 	prms := url.Values{}
 	ctx := context.Background()
 	goaCtx := goa.NewContext(goa.WithAction(ctx, "LoginTest"), rw, req, prms)
-	authorizeCtx, err := app.NewAuthorizeLoginContext(goaCtx, req, goa.New("LoginService"))
+	authorizeCtx, err := app.NewAuthorizeLoginContext(goaCtx, goa.New("LoginService"))
 	if err != nil {
 		panic("invalid test data " + err.Error()) // bug
 	}
@@ -166,7 +166,7 @@ func TestInvalidState(t *testing.T) {
 	}
 	ctx := context.Background()
 	goaCtx := goa.NewContext(goa.WithAction(ctx, "LoginTest"), rw, req, prms)
-	authorizeCtx, err := app.NewAuthorizeLoginContext(goaCtx, req, goa.New("LoginService"))
+	authorizeCtx, err := app.NewAuthorizeLoginContext(goaCtx, goa.New("LoginService"))
 	if err != nil {
 		panic("invalid test data " + err.Error()) // bug
 	}
@@ -211,7 +211,7 @@ func TestInvalidOAuthAuthorizationCode(t *testing.T) {
 	prms := url.Values{}
 	ctx := context.Background()
 	goaCtx := goa.NewContext(goa.WithAction(ctx, "LoginTest"), rw, req, prms)
-	authorizeCtx, err := app.NewAuthorizeLoginContext(goaCtx, req, goa.New("LoginService"))
+	authorizeCtx, err := app.NewAuthorizeLoginContext(goaCtx, goa.New("LoginService"))
 	if err != nil {
 		panic("invalid test data " + err.Error()) // bug
 	}
@@ -262,7 +262,7 @@ func TestInvalidOAuthAuthorizationCode(t *testing.T) {
 	}
 
 	goaCtx = goa.NewContext(goa.WithAction(ctx, "LoginTest"), rw, req, prms)
-	authorizeCtx, err = app.NewAuthorizeLoginContext(goaCtx, req, goa.New("LoginService"))
+	authorizeCtx, err = app.NewAuthorizeLoginContext(goaCtx, goa.New("LoginService"))
 
 	err = loginService.Perform(authorizeCtx, authEndpoint, tokenEndpoint)
 

--- a/rendering/markdown.go
+++ b/rendering/markdown.go
@@ -71,7 +71,7 @@ func (h highlightHTMLRenderer) BlockCode(out *bytes.Buffer, text []byte, lang st
 		}
 
 		if count == 0 {
-			out.WriteString("<pre><code>")
+			out.WriteString("<pre><code class=\"prettyprint\">")
 		} else {
 			out.WriteString("\">")
 		}

--- a/rendering/markdown.go
+++ b/rendering/markdown.go
@@ -62,7 +62,7 @@ func (h highlightHTMLRenderer) BlockCode(out *bytes.Buffer, text []byte, lang st
 				continue
 			}
 			if count == 0 {
-				out.WriteString("<pre><code class=\"language-")
+				out.WriteString("<pre><code class=\"prettyprint language-")
 			} else {
 				out.WriteByte(' ')
 			}

--- a/rendering/markdown.go
+++ b/rendering/markdown.go
@@ -1,0 +1,82 @@
+package rendering
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/russross/blackfriday"
+	"github.com/sourcegraph/syntaxhighlight"
+)
+
+const (
+	commonHTMLFlags = 0 |
+		blackfriday.HTML_USE_XHTML |
+		blackfriday.HTML_USE_SMARTYPANTS |
+		blackfriday.HTML_SMARTYPANTS_FRACTIONS |
+		blackfriday.HTML_SMARTYPANTS_DASHES |
+		blackfriday.HTML_SMARTYPANTS_LATEX_DASHES
+
+	commonExtensions = 0 |
+		blackfriday.EXTENSION_NO_INTRA_EMPHASIS |
+		blackfriday.EXTENSION_TABLES |
+		blackfriday.EXTENSION_FENCED_CODE |
+		blackfriday.EXTENSION_AUTOLINK |
+		blackfriday.EXTENSION_STRIKETHROUGH |
+		blackfriday.EXTENSION_SPACE_HEADERS |
+		blackfriday.EXTENSION_HEADER_IDS |
+		blackfriday.EXTENSION_BACKSLASH_LINE_BREAK |
+		blackfriday.EXTENSION_DEFINITION_LISTS
+)
+
+// MarkdownCommonHighlighter uses the blackfriday.MarkdownCommon setup but also includes
+// code-prettify formatting of BlockCode segments
+func MarkdownCommonHighlighter(input []byte) []byte {
+	renderer := highlightHTMLRenderer{blackfriday.HtmlRenderer(commonHTMLFlags, "", "")}
+	return blackfriday.MarkdownOptions(input, renderer, blackfriday.Options{
+		Extensions: commonExtensions})
+}
+
+type highlightHTMLRenderer struct {
+	blackfriday.Renderer
+}
+
+// BlackCode overrides the standard Html Renderer to add support for prettify of source code within block
+// If highlighter fail, normal Html.BlockCode is called
+func (h highlightHTMLRenderer) BlockCode(out *bytes.Buffer, text []byte, lang string) {
+	highlighted, err := syntaxhighlight.AsHTML(text)
+	if err != nil {
+		h.Renderer.BlockCode(out, text, lang)
+	} else {
+
+		if out.Len() > 0 {
+			out.WriteByte('\n')
+		}
+
+		// parse out the language names/classes
+		count := 0
+		for _, elt := range strings.Fields(lang) {
+			if elt[0] == '.' {
+				elt = elt[1:]
+			}
+			if len(elt) == 0 {
+				continue
+			}
+			if count == 0 {
+				out.WriteString("<pre><code class=\"language-")
+			} else {
+				out.WriteByte(' ')
+			}
+			out.Write([]byte(elt)) // attrEscape(out, []byte(elt))
+			count++
+		}
+
+		if count == 0 {
+			out.WriteString("<pre><code>")
+		} else {
+			out.WriteString("\">")
+		}
+
+		out.Write(highlighted)
+		out.WriteString("</code></pre>\n")
+	}
+}

--- a/rendering/markup_render.go
+++ b/rendering/markup_render.go
@@ -23,7 +23,7 @@ func RenderMarkupToHTML(content, markup string) string {
 	case SystemMarkupMarkdown:
 		unsafe := MarkdownCommonHighlighter([]byte(content))
 		p := bluemonday.UGCPolicy()
-		p.AllowAttrs("class").Matching(regexp.MustCompile("^language-[a-zA-Z0-9]+$")).OnElements("code")
+		p.AllowAttrs("class").Matching(regexp.MustCompile("^language-[a-zA-Z0-9]+$|prettyprint")).OnElements("code")
 		p.AllowAttrs("class").OnElements("span")
 		html := string(p.SanitizeBytes(unsafe))
 		return html

--- a/rendering/markup_render.go
+++ b/rendering/markup_render.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 
 	"github.com/microcosm-cc/bluemonday"
-	"github.com/russross/blackfriday"
 )
 
 // IsMarkupSupported indicates if the given markup is supported
@@ -22,9 +21,10 @@ func RenderMarkupToHTML(content, markup string) string {
 	case SystemMarkupPlainText:
 		return content
 	case SystemMarkupMarkdown:
-		unsafe := blackfriday.MarkdownCommon([]byte(content))
+		unsafe := MarkdownCommonHighlighter([]byte(content))
 		p := bluemonday.UGCPolicy()
 		p.AllowAttrs("class").Matching(regexp.MustCompile("^language-[a-zA-Z0-9]+$")).OnElements("code")
+		p.AllowAttrs("class").OnElements("span")
 		html := string(p.SanitizeBytes(unsafe))
 		return html
 	default:

--- a/rendering/markup_render_test.go
+++ b/rendering/markup_render_test.go
@@ -22,7 +22,7 @@ func TestRenderMarkdownContentWithFence(t *testing.T) {
 	result := rendering.RenderMarkupToHTML(content, rendering.SystemMarkupMarkdown)
 	t.Log(result)
 	require.NotNil(t, result)
-	assert.True(t, strings.Contains(result, "<code class=\"language-go\">"))
+	assert.True(t, strings.Contains(result, "<code class=\"prettyprint language-go\">"))
 }
 
 func TestRenderMarkdownContentWithFenceHighlighter(t *testing.T) {
@@ -30,7 +30,7 @@ func TestRenderMarkdownContentWithFenceHighlighter(t *testing.T) {
 	result := rendering.RenderMarkupToHTML(content, rendering.SystemMarkupMarkdown)
 	t.Log(result)
 	require.NotNil(t, result)
-	assert.True(t, strings.Contains(result, "<code class=\"language-go\">"))
+	assert.True(t, strings.Contains(result, "<code class=\"prettyprint language-go\">"))
 	assert.True(t, strings.Contains(result, "<span class=\"kwd\">func</span>"))
 }
 

--- a/rendering/markup_render_test.go
+++ b/rendering/markup_render_test.go
@@ -25,6 +25,15 @@ func TestRenderMarkdownContentWithFence(t *testing.T) {
 	assert.True(t, strings.Contains(result, "<code class=\"language-go\">"))
 }
 
+func TestRenderMarkdownContentWithFenceHighlighter(t *testing.T) {
+	content := "``` go\nfunc getTrue() bool {return true}\n```"
+	result := rendering.RenderMarkupToHTML(content, rendering.SystemMarkupMarkdown)
+	t.Log(result)
+	require.NotNil(t, result)
+	assert.True(t, strings.Contains(result, "<code class=\"language-go\">"))
+	assert.True(t, strings.Contains(result, "<span class=\"kwd\">func</span>"))
+}
+
 func TestIsMarkupSupported(t *testing.T) {
 	assert.True(t, rendering.IsMarkupSupported(rendering.SystemMarkupDefault))
 	assert.True(t, rendering.IsMarkupSupported(rendering.SystemMarkupPlainText))


### PR DESCRIPTION
HTML output support the Code-Prettify CSS styles.

When UI add the code prettify CSS the output will look like:
![screenshot from 2017-03-11 23-01-42](https://cloud.githubusercontent.com/assets/132158/23827903/f12cd332-06bf-11e7-94fa-e20aea646d8b.png)
