### PR TITLE
[WIP] [Questions] Use Space API to handle wi,wit and wilt

### DIFF
--- a/controller/comments_blackbox_test.go
+++ b/controller/comments_blackbox_test.go
@@ -84,7 +84,7 @@ func (s *CommentsSuite) createWorkItem(identity account.Identity) string {
 	spaceSelfURL := rest.AbsoluteURL(&goa.RequestData{
 		Request: &http.Request{Host: "api.service.domain.org"},
 	}, app.SpaceHref(space.SystemSpace.String()))
-	createWorkitemPayload := app.CreateWorkitemPayload{
+	createSpaceWorkitemsPayload := app.CreateSpaceWorkitemsPayload{
 		Data: &app.WorkItem2{
 			Type: APIStringTypeWorkItem,
 			Attributes: map[string]interface{}{
@@ -102,7 +102,7 @@ func (s *CommentsSuite) createWorkItem(identity account.Identity) string {
 		},
 	}
 	userSvc, workitemCtrl, _, _ := s.securedControllers(identity)
-	_, wi := test.CreateWorkitemCreated(s.T(), userSvc.Context, userSvc, workitemCtrl, &createWorkitemPayload)
+	_, wi := test.CreateSpaceWorkitemsCreated(s.T(), userSvc.Context, userSvc, workitemCtrl, space.SystemSpace.String(), &createSpaceWorkitemsPayload)
 	workitemId := *wi.Data.ID
 	s.T().Log(fmt.Sprintf("Created workitem with id %v", workitemId))
 	return workitemId

--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -251,11 +251,11 @@ func (s *searchBlackBoxTest) TestUnwantedCharactersRelatedToSearchLogic() {
 	assert.Empty(s.T(), sr.Data)
 }
 
-func (s *searchBlackBoxTest) getWICreatePayload() *app.CreateWorkitemPayload {
+func (s *searchBlackBoxTest) getWICreatePayload() *app.CreateSpaceWorkitemsPayload {
 	spaceSelfURL := rest.AbsoluteURL(&goa.RequestData{
 		Request: &http.Request{Host: "api.service.domain.org"},
 	}, app.SpaceHref(space.SystemSpace.String()))
-	c := app.CreateWorkitemPayload{
+	c := app.CreateSpaceWorkitemsPayload{
 		Data: &app.WorkItem2{
 			Type:       APIStringTypeWorkItem,
 			Attributes: map[string]interface{}{},
@@ -333,7 +333,7 @@ func (s *searchBlackBoxTest) TestAutoRegisterHostURL() {
 	wiCtrl := NewWorkitemController(s.svc, gormapplication.NewGormDB(s.DB))
 	// create a WI, search by `list view URL` of newly created item
 	newWI := s.getWICreatePayload()
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, wiCtrl, newWI)
+	_, wi := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, wiCtrl, space.SystemSpace, newWI)
 	require.NotNil(s.T(), wi)
 	customHost := "own.domain.one"
 	queryString := fmt.Sprintf("http://%s/work-item/list/detail/%s", customHost, *wi.Data.ID)

--- a/controller/space_workitemlinktypes.go
+++ b/controller/space_workitemlinktypes.go
@@ -1,0 +1,137 @@
+package controller
+
+import (
+	"github.com/almighty/almighty-core/app"
+	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/errors"
+	"github.com/almighty/almighty-core/jsonapi"
+	"github.com/almighty/almighty-core/login"
+	"github.com/almighty/almighty-core/rest"
+	"github.com/almighty/almighty-core/workitem/link"
+
+	"github.com/goadesign/goa"
+	uuid "github.com/satori/go.uuid"
+)
+
+// SpaceWorkitemlinktypesController implements the space_workitemlinktypes resource.
+type SpaceWorkitemlinktypesController struct {
+	*goa.Controller
+	db application.DB
+}
+
+// NewSpaceWorkitemlinktypesController creates a space_workitemlinktypes controller.
+func NewSpaceWorkitemlinktypesController(service *goa.Service, db application.DB) *SpaceWorkitemlinktypesController {
+	return &SpaceWorkitemlinktypesController{Controller: service.NewController("SpaceWorkitemlinktypesController"), db: db}
+}
+
+// Create runs the create action.
+func (c *SpaceWorkitemlinktypesController) Create(ctx *app.CreateSpaceWorkitemlinktypesContext) error {
+	spaceID, err := uuid.FromString(ctx.ID)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
+	}
+
+	// WorkItemLinkTypeController_Create: start_implement
+	// Convert payload from app to model representation
+	model := link.WorkItemLinkType{}
+	in := app.WorkItemLinkTypeSingle{
+		Data: ctx.Payload.Data,
+	}
+	err = link.ConvertLinkTypeToModel(in, &model)
+	if err != nil {
+		jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(err.Error()))
+		return ctx.BadRequest(jerrors)
+	}
+	currentUserIdentityID, err := login.ContextIdentity(ctx)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
+	}
+	return application.Transactional(c.db, func(appl application.Application) error {
+		//linkType, err := appl.WorkItemLinkTypes().Create(ctx.Context, model.Name, model.Description, model.SourceTypeID, model.TargetTypeID, model.ForwardName, model.ReverseName, model.Topology, model.LinkCategoryID, model.SpaceID)
+		//TODO: It confusing if whether the Space data will come from the ctx or payload
+		linkType, err := appl.WorkItemLinkTypes().Create(ctx.Context, model.Name, model.Description, model.SourceTypeID, model.TargetTypeID, model.ForwardName, model.ReverseName, model.Topology, model.LinkCategoryID, spaceID)
+		if err != nil {
+			jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(err)
+			return ctx.ResponseData.Service.Send(ctx.Context, httpStatusCode, jerrors)
+		}
+		// Enrich
+		linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkTypeHref, currentUserIdentityID)
+		err = enrichLinkTypeSingle(linkCtx, linkType)
+		if err != nil {
+			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInternal("Failed to enrich link type: %s", err.Error()))
+			return ctx.InternalServerError(jerrors)
+		}
+		ctx.ResponseData.Header().Set("Location", app.WorkItemLinkTypeHref(linkType.Data.ID))
+		return ctx.Created(linkType)
+	})
+	// WorkItemLinkTypeController_Create: end_implement
+}
+
+// List runs the list action.
+func (c *SpaceWorkitemlinktypesController) List(ctx *app.ListSpaceWorkitemlinktypesContext) error {
+	spaceID, err := uuid.FromString(ctx.ID)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
+	}
+
+	// WorkItemLinkTypeController_List: start_implement
+	return application.Transactional(c.db, func(appl application.Application) error {
+		result, err := appl.WorkItemLinkTypes().List(ctx.Context, spaceID)
+		if err != nil {
+			jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(err)
+			return ctx.ResponseData.Service.Send(ctx.Context, httpStatusCode, jerrors)
+		}
+		// Enrich
+		linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkTypeHref, nil)
+		err = enrichLinkTypeList(linkCtx, result)
+		if err != nil {
+			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInternal("Failed to enrich link types: %s", err.Error()))
+			return ctx.InternalServerError(jerrors)
+		}
+		return ctx.OK(result)
+	})
+}
+
+// enrichLinkTypeList includes related resources in the list's "included" array
+func enrichLinkTypeList(ctx *workItemLinkContext, list *app.WorkItemLinkTypeList) error {
+	// Add "links" element
+	for _, data := range list.Data {
+		selfURL := rest.AbsoluteURL(ctx.RequestData, ctx.LinkFunc(*data.ID))
+		data.Links = &app.GenericLinks{
+			Self: &selfURL,
+		}
+	}
+	// Build our "set" of distinct category IDs already converted as strings
+	categoryIDMap := map[uuid.UUID]bool{}
+	for _, typeData := range list.Data {
+		categoryIDMap[typeData.Relationships.LinkCategory.Data.ID] = true
+	}
+	// Now include the optional link category data in the work item link type "included" array
+	for categoryID := range categoryIDMap {
+		linkCat, err := ctx.Application.WorkItemLinkCategories().Load(ctx.Context, categoryID)
+		if err != nil {
+			jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(err)
+			return ctx.ResponseData.Service.Send(ctx.Context, httpStatusCode, jerrors)
+		}
+		list.Included = append(list.Included, linkCat.Data)
+	}
+
+	// Build our "set" of distinct space IDs already converted as strings
+	spaceIDMap := map[uuid.UUID]bool{}
+	for _, typeData := range list.Data {
+		spaceIDMap[*typeData.Relationships.Space.Data.ID] = true
+	}
+	// Now include the optional link space data in the work item link type "included" array
+	for spaceID := range spaceIDMap {
+		space, err := ctx.Application.Spaces().Load(ctx.Context, spaceID)
+		if err != nil {
+			jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(err)
+			return ctx.ResponseData.Service.Send(ctx.Context, httpStatusCode, jerrors)
+		}
+		spaceSingle := &app.SpaceSingle{
+			Data: ConvertSpace(ctx.RequestData, space),
+		}
+		list.Included = append(list.Included, spaceSingle.Data)
+	}
+	return nil
+}

--- a/controller/space_workitemlinktypes_test.go
+++ b/controller/space_workitemlinktypes_test.go
@@ -1,0 +1,56 @@
+package controller_test
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	. "github.com/almighty/almighty-core/controller"
+	"github.com/almighty/almighty-core/gormapplication"
+	"github.com/almighty/almighty-core/gormsupport/cleaner"
+	"github.com/almighty/almighty-core/gormtestsupport"
+	testsupport "github.com/almighty/almighty-core/test"
+	almtoken "github.com/almighty/almighty-core/token"
+
+	"github.com/goadesign/goa"
+	"github.com/stretchr/testify/suite"
+)
+
+type TestSpaceWorkitemlinktypesREST struct {
+	gormtestsupport.DBTestSuite
+
+	db    *gormapplication.GormDB
+	clean func()
+	ctx   context.Context
+}
+
+func TestRunSpaceWorkitemlinktypesREST(t *testing.T) {
+	suite.Run(t, &TestSpaceWorkitemlinktypesREST{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
+}
+
+func (rest *TestSpaceWorkitemlinktypesREST) SetupTest() {
+	rest.db = gormapplication.NewGormDB(rest.DB)
+	rest.clean = cleaner.DeleteCreatedEntities(rest.DB)
+
+	req := &http.Request{Host: "localhost"}
+	params := url.Values{}
+	rest.ctx = goa.NewContext(context.Background(), nil, req, params)
+}
+
+func (rest *TestSpaceWorkitemlinktypesREST) TearDownTest() {
+	rest.clean()
+}
+
+func (rest *TestSpaceWorkitemlinktypesREST) SecuredController() (*goa.Service, *SpaceWorkitemlinktypesController) {
+	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
+
+	svc := testsupport.ServiceAsUser("WorkItemLinkType-Service", almtoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
+	return svc, NewSpaceWorkitemlinktypesController(svc, rest.db)
+}
+
+func (rest *TestSpaceWorkitemlinktypesREST) UnSecuredController() (*goa.Service, *SpaceWorkitemlinktypesController) {
+	svc := goa.New("WorkItemLinkType-Service")
+	return svc, NewSpaceWorkitemlinktypesController(svc, rest.db)
+}

--- a/controller/space_workitems.go
+++ b/controller/space_workitems.go
@@ -1,0 +1,151 @@
+package controller
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/almighty/almighty-core/app"
+	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/criteria"
+	"github.com/almighty/almighty-core/errors"
+	"github.com/almighty/almighty-core/jsonapi"
+	"github.com/almighty/almighty-core/login"
+	query "github.com/almighty/almighty-core/query/simple"
+	"github.com/almighty/almighty-core/space"
+	"github.com/almighty/almighty-core/workitem"
+
+	"github.com/goadesign/goa"
+	errs "github.com/pkg/errors"
+	uuid "github.com/satori/go.uuid"
+)
+
+// SpaceWorkitemsController implements the space_workitems resource.
+type SpaceWorkitemsController struct {
+	*goa.Controller
+	db application.DB
+}
+
+// NewSpaceWorkitemsController creates a space_workitems controller.
+func NewSpaceWorkitemsController(service *goa.Service, db application.DB) *SpaceWorkitemsController {
+	return &SpaceWorkitemsController{Controller: service.NewController("SpaceWorkitemsController"), db: db}
+}
+
+// Create runs the create action.
+func (c *SpaceWorkitemsController) Create(ctx *app.CreateSpaceWorkitemsContext) error {
+	//TODO: It confusing if whether the Space data will come from the ctx or payload
+	spaceID, err := uuid.FromString(ctx.ID)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
+	}
+
+	currentUserIdentityID, err := login.ContextIdentity(ctx)
+	if err != nil {
+		jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(err.Error()))
+		return ctx.Unauthorized(jerrors)
+	}
+	var wit *uuid.UUID
+	if ctx.Payload.Data != nil && ctx.Payload.Data.Relationships != nil &&
+		ctx.Payload.Data.Relationships.BaseType != nil && ctx.Payload.Data.Relationships.BaseType.Data != nil {
+		wit = &ctx.Payload.Data.Relationships.BaseType.Data.ID
+	}
+	if wit == nil { // TODO Figure out path source etc. Should be a required relation
+		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("Data.Relationships.BaseType.Data.ID", err))
+	}
+	wi := app.WorkItem{
+		Fields: make(map[string]interface{}),
+	}
+	return application.Transactional(c.db, func(appl application.Application) error {
+		//verify spaceID:
+		// To be removed once we have endpoint like - /api/space/{spaceID}/workitems
+		if spaceID != space.SystemSpace {
+			_, spaceLoadErr := appl.Spaces().Load(ctx, spaceID)
+			if spaceLoadErr != nil {
+				return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("space", "string").Expected("valid space ID"))
+			}
+		}
+		err := ConvertJSONAPIToWorkItem(appl, *ctx.Payload.Data, &wi)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error creating work item")))
+		}
+		wi, err := appl.WorkItems().Create(ctx, spaceID, *wit, wi.Fields, *currentUserIdentityID)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error creating work item")))
+		}
+		wi2 := ConvertWorkItem(ctx.RequestData, wi)
+		resp := &app.WorkItem2Single{
+			Data: wi2,
+			Links: &app.WorkItemLinks{
+				Self: buildAbsoluteURL(ctx.RequestData),
+			},
+		}
+		ctx.ResponseData.Header().Set("Last-Modified", lastModified(wi))
+		ctx.ResponseData.Header().Set("Location", app.WorkitemHref(wi2.ID))
+		return ctx.Created(resp)
+	})
+}
+
+// List runs the list action.
+func (c *SpaceWorkitemsController) List(ctx *app.ListSpaceWorkitemsContext) error {
+	spaceID, err := uuid.FromString(ctx.ID)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
+	}
+
+	var additionalQuery []string
+	exp, err := query.Parse(ctx.Filter)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("could not parse filter", err))
+	}
+	if ctx.FilterAssignee != nil {
+		exp = criteria.And(exp, criteria.Equals(criteria.Field("system.assignees"), criteria.Literal([]string{*ctx.FilterAssignee})))
+		additionalQuery = append(additionalQuery, "filter[assignee]="+*ctx.FilterAssignee)
+	}
+	if ctx.FilterIteration != nil {
+		exp = criteria.And(exp, criteria.Equals(criteria.Field(workitem.SystemIteration), criteria.Literal(string(*ctx.FilterIteration))))
+		additionalQuery = append(additionalQuery, "filter[iteration]="+*ctx.FilterIteration)
+	}
+	if ctx.FilterWorkitemtype != nil {
+		exp = criteria.And(exp, criteria.Equals(criteria.Field("Type"), criteria.Literal([]uuid.UUID{*ctx.FilterWorkitemtype})))
+		additionalQuery = append(additionalQuery, "filter[workitemtype]="+ctx.FilterWorkitemtype.String())
+	}
+	if ctx.FilterArea != nil {
+		exp = criteria.And(exp, criteria.Equals(criteria.Field(workitem.SystemArea), criteria.Literal(string(*ctx.FilterArea))))
+		additionalQuery = append(additionalQuery, "filter[area]="+*ctx.FilterArea)
+	}
+	if ctx.FilterWorkitemstate != nil {
+		exp = criteria.And(exp, criteria.Equals(criteria.Field(workitem.SystemState), criteria.Literal(string(*ctx.FilterWorkitemstate))))
+		additionalQuery = append(additionalQuery, "filter[workitemstate]="+*ctx.FilterWorkitemstate)
+	}
+
+	offset, limit := computePagingLimts(ctx.PageOffset, ctx.PageLimit)
+	return application.Transactional(c.db, func(tx application.Application) error {
+		result, tc, err := tx.WorkItems().List(ctx.Context, spaceID, exp, &offset, &limit)
+		count := int(tc)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "Error listing work items"))
+		}
+
+		lastMod := findLastModified(result)
+
+		if ifMod, ok := ctx.RequestData.Header["If-Modified-Since"]; ok {
+			ifModSince, err := http.ParseTime(ifMod[0])
+			if err == nil {
+				if lastMod.Before(ifModSince) || lastMod.Equal(ifModSince) {
+					return ctx.NotModified()
+				}
+			}
+		}
+
+		response := app.WorkItem2List{
+			Links: &app.PagingLinks{},
+			Meta:  &app.WorkItemListResponseMeta{TotalCount: count},
+			Data:  ConvertWorkItems(ctx.RequestData, result),
+		}
+		setPagingLinks(response.Links, buildAbsoluteURL(ctx.RequestData), len(result), offset, limit, count, additionalQuery...)
+		addFilterLinks(response.Links, ctx.RequestData)
+
+		ctx.ResponseData.Header().Set("Last-Modified", lastModifiedTime(lastMod))
+		return ctx.OK(&response)
+	})
+
+}

--- a/controller/space_workitems_test.go
+++ b/controller/space_workitems_test.go
@@ -1,0 +1,56 @@
+package controller_test
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	. "github.com/almighty/almighty-core/controller"
+	"github.com/almighty/almighty-core/gormapplication"
+	"github.com/almighty/almighty-core/gormsupport/cleaner"
+	"github.com/almighty/almighty-core/gormtestsupport"
+	testsupport "github.com/almighty/almighty-core/test"
+	almtoken "github.com/almighty/almighty-core/token"
+
+	"github.com/goadesign/goa"
+	"github.com/stretchr/testify/suite"
+)
+
+type TestSpaceWorkitemREST struct {
+	gormtestsupport.DBTestSuite
+
+	db    *gormapplication.GormDB
+	clean func()
+	ctx   context.Context
+}
+
+func TestRunSpaceWorkitemREST(t *testing.T) {
+	suite.Run(t, &TestSpaceWorkitemREST{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
+}
+
+func (rest *TestSpaceWorkitemREST) SetupTest() {
+	rest.db = gormapplication.NewGormDB(rest.DB)
+	rest.clean = cleaner.DeleteCreatedEntities(rest.DB)
+
+	req := &http.Request{Host: "localhost"}
+	params := url.Values{}
+	rest.ctx = goa.NewContext(context.Background(), nil, req, params)
+}
+
+func (rest *TestSpaceWorkitemREST) TearDownTest() {
+	rest.clean()
+}
+
+func (rest *TestSpaceWorkitemREST) SecuredController() (*goa.Service, *SpaceWorkitemsController) {
+	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
+
+	svc := testsupport.ServiceAsUser("WorkItem-Service", almtoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
+	return svc, NewSpaceWorkitemsController(svc, rest.db)
+}
+
+func (rest *TestSpaceWorkitemREST) UnSecuredController() (*goa.Service, *SpaceWorkitemsController) {
+	svc := goa.New("WorkItem-Service")
+	return svc, NewSpaceWorkitemsController(svc, rest.db)
+}

--- a/controller/space_workitemstypes_test.go
+++ b/controller/space_workitemstypes_test.go
@@ -1,0 +1,56 @@
+package controller_test
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	. "github.com/almighty/almighty-core/controller"
+	"github.com/almighty/almighty-core/gormapplication"
+	"github.com/almighty/almighty-core/gormsupport/cleaner"
+	"github.com/almighty/almighty-core/gormtestsupport"
+	testsupport "github.com/almighty/almighty-core/test"
+	almtoken "github.com/almighty/almighty-core/token"
+
+	"github.com/goadesign/goa"
+	"github.com/stretchr/testify/suite"
+)
+
+type TestSpaceWorkitemtypesREST struct {
+	gormtestsupport.DBTestSuite
+
+	db    *gormapplication.GormDB
+	clean func()
+	ctx   context.Context
+}
+
+func TestRunSpaceWorkitemtypesREST(t *testing.T) {
+	suite.Run(t, &TestSpaceWorkitemtypesREST{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
+}
+
+func (rest *TestSpaceWorkitemtypesREST) SetupTest() {
+	rest.db = gormapplication.NewGormDB(rest.DB)
+	rest.clean = cleaner.DeleteCreatedEntities(rest.DB)
+
+	req := &http.Request{Host: "localhost"}
+	params := url.Values{}
+	rest.ctx = goa.NewContext(context.Background(), nil, req, params)
+}
+
+func (rest *TestSpaceWorkitemtypesREST) TearDownTest() {
+	rest.clean()
+}
+
+func (rest *TestSpaceWorkitemtypesREST) SecuredController() (*goa.Service, *SpaceWorkitemtypesController) {
+	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
+
+	svc := testsupport.ServiceAsUser("WorkItemType-Service", almtoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
+	return svc, NewSpaceWorkitemtypesController(svc, rest.db)
+}
+
+func (rest *TestSpaceWorkitemtypesREST) UnSecuredController() (*goa.Service, *SpaceWorkitemtypesController) {
+	svc := goa.New("WorkItemType-Service")
+	return svc, NewSpaceWorkitemtypesController(svc, rest.db)
+}

--- a/controller/space_workitemtypes.go
+++ b/controller/space_workitemtypes.go
@@ -1,0 +1,67 @@
+package controller
+
+import (
+	"github.com/almighty/almighty-core/app"
+	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/jsonapi"
+
+	"github.com/goadesign/goa"
+	errs "github.com/pkg/errors"
+	uuid "github.com/satori/go.uuid"
+)
+
+// SpaceWorkitemtypesController implements the space_workitemtypes resource.
+type SpaceWorkitemtypesController struct {
+	*goa.Controller
+	db application.DB
+}
+
+// NewSpaceWorkitemtypesController creates a space_workitemtypes controller.
+func NewSpaceWorkitemtypesController(service *goa.Service, db application.DB) *SpaceWorkitemtypesController {
+	return &SpaceWorkitemtypesController{Controller: service.NewController("SpaceWorkitemtypesController"), db: db}
+}
+
+// Create runs the create action.
+func (c *SpaceWorkitemtypesController) Create(ctx *app.CreateSpaceWorkitemtypesContext) error {
+	spaceID, err := uuid.FromString(ctx.ID)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
+	}
+
+	//TODO: It confusing if whether the Space data will come from the ctx or payload
+
+	return application.Transactional(c.db, func(appl application.Application) error {
+		var fields = map[string]app.FieldDefinition{}
+		for key, fd := range ctx.Payload.Data.Attributes.Fields {
+			fields[key] = *fd
+		}
+		//wit, err := appl.WorkItemTypes().Create(ctx.Context, *ctx.Payload.Data.Relationships.Space.Data.ID, ctx.Payload.Data.ID, ctx.Payload.Data.Attributes.ExtendedTypeName, ctx.Payload.Data.Attributes.Name, ctx.Payload.Data.Attributes.Description, ctx.Payload.Data.Attributes.Icon, fields)
+		wit, err := appl.WorkItemTypes().Create(ctx.Context, spaceID, ctx.Payload.Data.ID, ctx.Payload.Data.Attributes.ExtendedTypeName, ctx.Payload.Data.Attributes.Name, ctx.Payload.Data.Attributes.Description, ctx.Payload.Data.Attributes.Icon, fields)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, err)
+		}
+		ctx.ResponseData.Header().Set("Location", app.WorkitemtypeHref(wit.Data.ID))
+		return ctx.Created(wit)
+	})
+}
+
+// List runs the list action.
+func (c *SpaceWorkitemtypesController) List(ctx *app.ListSpaceWorkitemtypesContext) error {
+	spaceID, err := uuid.FromString(ctx.ID)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
+	}
+
+	start, limit, err := parseLimit(ctx.Page)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "Could not parse paging"))
+	}
+
+	return application.Transactional(c.db, func(appl application.Application) error {
+		result, err := appl.WorkItemTypes().List(ctx.Context, spaceID, start, &limit)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "Error listing work item types"))
+		}
+		return ctx.OK(result)
+	})
+}

--- a/controller/work_item_link_blackbox_test.go
+++ b/controller/work_item_link_blackbox_test.go
@@ -192,14 +192,14 @@ func (s *workItemLinkSuite) SetupTest() {
 	s.T().Logf("Created link space with ID: %s\n", *space.Data.ID)
 
 	payload := CreateWorkItemType(uuid.NewV4(), *space.Data.ID)
-	_, wit := test.CreateWorkitemtypeCreated(s.T(), s.svc.Context, s.svc, s.typeCtrl, &payload)
+	_, wit := test.CreateSpaceWorkitemtypesCreated(s.T(), s.svc.Context, s.svc, s.typeCtrl, s.userSpaceID.String(), &payload)
 
 	payload2 := CreateWorkItemType(uuid.NewV4(), *space.Data.ID)
-	_, wit2 := test.CreateWorkitemtypeCreated(s.T(), s.svc.Context, s.svc, s.typeCtrl, &payload2)
+	_, wit2 := test.CreateSpaceWorkitemtypesCreated(s.T(), s.svc.Context, s.svc, s.typeCtrl, s.userSpaceID.String(), &payload2)
 
 	// Create 3 work items (bug1, bug2, and feature1)
 	bug1Payload := CreateWorkItem(s.userSpaceID, *wit.Data.ID, "bug1")
-	_, bug1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, bug1Payload)
+	_, bug1 := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), bug1Payload)
 	require.NotNil(s.T(), bug1)
 	s.deleteWorkItems = append(s.deleteWorkItems, *bug1.Data.ID)
 	s.bug1ID, err = strconv.ParseUint(*bug1.Data.ID, 10, 64)
@@ -207,7 +207,7 @@ func (s *workItemLinkSuite) SetupTest() {
 	s.T().Logf("Created bug1 with ID: %s\n", *bug1.Data.ID)
 
 	bug2Payload := CreateWorkItem(s.userSpaceID, *wit.Data.ID, "bug2")
-	_, bug2 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, bug2Payload)
+	_, bug2 := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), bug2Payload)
 	require.NotNil(s.T(), bug2)
 	s.deleteWorkItems = append(s.deleteWorkItems, *bug2.Data.ID)
 	s.bug2ID, err = strconv.ParseUint(*bug2.Data.ID, 10, 64)
@@ -215,7 +215,7 @@ func (s *workItemLinkSuite) SetupTest() {
 	s.T().Logf("Created bug2 with ID: %s\n", *bug2.Data.ID)
 
 	bug3Payload := CreateWorkItem(s.userSpaceID, *wit.Data.ID, "bug3")
-	_, bug3 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, bug3Payload)
+	_, bug3 := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), bug3Payload)
 	require.NotNil(s.T(), bug3)
 	s.deleteWorkItems = append(s.deleteWorkItems, *bug3.Data.ID)
 	s.bug3ID, err = strconv.ParseUint(*bug3.Data.ID, 10, 64)
@@ -223,7 +223,7 @@ func (s *workItemLinkSuite) SetupTest() {
 	s.T().Logf("Created bug3 with ID: %s\n", *bug3.Data.ID)
 
 	feature1Payload := CreateWorkItem(s.userSpaceID, *wit2.Data.ID, "feature1")
-	_, feature1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, feature1Payload)
+	_, feature1 := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), feature1Payload)
 	require.NotNil(s.T(), feature1)
 	s.deleteWorkItems = append(s.deleteWorkItems, *feature1.Data.ID)
 	s.feature1ID, err = strconv.ParseUint(*feature1.Data.ID, 10, 64)
@@ -240,7 +240,7 @@ func (s *workItemLinkSuite) SetupTest() {
 
 	// Create work item link type payload
 	createLinkTypePayload := CreateWorkItemLinkType("test-bug-blocker", *wit.Data.ID, *wit.Data.ID, s.userLinkCategoryID, s.userSpaceID)
-	_, workItemLinkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.workItemLinkTypeCtrl, createLinkTypePayload)
+	_, workItemLinkType := test.CreateSpaceWorkItemLinkTypesCreated(s.T(), s.svc.Context, s.svc, s.workItemLinkTypeCtrl, s.userSpaceID.String(), createLinkTypePayload)
 	require.NotNil(s.T(), workItemLinkType)
 	//s.deleteWorkItemLinkTypes = append(s.deleteWorkItemLinkTypes, *workItemLinkType.Data.ID)
 	s.bugBlockerLinkTypeID = *workItemLinkType.Data.ID
@@ -273,11 +273,11 @@ func CreateWorkItemLinkCategory(name string) *app.CreateWorkItemLinkCategoryPayl
 }
 
 // CreateWorkItem defines a work item link
-func CreateWorkItem(spaceID uuid.UUID, workItemType uuid.UUID, title string) *app.CreateWorkitemPayload {
+func CreateWorkItem(spaceID uuid.UUID, workItemType uuid.UUID, title string) *app.CreateSpaceWorkitemsPayload {
 	spaceSelfURL := rest.AbsoluteURL(&goa.RequestData{
 		Request: &http.Request{Host: "api.service.domain.org"},
 	}, app.SpaceHref(spaceID.String()))
-	payload := app.CreateWorkitemPayload{
+	payload := app.CreateSpaceWorkitemsPayload{
 		Data: &app.WorkItem2{
 			Attributes: map[string]interface{}{
 				workitem.SystemTitle: title,

--- a/controller/work_item_link_type.go
+++ b/controller/work_item_link_type.go
@@ -7,10 +7,8 @@ import (
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/login"
 	"github.com/almighty/almighty-core/rest"
-	"github.com/almighty/almighty-core/workitem/link"
 
 	"github.com/goadesign/goa"
-	uuid "github.com/satori/go.uuid"
 )
 
 // WorkItemLinkTypeController implements the work-item-link-type resource.
@@ -61,86 +59,6 @@ func enrichLinkTypeSingle(ctx *workItemLinkContext, single *app.WorkItemLinkType
 	return nil
 }
 
-// enrichLinkTypeList includes related resources in the list's "included" array
-func enrichLinkTypeList(ctx *workItemLinkContext, list *app.WorkItemLinkTypeList) error {
-	// Add "links" element
-	for _, data := range list.Data {
-		selfURL := rest.AbsoluteURL(ctx.RequestData, ctx.LinkFunc(*data.ID))
-		data.Links = &app.GenericLinks{
-			Self: &selfURL,
-		}
-	}
-	// Build our "set" of distinct category IDs already converted as strings
-	categoryIDMap := map[uuid.UUID]bool{}
-	for _, typeData := range list.Data {
-		categoryIDMap[typeData.Relationships.LinkCategory.Data.ID] = true
-	}
-	// Now include the optional link category data in the work item link type "included" array
-	for categoryID := range categoryIDMap {
-		linkCat, err := ctx.Application.WorkItemLinkCategories().Load(ctx.Context, categoryID)
-		if err != nil {
-			jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(err)
-			return ctx.ResponseData.Service.Send(ctx.Context, httpStatusCode, jerrors)
-		}
-		list.Included = append(list.Included, linkCat.Data)
-	}
-
-	// Build our "set" of distinct space IDs already converted as strings
-	spaceIDMap := map[uuid.UUID]bool{}
-	for _, typeData := range list.Data {
-		spaceIDMap[*typeData.Relationships.Space.Data.ID] = true
-	}
-	// Now include the optional link space data in the work item link type "included" array
-	for spaceID := range spaceIDMap {
-		space, err := ctx.Application.Spaces().Load(ctx.Context, spaceID)
-		if err != nil {
-			jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(err)
-			return ctx.ResponseData.Service.Send(ctx.Context, httpStatusCode, jerrors)
-		}
-		spaceSingle := &app.SpaceSingle{
-			Data: ConvertSpace(ctx.RequestData, space),
-		}
-		list.Included = append(list.Included, spaceSingle.Data)
-	}
-	return nil
-}
-
-// Create runs the create action.
-func (c *WorkItemLinkTypeController) Create(ctx *app.CreateWorkItemLinkTypeContext) error {
-	// WorkItemLinkTypeController_Create: start_implement
-	// Convert payload from app to model representation
-	model := link.WorkItemLinkType{}
-	in := app.WorkItemLinkTypeSingle{
-		Data: ctx.Payload.Data,
-	}
-	err := link.ConvertLinkTypeToModel(in, &model)
-	if err != nil {
-		jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrBadRequest(err.Error()))
-		return ctx.BadRequest(jerrors)
-	}
-	currentUserIdentityID, err := login.ContextIdentity(ctx)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
-	}
-	return application.Transactional(c.db, func(appl application.Application) error {
-		linkType, err := appl.WorkItemLinkTypes().Create(ctx.Context, model.Name, model.Description, model.SourceTypeID, model.TargetTypeID, model.ForwardName, model.ReverseName, model.Topology, model.LinkCategoryID, model.SpaceID)
-		if err != nil {
-			jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(err)
-			return ctx.ResponseData.Service.Send(ctx.Context, httpStatusCode, jerrors)
-		}
-		// Enrich
-		linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkTypeHref, currentUserIdentityID)
-		err = enrichLinkTypeSingle(linkCtx, linkType)
-		if err != nil {
-			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInternal("Failed to enrich link type: %s", err.Error()))
-			return ctx.InternalServerError(jerrors)
-		}
-		ctx.ResponseData.Header().Set("Location", app.WorkItemLinkTypeHref(linkType.Data.ID))
-		return ctx.Created(linkType)
-	})
-	// WorkItemLinkTypeController_Create: end_implement
-}
-
 // Delete runs the delete action.
 func (c *WorkItemLinkTypeController) Delete(ctx *app.DeleteWorkItemLinkTypeContext) error {
 	// WorkItemLinkTypeController_Delete: start_implement
@@ -153,27 +71,6 @@ func (c *WorkItemLinkTypeController) Delete(ctx *app.DeleteWorkItemLinkTypeConte
 		return ctx.OK([]byte{})
 	})
 	// WorkItemLinkTypeController_Delete: end_implement
-}
-
-// List runs the list action.
-func (c *WorkItemLinkTypeController) List(ctx *app.ListWorkItemLinkTypeContext) error {
-	// WorkItemLinkTypeController_List: start_implement
-	return application.Transactional(c.db, func(appl application.Application) error {
-		result, err := appl.WorkItemLinkTypes().List(ctx.Context)
-		if err != nil {
-			jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(err)
-			return ctx.ResponseData.Service.Send(ctx.Context, httpStatusCode, jerrors)
-		}
-		// Enrich
-		linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkTypeHref, nil)
-		err = enrichLinkTypeList(linkCtx, result)
-		if err != nil {
-			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInternal("Failed to enrich link types: %s", err.Error()))
-			return ctx.InternalServerError(jerrors)
-		}
-		return ctx.OK(result)
-	})
-	// WorkItemLinkTypeController_List: end_implement
 }
 
 // Show runs the show action.

--- a/controller/work_item_link_type_blackbox_test.go
+++ b/controller/work_item_link_type_blackbox_test.go
@@ -141,7 +141,7 @@ func (s *workItemLinkTypeSuite) createDemoLinkType(name string) *app.CreateWorkI
 
 	//	 2. Create at least one work item type
 	workItemTypePayload := CreateWorkItemType(uuid.NewV4(), *space.Data.ID)
-	_, workItemType := test.CreateWorkitemtypeCreated(s.T(), s.svc.Context, s.svc, s.typeCtrl, &workItemTypePayload)
+	_, workItemType := test.CreateSpaceWorkitemtypesCreated(s.T(), s.svc.Context, s.svc, s.typeCtrl, *space.Data.ID, &workItemTypePayload)
 	require.NotNil(s.T(), workItemType)
 
 	//   3. Create a work item link category
@@ -168,7 +168,7 @@ func TestSuiteWorkItemLinkType(t *testing.T) {
 // TestCreateWorkItemLinkType tests if we can create the s.linkTypeName work item link type
 func (s *workItemLinkTypeSuite) TestCreateAndDeleteWorkItemLinkType() {
 	createPayload := s.createDemoLinkType(s.linkTypeName)
-	_, workItemLinkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, createPayload)
+	_, workItemLinkType := test.CreateSpaceWorkItemLinkTypesCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, s.spaceID.String(), createPayload)
 	require.NotNil(s.T(), workItemLinkType)
 
 	// Check that the link category is included in the response in the "included" array
@@ -232,7 +232,7 @@ func (s *workItemLinkTypeSuite) TestUpdateWorkItemLinkTypeNotFound() {
 
 func (s *workItemLinkTypeSuite) TestUpdateWorkItemLinkTypeOK() {
 	createPayload := s.createDemoLinkType(s.linkTypeName)
-	_, workItemLinkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, createPayload)
+	_, workItemLinkType := test.CreateSpaceWorkItemLinkTypesCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, s.spaceID.String(), createPayload)
 	require.NotNil(s.T(), workItemLinkType)
 	// Specify new description for link type that we just created
 	// Wrap data portion in an update payload instead of a create payload
@@ -271,7 +271,7 @@ func (s *workItemLinkTypeSuite) TestUpdateWorkItemLinkTypeOK() {
 func (s *workItemLinkTypeSuite) TestShowWorkItemLinkTypeOK() {
 	// Create the work item link type first and try to read it back in
 	createPayload := s.createDemoLinkType(s.linkTypeName)
-	_, workItemLinkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, createPayload)
+	_, workItemLinkType := test.CreateSpaceWorkItemLinkTypesCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, s.spaceID.String(), createPayload)
 	require.NotNil(s.T(), workItemLinkType)
 	_, readIn := test.ShowWorkItemLinkTypeOK(s.T(), nil, nil, s.linkTypeCtrl, *workItemLinkType.Data.ID)
 	require.NotNil(s.T(), readIn)
@@ -305,15 +305,15 @@ func (s *workItemLinkTypeSuite) TestShowWorkItemLinkTypeNotFound() {
 // s.linkTypeName and s.linkName in the list of work item link types
 func (s *workItemLinkTypeSuite) TestListWorkItemLinkTypeOK() {
 	bugBlockerPayload := s.createDemoLinkType(s.linkTypeName)
-	_, bugBlockerType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, bugBlockerPayload)
+	_, bugBlockerType := test.CreateSpaceWorkItemLinkTypesCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, s.spaceID.String(), bugBlockerPayload)
 	require.NotNil(s.T(), bugBlockerType)
 
 	workItemTypePayload := CreateWorkItemType(uuid.NewV4(), *s.spaceID)
-	_, workItemType := test.CreateWorkitemtypeCreated(s.T(), s.svc.Context, s.svc, s.typeCtrl, &workItemTypePayload)
+	_, workItemType := test.CreateSpaceWorkitemtypesCreated(s.T(), s.svc.Context, s.svc, s.typeCtrl, s.spaceID.String(), &workItemTypePayload)
 	require.NotNil(s.T(), workItemType)
 
 	relatedPayload := CreateWorkItemLinkType(s.linkName, *workItemType.Data.ID, *workItemType.Data.ID, bugBlockerType.Data.Relationships.LinkCategory.Data.ID, *bugBlockerType.Data.Relationships.Space.Data.ID)
-	_, relatedType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, relatedPayload)
+	_, relatedType := test.CreateSpaceWorkItemLinkTypesCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, *bugBlockerType.Data.Relationships.Space.Data.ID.String(), relatedPayload)
 	require.NotNil(s.T(), relatedType)
 
 	// Fetch a single work item link type

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -12,11 +12,9 @@ import (
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/codebase"
-	"github.com/almighty/almighty-core/criteria"
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/login"
-	query "github.com/almighty/almighty-core/query/simple"
 	"github.com/almighty/almighty-core/rendering"
 	"github.com/almighty/almighty-core/rest"
 	"github.com/almighty/almighty-core/space"
@@ -46,68 +44,6 @@ func NewWorkitemController(service *goa.Service, db application.DB) *WorkitemCon
 		panic("db must not be nil")
 	}
 	return &WorkitemController{Controller: service.NewController("WorkitemController"), db: db}
-}
-
-// List runs the list action.
-// Prev and Next links will be present only when there actually IS a next or previous page.
-// Last will always be present. Total Item count needs to be computed from the "Last" link.
-func (c *WorkitemController) List(ctx *app.ListWorkitemContext) error {
-	var additionalQuery []string
-	exp, err := query.Parse(ctx.Filter)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("could not parse filter", err))
-	}
-	if ctx.FilterAssignee != nil {
-		exp = criteria.And(exp, criteria.Equals(criteria.Field("system.assignees"), criteria.Literal([]string{*ctx.FilterAssignee})))
-		additionalQuery = append(additionalQuery, "filter[assignee]="+*ctx.FilterAssignee)
-	}
-	if ctx.FilterIteration != nil {
-		exp = criteria.And(exp, criteria.Equals(criteria.Field(workitem.SystemIteration), criteria.Literal(string(*ctx.FilterIteration))))
-		additionalQuery = append(additionalQuery, "filter[iteration]="+*ctx.FilterIteration)
-	}
-	if ctx.FilterWorkitemtype != nil {
-		exp = criteria.And(exp, criteria.Equals(criteria.Field("Type"), criteria.Literal([]uuid.UUID{*ctx.FilterWorkitemtype})))
-		additionalQuery = append(additionalQuery, "filter[workitemtype]="+ctx.FilterWorkitemtype.String())
-	}
-	if ctx.FilterArea != nil {
-		exp = criteria.And(exp, criteria.Equals(criteria.Field(workitem.SystemArea), criteria.Literal(string(*ctx.FilterArea))))
-		additionalQuery = append(additionalQuery, "filter[area]="+*ctx.FilterArea)
-	}
-	if ctx.FilterWorkitemstate != nil {
-		exp = criteria.And(exp, criteria.Equals(criteria.Field(workitem.SystemState), criteria.Literal(string(*ctx.FilterWorkitemstate))))
-		additionalQuery = append(additionalQuery, "filter[workitemstate]="+*ctx.FilterWorkitemstate)
-	}
-
-	offset, limit := computePagingLimts(ctx.PageOffset, ctx.PageLimit)
-	return application.Transactional(c.db, func(tx application.Application) error {
-		result, tc, err := tx.WorkItems().List(ctx.Context, exp, &offset, &limit)
-		count := int(tc)
-		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "Error listing work items"))
-		}
-
-		lastMod := findLastModified(result)
-
-		if ifMod, ok := ctx.RequestData.Header["If-Modified-Since"]; ok {
-			ifModSince, err := http.ParseTime(ifMod[0])
-			if err == nil {
-				if lastMod.Before(ifModSince) || lastMod.Equal(ifModSince) {
-					return ctx.NotModified()
-				}
-			}
-		}
-
-		response := app.WorkItem2List{
-			Links: &app.PagingLinks{},
-			Meta:  &app.WorkItemListResponseMeta{TotalCount: count},
-			Data:  ConvertWorkItems(ctx.RequestData, result),
-		}
-		setPagingLinks(response.Links, buildAbsoluteURL(ctx.RequestData), len(result), offset, limit, count, additionalQuery...)
-		addFilterLinks(response.Links, ctx.RequestData)
-
-		ctx.ResponseData.Header().Set("Last-Modified", lastModifiedTime(lastMod))
-		return ctx.OK(&response)
-	})
 }
 
 // Update does PATCH workitem
@@ -147,61 +83,6 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 
 		ctx.ResponseData.Header().Set("Last-Modified", lastModified(wi))
 		return ctx.OK(resp)
-	})
-}
-
-// Create does POST workitem
-func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
-	currentUserIdentityID, err := login.ContextIdentity(ctx)
-	if err != nil {
-		jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(err.Error()))
-		return ctx.Unauthorized(jerrors)
-	}
-	var wit *uuid.UUID
-	if ctx.Payload.Data != nil && ctx.Payload.Data.Relationships != nil &&
-		ctx.Payload.Data.Relationships.BaseType != nil && ctx.Payload.Data.Relationships.BaseType.Data != nil {
-		wit = &ctx.Payload.Data.Relationships.BaseType.Data.ID
-	}
-	if wit == nil { // TODO Figure out path source etc. Should be a required relation
-		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("Data.Relationships.BaseType.Data.ID", err))
-	}
-	// Following is a temporary fix. Until the API itself understands space context we will add default space like this
-	// To be removed once we have endpoint like - /api/space/{spaceID}/workitems
-	spaceID := space.SystemSpace
-	if ctx.Payload.Data != nil && ctx.Payload.Data.Relationships != nil &&
-		ctx.Payload.Data.Relationships.Space != nil && ctx.Payload.Data.Relationships.Space.Data != nil {
-		spaceID = *ctx.Payload.Data.Relationships.Space.Data.ID
-	}
-	wi := app.WorkItem{
-		Fields: make(map[string]interface{}),
-	}
-	return application.Transactional(c.db, func(appl application.Application) error {
-		//verify spaceID:
-		// To be removed once we have endpoint like - /api/space/{spaceID}/workitems
-		if spaceID != space.SystemSpace {
-			_, spaceLoadErr := appl.Spaces().Load(ctx, spaceID)
-			if spaceLoadErr != nil {
-				return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("space", "string").Expected("valid space ID"))
-			}
-		}
-		err := ConvertJSONAPIToWorkItem(appl, *ctx.Payload.Data, &wi)
-		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error creating work item")))
-		}
-		wi, err := appl.WorkItems().Create(ctx, spaceID, *wit, wi.Fields, *currentUserIdentityID)
-		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error creating work item")))
-		}
-		wi2 := ConvertWorkItem(ctx.RequestData, wi)
-		resp := &app.WorkItem2Single{
-			Data: wi2,
-			Links: &app.WorkItemLinks{
-				Self: buildAbsoluteURL(ctx.RequestData),
-			},
-		}
-		ctx.ResponseData.Header().Set("Last-Modified", lastModified(wi))
-		ctx.ResponseData.Header().Set("Location", app.WorkitemHref(wi2.ID))
-		return ctx.Created(resp)
 	})
 }
 

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -110,7 +110,7 @@ func (s *WorkItemSuite) SetupTest() {
 	payload := minimumRequiredCreateWithType(workitem.SystemBug)
 	payload.Data.Attributes[workitem.SystemTitle] = "Test WI"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, &payload)
+	_, wi := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.controller, space.SystemSpace.String(), &payload)
 	s.wi = wi.Data
 	s.minimumPayload = getMinimumRequiredUpdatePayload(s.wi)
 }
@@ -144,7 +144,7 @@ func (s *WorkItemSuite) TestCreateWI() {
 	payload.Data.Attributes[workitem.SystemTitle] = "Test WI"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	// when
-	_, created := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, &payload)
+	_, created := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.controller, space.SystemSpace.String(), &payload)
 	// then
 	require.NotNil(s.T(), created.Data.ID)
 	assert.NotEmpty(s.T(), *created.Data.ID)
@@ -168,7 +168,7 @@ func (s *WorkItemSuite) TestListByFields() {
 	payload := minimumRequiredCreateWithType(workitem.SystemBug)
 	payload.Data.Attributes[workitem.SystemTitle] = "run integration test"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateClosed
-	test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, &payload)
+	test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.controller, space.SystemSpace.String(), &payload)
 	// when
 	filter := "{\"system.title\":\"run integration test\"}"
 	offset := "0"
@@ -413,7 +413,7 @@ func minimumRequiredUpdatePayload() app.UpdateWorkitemPayload {
 	}
 }
 
-func minimumRequiredCreateWithType(wit uuid.UUID) app.CreateWorkitemPayload {
+func minimumRequiredCreateWithType(wit uuid.UUID) app.CreateSpaceWorkitemsPayload {
 	c := minimumRequiredCreatePayload()
 	c.Data.Relationships.BaseType = &app.RelationBaseType{
 		Data: &app.BaseTypeData{
@@ -424,12 +424,12 @@ func minimumRequiredCreateWithType(wit uuid.UUID) app.CreateWorkitemPayload {
 	return c
 }
 
-func minimumRequiredCreatePayload() app.CreateWorkitemPayload {
+func minimumRequiredCreatePayload() app.CreateSpaceWorkitemsPayload {
 	spaceSelfURL := rest.AbsoluteURL(&goa.RequestData{
 		Request: &http.Request{Host: "api.service.domain.org"},
 	}, app.SpaceHref(space.SystemSpace.String()))
 
-	return app.CreateWorkitemPayload{
+	return app.CreateSpaceWorkitemsPayload{
 		Data: &app.WorkItem2{
 			Type:       APIStringTypeWorkItem,
 			Attributes: map[string]interface{}{},
@@ -581,7 +581,7 @@ func (s *WorkItem2Suite) SetupTest() {
 	payload.Data.Attributes[workitem.SystemTitle] = "Test WI"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wiCtrl, &payload)
+	_, wi := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wiCtrl, space.SystemSpace.String(), &payload)
 	s.wi = wi.Data
 	s.minimumPayload = getMinimumRequiredUpdatePayload(s.wi)
 }
@@ -624,7 +624,7 @@ func (s *WorkItem2Suite) TestWI2UpdateSetBaseType() {
 	c.Data.Attributes[workitem.SystemTitle] = "Test title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 
-	_, created := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, created := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	assert.Equal(s.T(), created.Data.Relationships.BaseType.Data.ID, workitem.SystemBug)
 
 	u := minimumRequiredUpdatePayload()
@@ -767,7 +767,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWorkItem() {
 		},
 	}
 	// when
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	// then
 	assert.NotNil(s.T(), wi.Data)
 	assert.NotNil(s.T(), wi.Data.ID)
@@ -794,7 +794,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWorkItemWithoutDescription() {
 		},
 	}
 	// when
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	// then
 	require.NotNil(s.T(), wi.Data)
 	require.NotNil(s.T(), wi.Data.Attributes)
@@ -818,7 +818,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWorkItemWithLegacyDescription() {
 		},
 	}
 	// when
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), space.SystemSpace.String(), &c)
 	// then
 	require.NotNil(s.T(), wi.Data)
 	require.NotNil(s.T(), wi.Data.Attributes)
@@ -843,7 +843,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWorkItemWithDescriptionAndMarkup() 
 		},
 	}
 	// when
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	// then
 	require.NotNil(s.T(), wi.Data)
 	require.NotNil(s.T(), wi.Data.Attributes)
@@ -868,7 +868,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWorkItemWithDescriptionAndNoMarkup(
 		},
 	}
 	// when
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	// then
 	require.NotNil(s.T(), wi.Data)
 	require.NotNil(s.T(), wi.Data.Attributes)
@@ -919,7 +919,7 @@ func (s *WorkItem2Suite) TestWI2FailCreateWithAssigneeAsField() {
 		},
 	}
 	// when
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	// then
 	assert.NotNil(s.T(), wi.Data)
 	assert.NotNil(s.T(), wi.Data.ID)
@@ -979,7 +979,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWithAssigneeRelation() {
 			}},
 	}
 	// when
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	// then
 	assert.NotNil(s.T(), wi.Data)
 	assert.NotNil(s.T(), wi.Data.ID)
@@ -1009,7 +1009,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWithAssigneesRelation() {
 		},
 	}
 	// when
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	// then
 	assert.NotNil(s.T(), wi.Data)
 	assert.NotNil(s.T(), wi.Data.ID)
@@ -1056,7 +1056,7 @@ func (s *WorkItem2Suite) TestWI2ListByAssigneeFilter() {
 		},
 	}
 	// when
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	// then
 	assert.NotNil(s.T(), wi.Data)
 	assert.NotNil(s.T(), wi.Data.ID)
@@ -1083,7 +1083,7 @@ func (s *WorkItem2Suite) TestWI2ListByWorkitemtypeFilter() {
 		},
 	}
 	// when
-	_, expected := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, expected := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	// then
 	assert.NotNil(s.T(), expected.Data)
 	require.NotNil(s.T(), expected.Data.ID)
@@ -1119,8 +1119,8 @@ func (s *WorkItem2Suite) TestWI2ListByWorkitemstateFilter() {
 		},
 	}
 	// when
-	_, expected := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
-	_, notExpected := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &l)
+	_, expected := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
+	_, notExpected := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &l)
 	// then
 	assert.NotNil(s.T(), expected.Data)
 	require.NotNil(s.T(), expected.Data.ID)
@@ -1164,7 +1164,7 @@ func (s *WorkItem2Suite) TestWI2ListByAreaFilter() {
 			ID: &areaID,
 		},
 	}
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	require.NotNil(s.T(), wi.Data)
 	require.NotNil(s.T(), wi.Data.ID)
 	require.NotNil(s.T(), wi.Data.Type)
@@ -1196,7 +1196,7 @@ func (s *WorkItem2Suite) TestWI2ListByIterationFilter() {
 			ID: &iterationID,
 		},
 	}
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	require.NotNil(s.T(), wi.Data)
 	require.NotNil(s.T(), wi.Data.ID)
 	require.NotNil(s.T(), wi.Data.Type)
@@ -1246,7 +1246,7 @@ func (s *WorkItem2Suite) TestWI2FailUpdateInvalidAssignees() {
 			ident(newUser.ID),
 		},
 	}
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi := test.CreateSpaceWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 
 	update := minimumRequiredUpdatePayload()
 	update.Data.ID = wi.Data.ID
@@ -1280,7 +1280,7 @@ func (s *WorkItem2Suite) TestWI2SuccessUpdateWithAssigneesRelation() {
 			ident(newUser2.ID),
 		},
 	}
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi := test.CreateSpaceWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	assert.NotNil(s.T(), wi.Data)
 	assert.NotNil(s.T(), wi.Data.ID)
 	assert.NotNil(s.T(), wi.Data.Type)
@@ -1298,7 +1298,7 @@ func (s *WorkItem2Suite) TestWI2SuccessShow() {
 			ID:   workitem.SystemBug,
 		},
 	}
-	_, createdWi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, createdWi := test.CreateSpaceWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	_, fetchedWi := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWi.Data.ID)
 	assert.NotNil(s.T(), fetchedWi.Data)
 	assert.NotNil(s.T(), fetchedWi.Data.ID)
@@ -1325,7 +1325,7 @@ func (s *WorkItem2Suite) TestWI2SuccessDelete() {
 			ID:   workitem.SystemBug,
 		},
 	}
-	_, createdWi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, createdWi := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWi.Data.ID)
 	test.DeleteWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWi.Data.ID)
 	test.ShowWorkitemNotFound(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWi.Data.ID)
@@ -1345,10 +1345,10 @@ func (s *WorkItem2Suite) TestWI2DeleteLinksOnWIDeletionOK() {
 			ID:   workitem.SystemBug,
 		},
 	}
-	_, wi1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi1 := test.CreateSpaceWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	require.NotNil(s.T(), wi1)
 	c.Data.Attributes[workitem.SystemTitle] = "WI2"
-	_, wi2 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi2 := test.CreateSpaceWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	require.NotNil(s.T(), wi2)
 
 	// Create link category
@@ -1362,7 +1362,7 @@ func (s *WorkItem2Suite) TestWI2DeleteLinksOnWIDeletionOK() {
 
 	// Create work item link type payload
 	linkTypePayload := CreateWorkItemLinkType("MyLinkType", workitem.SystemBug, workitem.SystemBug, *linkCat.Data.ID, *space.Data.ID)
-	_, linkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, linkTypePayload)
+	_, linkType := test.CreateSpaceWorkItemLinkTypesCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, *space.Data.ID.String(), linkTypePayload)
 	require.NotNil(s.T(), linkType)
 
 	// Create link between wi1 and wi2
@@ -1417,7 +1417,7 @@ func (s *WorkItem2Suite) TestWI2CreateWithArea() {
 			},
 		},
 	}
-	_, wi := test.CreateWorkitemCreated(t, s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi := test.CreateSpaceWorkitemCreated(t, s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	assert.NotNil(t, wi.Data.Relationships.Area)
 	assert.Equal(t, areaID, *wi.Data.Relationships.Area.Data.ID)
 }
@@ -1437,7 +1437,7 @@ func (s *WorkItem2Suite) TestWI2UpdateWithArea() {
 			ID:   workitem.SystemBug,
 		},
 	}
-	_, wi := test.CreateWorkitemCreated(t, s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi := test.CreateSpaceWorkitemCreated(t, s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	assert.NotNil(t, wi.Data.Relationships.Area)
 	assert.Nil(t, wi.Data.Relationships.Area.Data)
 
@@ -1514,7 +1514,7 @@ func (s *WorkItem2Suite) TestWI2CreateWithIteration() {
 			},
 		},
 	}
-	_, wi := test.CreateWorkitemCreated(t, s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi := test.CreateSpaceWorkitemCreated(t, s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	assert.NotNil(t, wi.Data.Relationships.Iteration)
 	assert.Equal(t, iterationID, *wi.Data.Relationships.Iteration.Data.ID)
 }
@@ -1535,7 +1535,7 @@ func (s *WorkItem2Suite) TestWI2UpdateWithIteration() {
 			ID:   workitem.SystemBug,
 		},
 	}
-	_, wi := test.CreateWorkitemCreated(t, s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi := test.CreateSpaceWorkitemsCreated(t, s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	assert.NotNil(t, wi.Data.Relationships.Iteration)
 	assert.Nil(t, wi.Data.Relationships.Iteration.Data)
 
@@ -1581,7 +1581,7 @@ func (s *WorkItem2Suite) TestWI2UpdateRemoveIteration() {
 			ID:   &iterationID,
 		},
 	}
-	_, wi := test.CreateWorkitemCreated(t, s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, wi := test.CreateSpaceWorkitemsCreated(t, s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	assert.NotNil(t, wi.Data.Relationships.Iteration)
 	assert.NotNil(t, wi.Data.Relationships.Iteration.Data)
 
@@ -1633,7 +1633,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateAndPreventJavascriptInjectionWithLe
 			ID:   workitem.SystemBug,
 		},
 	}
-	_, createdWi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, createdWi := test.CreateSpaceWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	_, fetchedWi := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWi.Data.ID)
 	require.NotNil(s.T(), fetchedWi.Data)
 	require.NotNil(s.T(), fetchedWi.Data.Attributes)
@@ -1654,7 +1654,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateAndPreventJavascriptInjectionWithPl
 			ID:   workitem.SystemBug,
 		},
 	}
-	_, createdWi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, createdWi := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	_, fetchedWi := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWi.Data.ID)
 	require.NotNil(s.T(), fetchedWi.Data)
 	require.NotNil(s.T(), fetchedWi.Data.Attributes)
@@ -1675,7 +1675,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateAndPreventJavascriptInjectionWithMa
 			ID:   workitem.SystemBug,
 		},
 	}
-	_, createdWi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, createdWi := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	_, fetchedWi := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWi.Data.ID)
 	require.NotNil(s.T(), fetchedWi.Data)
 	require.NotNil(s.T(), fetchedWi.Data.Attributes)
@@ -1706,7 +1706,7 @@ func (s *WorkItem2Suite) TestCreateWIWithCodebase() {
 		LineNumber: line,
 	}
 	c.Data.Attributes[workitem.SystemCodebase] = cbase.ToMap()
-	_, createdWi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, createdWi := test.CreateSpaceWorkitemsCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	require.NotNil(t, createdWi)
 	_, fetchedWi := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWi.Data.ID)
 	require.NotNil(t, fetchedWi.Data)
@@ -1753,7 +1753,7 @@ func (s *WorkItem2Suite) TestCreateWorkItemWithDefaultSpace() {
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	// remove Space relation and see if WI gets default space.
 	c.Data.Relationships.Space = nil
-	_, item := test.CreateWorkitemCreated(t, s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, item := test.CreateSpaceWorkitemsCreated(t, s.svc.Context, s.svc, s.wi2Ctrl, &c)
 	require.NotNil(t, item)
 	assert.Equal(t, title, item.Data.Attributes[workitem.SystemTitle])
 	require.NotNil(t, item.Data.Relationships)
@@ -1780,7 +1780,7 @@ func (s *WorkItem2Suite) TestCreateWorkItemWithCustomSpace() {
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	// set custom space and see if WI gets custom space
 	c.Data.Relationships.Space.Data.ID = customSpace.Data.ID
-	_, item := test.CreateWorkitemCreated(t, s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	_, item := test.CreateSpaceWorkitemsCreated(t, s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 	require.NotNil(t, item)
 	assert.Equal(t, title, item.Data.Attributes[workitem.SystemTitle])
 	require.NotNil(t, item.Data.Relationships)
@@ -1817,7 +1817,7 @@ func (s *WorkItem2Suite) xTestWI2IfModifiedSince() {
 		},
 	}
 
-	resp, wi := test.CreateWorkitemCreated(t, s.svc.Context, s.svc, s.wi2Ctrl, &c)
+	resp, wi := test.CreateSpaceWorkitemsCreated(t, s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), &c)
 
 	lastMod := resp.Header().Get("Last-Modified")
 	s.svc.Use(func(handler goa.Handler) goa.Handler {

--- a/controller/workitemtype.go
+++ b/controller/workitemtype.go
@@ -5,7 +5,6 @@ import (
 	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/goadesign/goa"
-	errs "github.com/pkg/errors"
 )
 
 const (
@@ -35,37 +34,6 @@ func (c *WorkitemtypeController) Show(ctx *app.ShowWorkitemtypeContext) error {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 		return ctx.OK(res)
-	})
-}
-
-// Create runs the create action.
-func (c *WorkitemtypeController) Create(ctx *app.CreateWorkitemtypeContext) error {
-	return application.Transactional(c.db, func(appl application.Application) error {
-		var fields = map[string]app.FieldDefinition{}
-		for key, fd := range ctx.Payload.Data.Attributes.Fields {
-			fields[key] = *fd
-		}
-		wit, err := appl.WorkItemTypes().Create(ctx.Context, *ctx.Payload.Data.Relationships.Space.Data.ID, ctx.Payload.Data.ID, ctx.Payload.Data.Attributes.ExtendedTypeName, ctx.Payload.Data.Attributes.Name, ctx.Payload.Data.Attributes.Description, ctx.Payload.Data.Attributes.Icon, fields)
-		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, err)
-		}
-		ctx.ResponseData.Header().Set("Location", app.WorkitemtypeHref(wit.Data.ID))
-		return ctx.Created(wit)
-	})
-}
-
-// List runs the list action
-func (c *WorkitemtypeController) List(ctx *app.ListWorkitemtypeContext) error {
-	start, limit, err := parseLimit(ctx.Page)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "Could not parse paging"))
-	}
-	return application.Transactional(c.db, func(appl application.Application) error {
-		result, err := appl.WorkItemTypes().List(ctx.Context, start, &limit)
-		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "Error listing work item types"))
-		}
-		return ctx.OK(result)
 	})
 }
 

--- a/controller/workitemtype_blackbox_test.go
+++ b/controller/workitemtype_blackbox_test.go
@@ -174,7 +174,7 @@ func (s *workItemTypeSuite) createWorkItemTypeAnimal() (http.ResponseWriter, *ap
 		},
 	}
 
-	responseWriter, wi := test.CreateWorkitemtypeCreated(s.T(), nil, nil, s.typeCtrl, &payload)
+	responseWriter, wi := test.CreateSpaceWorkitemtypesCreated(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), &payload)
 	require.NotNil(s.T(), wi)
 	require.NotNil(s.T(), wi.Data)
 	require.NotNil(s.T(), wi.Data.ID)
@@ -218,7 +218,7 @@ func (s *workItemTypeSuite) createWorkItemTypePerson() (http.ResponseWriter, *ap
 		},
 	}
 
-	responseWriter, wi := test.CreateWorkitemtypeCreated(s.T(), nil, nil, s.typeCtrl, &payload)
+	responseWriter, wi := test.CreateSpaceWorkitemtypesCreated(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), &payload)
 	require.NotNil(s.T(), wi)
 	require.NotNil(s.T(), wi.Data)
 	require.NotNil(s.T(), wi.Data.ID)
@@ -226,7 +226,7 @@ func (s *workItemTypeSuite) createWorkItemTypePerson() (http.ResponseWriter, *ap
 	return responseWriter, wi
 }
 
-func CreateWorkItemType(id uuid.UUID, spaceID uuid.UUID) app.CreateWorkitemtypePayload {
+func CreateWorkItemType(id uuid.UUID, spaceID uuid.UUID) app.CreateSpaceWorkitemtypesPayload {
 	// Create the type for the "color" field
 	nameFieldDef := app.FieldDefinition{
 		Required: false,
@@ -241,7 +241,7 @@ func CreateWorkItemType(id uuid.UUID, spaceID uuid.UUID) app.CreateWorkitemtypeP
 		Request: &http.Request{Host: "api.service.domain.org"},
 	}
 	spaceSelfURL := rest.AbsoluteURL(reqLong, app.SpaceHref(spaceID.String()))
-	payload := app.CreateWorkitemtypePayload{
+	payload := app.CreateWorkitemtypesPayload{
 		Data: &app.WorkItemTypeData{
 			ID:   &id,
 			Type: "workitemtypes",
@@ -347,14 +347,14 @@ func (s *workItemTypeSuite) TestListSourceAndTargetLinkTypes() {
 	// Create work item link type
 	animalLinksToBugStr := "animal-links-to-bug"
 	linkTypePayload := CreateWorkItemLinkType(animalLinksToBugStr, animalID, workitem.SystemBug, *linkCat.Data.ID, *space.Data.ID)
-	_, linkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, linkTypePayload)
+	_, linkType := test.CreateSpaceWorkItemLinkTypesCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, *space.Data.ID.String(), linkTypePayload)
 	require.NotNil(s.T(), linkType)
 	s.T().Log("Created work item link 1")
 
 	// Create another work item link type
 	bugLinksToAnimalStr := "bug-links-to-animal"
 	linkTypePayload = CreateWorkItemLinkType(bugLinksToAnimalStr, workitem.SystemBug, animalID, *linkCat.Data.ID, *space.Data.ID)
-	_, linkType = test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, linkTypePayload)
+	_, linkType = test.CreateSpaceWorkItemLinkTypesCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, linkTypePayload)
 	require.NotNil(s.T(), linkType)
 	s.T().Log("Created work item link 2")
 

--- a/design/work_item_link_type.go
+++ b/design/work_item_link_type.go
@@ -165,33 +165,6 @@ var _ = a.Resource("work_item_link_type", func() {
 		a.Response(d.NotFound, JSONAPIErrors)
 	})
 
-	a.Action("list", func() {
-		a.Routing(
-			a.GET(""),
-		)
-		a.Description("List work item link types.")
-		a.Response(d.OK, func() {
-			a.Media(workItemLinkTypeList)
-		})
-		a.Response(d.BadRequest, JSONAPIErrors)
-		a.Response(d.InternalServerError, JSONAPIErrors)
-	})
-
-	a.Action("create", func() {
-		a.Security("jwt")
-		a.Routing(
-			a.POST(""),
-		)
-		a.Description("Create a work item link type")
-		a.Payload(createWorkItemLinkTypePayload)
-		a.Response(d.Created, "/workitemlinktypes/.*", func() {
-			a.Media(workItemLinkType)
-		})
-		a.Response(d.BadRequest, JSONAPIErrors)
-		a.Response(d.InternalServerError, JSONAPIErrors)
-		a.Response(d.Unauthorized, JSONAPIErrors)
-	})
-
 	a.Action("delete", func() {
 		a.Security("jwt")
 		a.Routing(
@@ -224,6 +197,38 @@ var _ = a.Resource("work_item_link_type", func() {
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+	})
+})
+
+var _ = a.Resource("space_workitemlinktypes", func() {
+	a.Parent("space")
+
+	a.Action("list", func() {
+		a.Routing(
+			a.GET("workitemlinktypes"),
+		)
+		a.Description("List work item link types.")
+		a.Response(d.OK, func() {
+			a.Media(workItemLinkTypeList)
+		})
+
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+	})
+	a.Action("create", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.POST("workitemlinktypes"),
+		)
+		a.Description("Create a work item link type")
+		a.Payload(createWorkItemLinkTypePayload)
+		a.Response(d.Created, "/workitemlinktypes/.*", func() {
+			a.Media(workItemLinkType)
+		})
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 	})
 })

--- a/design/workitems.go
+++ b/design/workitems.go
@@ -99,43 +99,6 @@ var _ = a.Resource("workitem", func() {
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
 	})
-	a.Action("list", func() {
-		a.Routing(
-			a.GET(""),
-		)
-		a.Description("List work items.")
-		a.Params(func() {
-			a.Param("filter", d.String, "a query language expression restricting the set of found work items")
-			a.Param("page[offset]", d.String, "Paging start position")
-			a.Param("page[limit]", d.Integer, "Paging size")
-			a.Param("filter[assignee]", d.String, "Work Items assigned to the given user")
-			a.Param("filter[iteration]", d.String, "IterationID to filter work items")
-			a.Param("filter[workitemtype]", d.UUID, "ID of work item type to filter work items by")
-			a.Param("filter[area]", d.String, "AreaID to filter work items")
-			a.Param("filter[workitemstate]", d.String, "work item state to filter work items by")
-
-		})
-		a.Response(d.OK, func() {
-			a.Media(workItemList)
-		})
-		a.Response(d.NotModified)
-		a.Response(d.BadRequest, JSONAPIErrors)
-		a.Response(d.InternalServerError, JSONAPIErrors)
-	})
-	a.Action("create", func() {
-		a.Security("jwt")
-		a.Routing(
-			a.POST(""),
-		)
-		a.Description("create work item with type and id.")
-		a.Payload(workItemSingle)
-		a.Response(d.Created, "/workitems/.*", func() {
-			a.Media(workItemSingle)
-		})
-		a.Response(d.BadRequest, JSONAPIErrors)
-		a.Response(d.InternalServerError, JSONAPIErrors)
-		a.Response(d.Unauthorized, JSONAPIErrors)
-	})
 	a.Action("delete", func() {
 		a.Security("jwt")
 		a.Routing(
@@ -167,6 +130,49 @@ var _ = a.Resource("workitem", func() {
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+	})
+})
+
+var _ = a.Resource("space_workitems", func() {
+	a.Parent("space")
+
+	a.Action("list", func() {
+		a.Routing(
+			a.GET("workitems"),
+		)
+		a.Description("List work items.")
+		a.Params(func() {
+			a.Param("filter", d.String, "a query language expression restricting the set of found work items")
+			a.Param("page[offset]", d.String, "Paging start position")
+			a.Param("page[limit]", d.Integer, "Paging size")
+			a.Param("filter[assignee]", d.String, "Work Items assigned to the given user")
+			a.Param("filter[iteration]", d.String, "IterationID to filter work items")
+			a.Param("filter[workitemtype]", d.UUID, "ID of work item type to filter work items by")
+			a.Param("filter[area]", d.String, "AreaID to filter work items")
+			a.Param("filter[workitemstate]", d.String, "work item state to filter work items by")
+		})
+		a.Response(d.OK, func() {
+			a.Media(workItemList)
+		})
+
+		a.Response(d.NotModified)
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+	})
+	a.Action("create", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.POST("workitems"),
+		)
+		a.Description("create work item with type and id.")
+		a.Payload(workItemSingle)
+		a.Response(d.Created, "/workitems/.*", func() {
+			a.Media(workItemSingle)
+		})
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 	})
 })

--- a/design/workitemtype.go
+++ b/design/workitemtype.go
@@ -129,35 +129,6 @@ var _ = a.Resource("workitemtype", func() {
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 	})
-	a.Action("create", func() {
-		a.Security("jwt")
-		a.Routing(
-			a.POST(""),
-		)
-		a.Description("Create work item type.")
-		a.Payload(workItemTypeSingle)
-		a.Response(d.Created, "/workitemtypes/.*", func() {
-			a.Media(workItemTypeSingle)
-		})
-		a.Response(d.BadRequest, JSONAPIErrors)
-		a.Response(d.InternalServerError, JSONAPIErrors)
-		a.Response(d.Unauthorized, JSONAPIErrors)
-	})
-	a.Action("list", func() {
-		a.Routing(
-			a.GET(""),
-		)
-		a.Description("List work item types.")
-		a.Params(func() {
-			a.Param("page", d.String, "Paging in the format <start>,<limit>")
-			// TODO: Support same params as in work item list-action?
-		})
-		a.Response(d.OK, func() {
-			a.Media(workItemTypeList)
-		})
-		a.Response(d.BadRequest, JSONAPIErrors)
-		a.Response(d.InternalServerError, JSONAPIErrors)
-	})
 
 	a.Action("list-source-link-types", func() {
 		a.Routing(
@@ -189,5 +160,42 @@ given work item type can be used in the target of the link.`)
 		})
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
+	})
+})
+
+var _ = a.Resource("space_workitemtypes", func() {
+	a.Parent("space")
+
+	a.Action("list", func() {
+		a.Routing(
+			a.GET("workitemtypes"),
+		)
+		a.Description("List work item types.")
+		a.Params(func() {
+			a.Param("page", d.String, "Paging in the format <start>,<limit>")
+			// TODO: Support same params as in work item list-action?
+		})
+		a.Response(d.OK, func() {
+			a.Media(workItemTypeList)
+		})
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+	})
+
+	a.Action("create", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.POST("workitemtypes"),
+		)
+		a.Description("Create work item type.")
+		a.Payload(workItemTypeSingle)
+		a.Response(d.Created, "/workitemtypes/.*", func() {
+			a.Media(workItemTypeSingle)
+		})
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
 	})
 })

--- a/remoteworkitem/trackeritem_repository.go
+++ b/remoteworkitem/trackeritem_repository.go
@@ -133,7 +133,7 @@ func upsert(ctx context.Context, db *gorm.DB, workItem app.WorkItem) (*app.WorkI
 	}, "Upsert on workItemRemoteID=%s", workItemRemoteID)
 	// Querying the database to fetch the work item (if it exists)
 	sqlExpression := criteria.Equals(criteria.Field(workitem.SystemRemoteItemID), criteria.Literal(workItemRemoteID))
-	existingWorkItem, err := wir.Fetch(ctx, sqlExpression)
+	existingWorkItem, err := wir.Fetch(ctx, *workItem.Relationships.Space.Data.ID, sqlExpression)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/test/work_item_repository.go
+++ b/test/work_item_repository.go
@@ -56,10 +56,11 @@ type WorkItemRepository struct {
 		result1 *app.WorkItem
 		result2 error
 	}
-	ListStub        func(ctx context.Context, criteria criteria.Expression, start *int, length *int) ([]*app.WorkItem, uint64, error)
+	ListStub        func(ctx context.Context, spaceID uuid.UUID, criteria criteria.Expression, start *int, length *int) ([]*app.WorkItem, uint64, error)
 	listMutex       sync.RWMutex
 	listArgsForCall []struct {
 		ctx      context.Context
+		spaceID  uuid.UUID
 		criteria criteria.Expression
 		start    *int
 		length   *int
@@ -69,10 +70,11 @@ type WorkItemRepository struct {
 		result2 uint64
 		result3 error
 	}
-	FetchStub        func(ctx context.Context, criteria criteria.Expression) (*app.WorkItem, error)
+	FetchStub        func(ctx context.Context, spaceID uuid.UUID, criteria criteria.Expression) (*app.WorkItem, error)
 	fetchMutex       sync.RWMutex
 	fetchArgsForCall []struct {
 		ctx      context.Context
+		spaceID  uuid.UUID
 		criteria criteria.Expression
 	}
 	fetchReturns struct {
@@ -243,18 +245,19 @@ func (fake *WorkItemRepository) CreateReturns(result1 *app.WorkItem, result2 err
 	}{result1, result2}
 }
 
-func (fake *WorkItemRepository) List(ctx context.Context, c criteria.Expression, start *int, length *int) ([]*app.WorkItem, uint64, error) {
+func (fake *WorkItemRepository) List(ctx context.Context, spaceID uuid.UUID, c criteria.Expression, start *int, length *int) ([]*app.WorkItem, uint64, error) {
 	fake.listMutex.Lock()
 	fake.listArgsForCall = append(fake.listArgsForCall, struct {
 		ctx      context.Context
+		spaceID  uuid.UUID
 		criteria criteria.Expression
 		start    *int
 		length   *int
-	}{ctx, c, start, length})
-	fake.recordInvocation("List", []interface{}{ctx, c, start, length})
+	}{ctx, spaceID, c, start, length})
+	fake.recordInvocation("List", []interface{}{ctx, spaceID, c, start, length})
 	fake.listMutex.Unlock()
 	if fake.ListStub != nil {
-		return fake.ListStub(ctx, c, start, length)
+		return fake.ListStub(ctx, spaceID, c, start, length)
 	}
 	return fake.listReturns.result1, fake.listReturns.result2, fake.listReturns.result3
 }
@@ -280,16 +283,17 @@ func (fake *WorkItemRepository) ListReturns(result1 []*app.WorkItem, result2 uin
 	}{result1, result2, result3}
 }
 
-func (fake *WorkItemRepository) Fetch(ctx context.Context, c criteria.Expression) (*app.WorkItem, error) {
+func (fake *WorkItemRepository) Fetch(ctx context.Context, spaceID uuid.UUID, c criteria.Expression) (*app.WorkItem, error) {
 	fake.fetchMutex.Lock()
 	fake.fetchArgsForCall = append(fake.fetchArgsForCall, struct {
 		ctx      context.Context
+		spaceID  uuid.UUID
 		criteria criteria.Expression
-	}{ctx, c})
-	fake.recordInvocation("Fetch", []interface{}{ctx, c})
+	}{ctx, spaceID, c})
+	fake.recordInvocation("Fetch", []interface{}{ctx, spaceID, c})
 	fake.fetchMutex.Unlock()
 	if fake.FetchStub != nil {
-		return fake.FetchStub(ctx, c)
+		return fake.FetchStub(ctx, spaceID, c)
 	}
 	return fake.fetchReturns.result1, fake.fetchReturns.result2
 }

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -25,8 +25,8 @@ type WorkItemRepository interface {
 	Save(ctx context.Context, wi app.WorkItem, modifierID uuid.UUID) (*app.WorkItem, error)
 	Delete(ctx context.Context, ID string, suppressorID uuid.UUID) error
 	Create(ctx context.Context, spaceID uuid.UUID, typeID uuid.UUID, fields map[string]interface{}, creatorID uuid.UUID) (*app.WorkItem, error)
-	List(ctx context.Context, criteria criteria.Expression, start *int, length *int) ([]*app.WorkItem, uint64, error)
-	Fetch(ctx context.Context, criteria criteria.Expression) (*app.WorkItem, error)
+	List(ctx context.Context, spaceID uuid.UUID, criteria criteria.Expression, start *int, length *int) ([]*app.WorkItem, uint64, error)
+	Fetch(ctx context.Context, spaceID uuid.UUID, criteria criteria.Expression) (*app.WorkItem, error)
 	GetCountsPerIteration(ctx context.Context, spaceID uuid.UUID) (map[string]WICountsPerIteration, error)
 	GetCountsForIteration(ctx context.Context, iterationID uuid.UUID) (map[string]WICountsPerIteration, error)
 }
@@ -328,7 +328,7 @@ func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, criteria c
 }
 
 // List returns work item selected by the given criteria.Expression, starting with start (zero-based) and returning at most limit items
-func (r *GormWorkItemRepository) List(ctx context.Context, criteria criteria.Expression, start *int, limit *int) ([]*app.WorkItem, uint64, error) {
+func (r *GormWorkItemRepository) List(ctx context.Context, spaceID uuid.UUID, criteria criteria.Expression, start *int, limit *int) ([]*app.WorkItem, uint64, error) {
 	result, count, err := r.listItemsFromDB(ctx, criteria, start, limit)
 	if err != nil {
 		return nil, 0, errs.WithStack(err)
@@ -345,9 +345,9 @@ func (r *GormWorkItemRepository) List(ctx context.Context, criteria criteria.Exp
 }
 
 // Fetch fetches the (first) work item matching by the given criteria.Expression.
-func (r *GormWorkItemRepository) Fetch(ctx context.Context, criteria criteria.Expression) (*app.WorkItem, error) {
+func (r *GormWorkItemRepository) Fetch(ctx context.Context, spaceID uuid.UUID, criteria criteria.Expression) (*app.WorkItem, error) {
 	limit := 1
-	results, count, err := r.List(ctx, criteria, nil, &limit)
+	results, count, err := r.List(ctx, spaceID, criteria, nil, &limit)
 	if err != nil {
 		return nil, err
 	}

--- a/workitem/workitemtype_repository.go
+++ b/workitem/workitemtype_repository.go
@@ -24,7 +24,7 @@ var cache = NewWorkItemTypeCache()
 type WorkItemTypeRepository interface {
 	Load(ctx context.Context, id uuid.UUID) (*app.WorkItemTypeSingle, error)
 	Create(ctx context.Context, spaceID uuid.UUID, id *uuid.UUID, extendedTypeID *uuid.UUID, name string, description *string, icon string, fields map[string]app.FieldDefinition) (*app.WorkItemTypeSingle, error)
-	List(ctx context.Context, start *int, length *int) (*app.WorkItemTypeList, error)
+	List(ctx context.Context, spaceID uuid.UUID, start *int, length *int) (*app.WorkItemTypeList, error)
 }
 
 // NewWorkItemTypeRepository creates a wi type repository based on gorm
@@ -153,12 +153,13 @@ func (r *GormWorkItemTypeRepository) Create(ctx context.Context, spaceID uuid.UU
 }
 
 // List returns work item types selected by the given criteria.Expression, starting with start (zero-based) and returning at most "limit" item types
-func (r *GormWorkItemTypeRepository) List(ctx context.Context, start *int, limit *int) (*app.WorkItemTypeList, error) {
+func (r *GormWorkItemTypeRepository) List(ctx context.Context, spaceID uuid.UUID, start *int, limit *int) (*app.WorkItemTypeList, error) {
 	// Currently we don't implement filtering here, so leave this empty
 	// TODO: (kwk) implement criteria parsing just like for work items
-	var where string
 	var parameters []interface{}
 
+	where := "space_id = ?"
+	parameters = append(parameters, spaceID.String)
 	var rows []WorkItemType
 	db := r.db.Where(where, parameters...)
 	if start != nil {


### PR DESCRIPTION
related to: https://github.com/almighty/almighty-core/issues/955 and https://github.com/almighty/almighty-core/issues/943

I have the following questions:
- Initially I started adding `space_workitems, space_workitemtypes,...` but if we are going to move everything under `space/*`. Why don't we simply reuse the existing resources and add `Parent(space)`. According to this changes, I had to prefix stuff  with `Space` keyworkd such as `SpaceWorkItemController, CreatedSpaceWorkitem....`. That could change based on the answer to the question aforementioned here.
- In the existing code, we get the SpaceID out of the Payload. However with this new implementation, the space ID will be eventually extracted from the URL e.g. `api/space/:id/workitems/*`. Am I right ?
- I saw that iterations only bring under the space API the operation `list, create`. Will that happen for the others wi, wit and wilt ? Or we move  `ALL` the operations `delete,show,create` under the space umbrella. I just want to be sure, we're in the same page and to avoid longer coding cycles.

TODO list:
- [ ] Address my questions
- [ ] Adapt the tests
- [ ] Test all the stuff