### PR TITLE
Use latest goa v1 commit which includes gen_controller

### DIFF
--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -301,7 +301,7 @@ func (s *searchBlackBoxTest) searchByURL(customHost, queryString string) *app.Se
 	prms := url.Values{}
 	prms["q"] = []string{queryString} // any value will do
 	goaCtx := goa.NewContext(goa.WithAction(s.svc.Context, "SearchTest"), rw, req, prms)
-	showCtx, err := app.NewShowSearchContext(goaCtx, s.svc)
+	showCtx, err := app.NewShowSearchContext(goaCtx, req, s.svc)
 	require.Nil(s.T(), err)
 	// Perform action
 	err = s.controller.Show(showCtx)

--- a/glide.lock
+++ b/glide.lock
@@ -39,7 +39,7 @@ imports:
 - name: github.com/fzipp/gocyclo
   version: 6acd4345c835499920e8426c7e4e8d7a34f1bb83
 - name: github.com/goadesign/goa
-  version: 8f0fdca409904318050f9e03579c3878f8928826
+  version: be1e8b9a2614909d8805079ebd1c947778170c0e
   vcs: git
   subpackages:
   - client

--- a/login/service_blackbox_test.go
+++ b/login/service_blackbox_test.go
@@ -100,7 +100,7 @@ func TestKeycloakAuthorizationRedirect(t *testing.T) {
 	prms := url.Values{}
 	ctx := context.Background()
 	goaCtx := goa.NewContext(goa.WithAction(ctx, "LoginTest"), rw, req, prms)
-	authorizeCtx, err := app.NewAuthorizeLoginContext(goaCtx, goa.New("LoginService"))
+	authorizeCtx, err := app.NewAuthorizeLoginContext(goaCtx, req, goa.New("LoginService"))
 	if err != nil {
 		panic("invalid test data " + err.Error()) // bug
 	}
@@ -166,7 +166,7 @@ func TestInvalidState(t *testing.T) {
 	}
 	ctx := context.Background()
 	goaCtx := goa.NewContext(goa.WithAction(ctx, "LoginTest"), rw, req, prms)
-	authorizeCtx, err := app.NewAuthorizeLoginContext(goaCtx, goa.New("LoginService"))
+	authorizeCtx, err := app.NewAuthorizeLoginContext(goaCtx, req, goa.New("LoginService"))
 	if err != nil {
 		panic("invalid test data " + err.Error()) // bug
 	}
@@ -211,7 +211,7 @@ func TestInvalidOAuthAuthorizationCode(t *testing.T) {
 	prms := url.Values{}
 	ctx := context.Background()
 	goaCtx := goa.NewContext(goa.WithAction(ctx, "LoginTest"), rw, req, prms)
-	authorizeCtx, err := app.NewAuthorizeLoginContext(goaCtx, goa.New("LoginService"))
+	authorizeCtx, err := app.NewAuthorizeLoginContext(goaCtx, req, goa.New("LoginService"))
 	if err != nil {
 		panic("invalid test data " + err.Error()) // bug
 	}
@@ -262,7 +262,7 @@ func TestInvalidOAuthAuthorizationCode(t *testing.T) {
 	}
 
 	goaCtx = goa.NewContext(goa.WithAction(ctx, "LoginTest"), rw, req, prms)
-	authorizeCtx, err = app.NewAuthorizeLoginContext(goaCtx, goa.New("LoginService"))
+	authorizeCtx, err = app.NewAuthorizeLoginContext(goaCtx, req, goa.New("LoginService"))
 
 	err = loginService.Perform(authorizeCtx, authEndpoint, tokenEndpoint)
 


### PR DESCRIPTION
It seems like goa `gen_controller` is not longer inside `v1.1.0`. I am trying to understand why of this reason. Meanwhile, you could use the following version ID for goa if you face problems.

@aslakknutsen I remember you upgraded goa version https://github.com/almighty/almighty-core/commit/e4f70a5fbb1d90ae2630d6916e7c9f04f4aff931. So we might be blocked by this...