### PR TITLE
remove only those spaces which are created in unit tests

### DIFF
--- a/controller/work_item_link_blackbox_test.go
+++ b/controller/work_item_link_blackbox_test.go
@@ -164,7 +164,7 @@ func (s *workItemLinkSuite) cleanup() {
 	require.Nil(s.T(), db.Error)
 	db = db.Unscoped().Delete(&link.WorkItemLinkCategory{Name: "test-user"})
 	require.Nil(s.T(), db.Error)
-	db = db.Unscoped().Delete(&space.Space{Name: "test-space"})
+	db = db.Unscoped().Delete(&space.Space{ID: s.userSpaceID})
 	require.Nil(s.T(), db.Error)
 
 	// Last but not least delete the work items

--- a/controller/work_item_link_type_blackbox_test.go
+++ b/controller/work_item_link_type_blackbox_test.go
@@ -111,7 +111,9 @@ func (s *workItemLinkTypeSuite) cleanup() {
 	require.Nil(s.T(), db.Error)
 	db = db.Unscoped().Delete(&link.WorkItemLinkCategory{Name: s.categoryName})
 	require.Nil(s.T(), db.Error)
-	db = db.Unscoped().Delete(&space.Space{Name: s.spaceName})
+	if s.spaceID != nil {
+		db = db.Unscoped().Delete(&space.Space{ID: *s.spaceID})
+	}
 	require.Nil(s.T(), db.Error)
 	//db = db.Unscoped().Delete(&link.WorkItemType{Name: "foo.bug"})
 


### PR DESCRIPTION
- ensured that unscoped deletes in tests happens by ID and not by name.
- above change was made because it was noticed that *all spaces* were being deleted whenever `db = db.Unscoped().Delete(&space.Space{Name: s.spaceName})` was being called.

fixes #991 

