### PR TITLE
Replace imported satoriuud with uuid

### DIFF
--- a/controller/work_item_link.go
+++ b/controller/work_item_link.go
@@ -12,7 +12,7 @@ import (
 	"github.com/almighty/almighty-core/workitem/link"
 	"github.com/goadesign/goa"
 	errs "github.com/pkg/errors"
-	satoriuuid "github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 // WorkItemLinkController implements the work-item-link resource.
@@ -45,13 +45,13 @@ type workItemLinkContext struct {
 	ResponseData          *goa.ResponseData
 	Application           application.Application
 	Context               context.Context
-	CurrentUserIdentityID *satoriuuid.UUID
+	CurrentUserIdentityID *uuid.UUID
 	DB                    application.DB
 	LinkFunc              hrefLinkFunc
 }
 
 // newWorkItemLinkContext returns a new workItemLinkContext
-func newWorkItemLinkContext(ctx context.Context, appl application.Application, db application.DB, requestData *goa.RequestData, responseData *goa.ResponseData, linkFunc hrefLinkFunc, currentUserIdentityID *satoriuuid.UUID) *workItemLinkContext {
+func newWorkItemLinkContext(ctx context.Context, appl application.Application, db application.DB, requestData *goa.RequestData, responseData *goa.ResponseData, linkFunc hrefLinkFunc, currentUserIdentityID *uuid.UUID) *workItemLinkContext {
 	return &workItemLinkContext{
 		RequestData:           requestData,
 		ResponseData:          responseData,
@@ -67,7 +67,7 @@ func newWorkItemLinkContext(ctx context.Context, appl application.Application, d
 // given work item links
 func getTypesOfLinks(ctx *workItemLinkContext, linksDataArr []*app.WorkItemLinkData) ([]*app.WorkItemLinkTypeData, error) {
 	// Build our "set" of distinct type IDs already converted as strings
-	typeIDMap := map[satoriuuid.UUID]bool{}
+	typeIDMap := map[uuid.UUID]bool{}
 	for _, linkData := range linksDataArr {
 		typeIDMap[linkData.Relationships.LinkType.Data.ID] = true
 	}
@@ -108,7 +108,7 @@ func getWorkItemsOfLinks(ctx *workItemLinkContext, linksDataArr []*app.WorkItemL
 // categories for the given work item link types
 func getCategoriesOfLinkTypes(ctx *workItemLinkContext, linkTypeDataArr []*app.WorkItemLinkTypeData) ([]*app.WorkItemLinkCategoryData, error) {
 	// Build our "set" of distinct category IDs already converted as strings
-	catIDMap := map[satoriuuid.UUID]bool{}
+	catIDMap := map[uuid.UUID]bool{}
 	for _, linkTypeData := range linkTypeDataArr {
 		catIDMap[linkTypeData.Relationships.LinkCategory.Data.ID] = true
 	}
@@ -283,7 +283,7 @@ type deleteWorkItemLinkFuncs interface {
 	OK(resp []byte) error
 }
 
-func deleteWorkItemLink(ctx *workItemLinkContext, funcs deleteWorkItemLinkFuncs, linkID satoriuuid.UUID) error {
+func deleteWorkItemLink(ctx *workItemLinkContext, funcs deleteWorkItemLinkFuncs, linkID uuid.UUID) error {
 	err := ctx.Application.WorkItemLinks().Delete(ctx.Context, linkID, *ctx.CurrentUserIdentityID)
 	if err != nil {
 		jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(err)
@@ -340,7 +340,7 @@ type showWorkItemLinkFuncs interface {
 	OK(r *app.WorkItemLinkSingle) error
 }
 
-func showWorkItemLink(ctx *workItemLinkContext, funcs showWorkItemLinkFuncs, linkID satoriuuid.UUID) error {
+func showWorkItemLink(ctx *workItemLinkContext, funcs showWorkItemLinkFuncs, linkID uuid.UUID) error {
 	link, err := ctx.Application.WorkItemLinks().Load(ctx.Context, linkID)
 	if err != nil {
 		jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(err)

--- a/controller/work_item_link_category.go
+++ b/controller/work_item_link_category.go
@@ -8,7 +8,7 @@ import (
 	"github.com/almighty/almighty-core/login"
 	"github.com/almighty/almighty-core/rest"
 	"github.com/goadesign/goa"
-	//satoriuuid "github.com/satori/go.uuid"
+	//uuid "github.com/satori/go.uuid"
 )
 
 // WorkItemLinkCategoryController implements the work-item-link-category resource.

--- a/controller/work_item_link_category_blackbox_test.go
+++ b/controller/work_item_link_category_blackbox_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	satoriuuid "github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 // In order for 'go test' to run this suite, we need to create
@@ -115,7 +115,7 @@ func (s *workItemLinkCategorySuite) TearDownTest() {
 func (s *workItemLinkCategorySuite) createWorkItemLinkCategorySystem() (http.ResponseWriter, *app.WorkItemLinkCategorySingle) {
 	name := "test-system"
 	description := "This work item link category is reserved for the core system."
-	id := satoriuuid.FromStringOrNil("0e671e36-871b-43a6-9166-0c4bd573e231")
+	id := uuid.FromStringOrNil("0e671e36-871b-43a6-9166-0c4bd573e231")
 
 	// Use the goa generated code to create a work item link category
 	payload := app.CreateWorkItemLinkCategoryPayload{
@@ -136,7 +136,7 @@ func (s *workItemLinkCategorySuite) createWorkItemLinkCategorySystem() (http.Res
 func (s *workItemLinkCategorySuite) createWorkItemLinkCategoryUser() (http.ResponseWriter, *app.WorkItemLinkCategorySingle) {
 	name := "test-user"
 	description := "This work item link category is managed by an admin user."
-	id := satoriuuid.FromStringOrNil("bf30167a-9446-42de-82be-6b3815152051")
+	id := uuid.FromStringOrNil("bf30167a-9446-42de-82be-6b3815152051")
 
 	// Use the goa generated code to create a work item link category
 	payload := app.CreateWorkItemLinkCategoryPayload{
@@ -171,7 +171,7 @@ func (s *workItemLinkCategorySuite) TestCreateAndDeleteWorkItemLinkCategory() {
 func (s *workItemLinkCategorySuite) TestCreateWorkItemLinkCategoryBadRequest() {
 	description := "New description for work item link category."
 	name := "" // This will lead to a bad parameter error
-	id := satoriuuid.FromStringOrNil("88727441-4a21-4b35-aabe-007f8273cdBB")
+	id := uuid.FromStringOrNil("88727441-4a21-4b35-aabe-007f8273cdBB")
 	payload := &app.CreateWorkItemLinkCategoryPayload{
 		Data: &app.WorkItemLinkCategoryData{
 			ID:   &id,
@@ -186,12 +186,12 @@ func (s *workItemLinkCategorySuite) TestCreateWorkItemLinkCategoryBadRequest() {
 }
 
 func (s *workItemLinkCategorySuite) TestDeleteWorkItemLinkCategoryNotFound() {
-	test.DeleteWorkItemLinkCategoryNotFound(s.T(), s.svc.Context, s.svc, s.linkCatCtrl, satoriuuid.FromStringOrNil("01f6c751-53f3-401f-be9b-6a9a230db8AA"))
+	test.DeleteWorkItemLinkCategoryNotFound(s.T(), s.svc.Context, s.svc, s.linkCatCtrl, uuid.FromStringOrNil("01f6c751-53f3-401f-be9b-6a9a230db8AA"))
 }
 
 func (s *workItemLinkCategorySuite) TestUpdateWorkItemLinkCategoryNotFound() {
 	description := "New description for work item link category."
-	id := satoriuuid.FromStringOrNil("88727441-4a21-4b35-aabe-007f8273cd19")
+	id := uuid.FromStringOrNil("88727441-4a21-4b35-aabe-007f8273cd19")
 	payload := &app.UpdateWorkItemLinkCategoryPayload{
 		Data: &app.WorkItemLinkCategoryData{
 			ID:   &id,
@@ -221,7 +221,7 @@ func (s *workItemLinkCategorySuite) TestUpdateWorkItemLinkCategoryNotFound() {
 
 func (s *workItemLinkCategorySuite) UpdateWorkItemLinkCategoryBadRequestDueToBadType() {
 	description := "New description for work item link category."
-	id := satoriuuid.FromStringOrNil("88727441-4a21-4b35-aabe-007f8273cd19")
+	id := uuid.FromStringOrNil("88727441-4a21-4b35-aabe-007f8273cd19")
 	payload := &app.UpdateWorkItemLinkCategoryPayload{
 		Data: &app.WorkItemLinkCategoryData{
 			ID:   &id,
@@ -236,7 +236,7 @@ func (s *workItemLinkCategorySuite) UpdateWorkItemLinkCategoryBadRequestDueToBad
 
 func (s *workItemLinkCategorySuite) UpdateWorkItemLinkCategoryBadRequestDueToEmptyName() {
 	name := "" // When updating the name, it must not be empty
-	id := satoriuuid.FromStringOrNil("88727441-4a21-4b35-aabe-007f8273cd19")
+	id := uuid.FromStringOrNil("88727441-4a21-4b35-aabe-007f8273cd19")
 	payload := &app.UpdateWorkItemLinkCategoryPayload{
 		Data: &app.WorkItemLinkCategoryData{
 			ID:   &id,
@@ -309,7 +309,7 @@ func (s *workItemLinkCategorySuite) TestShowWorkItemLinkCategoryOK() {
 
 // TestShowWorkItemLinkCategoryNotFound tests if we can fetch a non existing work item link category
 func (s *workItemLinkCategorySuite) TestShowWorkItemLinkCategoryNotFound() {
-	test.ShowWorkItemLinkCategoryNotFound(s.T(), nil, nil, s.linkCatCtrl, satoriuuid.FromStringOrNil("88727441-4a21-4b35-aabe-007f8273cd19"))
+	test.ShowWorkItemLinkCategoryNotFound(s.T(), nil, nil, s.linkCatCtrl, uuid.FromStringOrNil("88727441-4a21-4b35-aabe-007f8273cd19"))
 }
 
 // TestListWorkItemLinkCategoryOK tests if we can find the work item link categories

--- a/space/space_test.go
+++ b/space/space_test.go
@@ -8,15 +8,15 @@ import (
 	"github.com/almighty/almighty-core/gormtestsupport"
 	"github.com/almighty/almighty-core/space"
 	errs "github.com/pkg/errors"
-	satoriuuid "github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/net/context"
 )
 
-var testSpace string = satoriuuid.NewV4().String()
-var testSpace2 string = satoriuuid.NewV4().String()
+var testSpace string = uuid.NewV4().String()
+var testSpace2 string = uuid.NewV4().String()
 
 func TestRunRepoBBTest(t *testing.T) {
 	suite.Run(t, &repoBBTest{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
@@ -47,7 +47,7 @@ func (test *repoBBTest) TestCreate() {
 }
 
 func (test *repoBBTest) TestLoad() {
-	expectSpace(test.load(satoriuuid.NewV4()), test.assertNotFound())
+	expectSpace(test.load(uuid.NewV4()), test.assertNotFound())
 	res, _ := expectSpace(test.create(testSpace), test.requireOk)
 
 	res2, _ := expectSpace(test.load(res.ID), test.requireOk)
@@ -57,7 +57,7 @@ func (test *repoBBTest) TestLoad() {
 func (test *repoBBTest) TestSaveOk() {
 	res, _ := expectSpace(test.create(testSpace), test.requireOk)
 
-	newName := satoriuuid.NewV4().String()
+	newName := uuid.NewV4().String()
 	res.Name = newName
 	res2, _ := expectSpace(test.save(*res), test.requireOk)
 	assert.Equal(test.T(), newName, res2.Name)
@@ -76,7 +76,7 @@ func (test *repoBBTest) TestSaveFail() {
 
 func (test *repoBBTest) TestSaveNew() {
 	p := space.Space{
-		ID:      satoriuuid.NewV4(),
+		ID:      uuid.NewV4(),
 		Version: 0,
 		Name:    testSpace,
 	}
@@ -89,8 +89,8 @@ func (test *repoBBTest) TestDelete() {
 	expectSpace(test.load(res.ID), test.requireOk)
 	expectSpace(test.delete(res.ID), func(p *space.Space, err error) { require.Nil(test.T(), err) })
 	expectSpace(test.load(res.ID), test.assertNotFound())
-	expectSpace(test.delete(satoriuuid.NewV4()), test.assertNotFound())
-	expectSpace(test.delete(satoriuuid.Nil), test.assertNotFound())
+	expectSpace(test.delete(uuid.NewV4()), test.assertNotFound())
+	expectSpace(test.delete(uuid.Nil), test.assertNotFound())
 }
 
 func (test *repoBBTest) TestList() {
@@ -109,26 +109,26 @@ func (test *repoBBTest) TestListDoNotReturnPointerToSameObject() {
 }
 
 func (test *repoBBTest) TestLoadSpaceByName() {
-	expectSpace(test.load(satoriuuid.NewV4()), test.assertNotFound())
+	expectSpace(test.load(uuid.NewV4()), test.assertNotFound())
 	res, _ := expectSpace(test.create(testSpace), test.requireOk)
 
-	res2, _ := expectSpace(test.loadByUserIdAndName(satoriuuid.Nil, res.Name), test.requireOk)
+	res2, _ := expectSpace(test.loadByUserIdAndName(uuid.Nil, res.Name), test.requireOk)
 	assert.True(test.T(), (*res).Equal(*res2))
 }
 
 func (test *repoBBTest) TestLoadSpaceByNameDifferentOwner() {
-	expectSpace(test.load(satoriuuid.NewV4()), test.assertNotFound())
+	expectSpace(test.load(uuid.NewV4()), test.assertNotFound())
 	res, _ := expectSpace(test.create(testSpace), test.requireOk)
 
-	_, err := expectSpace(test.loadByUserIdAndName(satoriuuid.NewV4(), res.Name), test.requireErrorType(errors.NotFoundError{}))
+	_, err := expectSpace(test.loadByUserIdAndName(uuid.NewV4(), res.Name), test.requireErrorType(errors.NotFoundError{}))
 	assert.NotNil(test.T(), err)
 }
 
 func (test *repoBBTest) TestLoadSpaceByNameNonExistentSpaceName() {
-	expectSpace(test.load(satoriuuid.NewV4()), test.assertNotFound())
+	expectSpace(test.load(uuid.NewV4()), test.assertNotFound())
 	expectSpace(test.create(testSpace), test.requireOk)
 
-	_, err := expectSpace(test.loadByUserIdAndName(satoriuuid.Nil, satoriuuid.NewV4().String()), test.requireErrorType(errors.NotFoundError{}))
+	_, err := expectSpace(test.loadByUserIdAndName(uuid.Nil, uuid.NewV4().String()), test.requireErrorType(errors.NotFoundError{}))
 	assert.NotNil(test.T(), err)
 }
 
@@ -169,7 +169,7 @@ func (test *repoBBTest) requireErrorType(e error) func(p *space.Space, err error
 func (test *repoBBTest) create(name string) func() (*space.Space, error) {
 	newSpace := space.Space{
 		Name:    name,
-		OwnerId: satoriuuid.Nil,
+		OwnerId: uuid.Nil,
 	}
 	return func() (*space.Space, error) { return test.repo.Create(context.Background(), &newSpace) }
 }
@@ -178,17 +178,17 @@ func (test *repoBBTest) save(p space.Space) func() (*space.Space, error) {
 	return func() (*space.Space, error) { return test.repo.Save(context.Background(), &p) }
 }
 
-func (test *repoBBTest) load(id satoriuuid.UUID) func() (*space.Space, error) {
+func (test *repoBBTest) load(id uuid.UUID) func() (*space.Space, error) {
 	return func() (*space.Space, error) { return test.repo.Load(context.Background(), id) }
 }
 
-func (test *repoBBTest) loadByUserIdAndName(userId satoriuuid.UUID, spaceName string) func() (*space.Space, error) {
+func (test *repoBBTest) loadByUserIdAndName(userId uuid.UUID, spaceName string) func() (*space.Space, error) {
 	return func() (*space.Space, error) {
 		return test.repo.LoadByOwnerAndName(context.Background(), &userId, &spaceName)
 	}
 }
 
-func (test *repoBBTest) delete(id satoriuuid.UUID) func() (*space.Space, error) {
+func (test *repoBBTest) delete(id uuid.UUID) func() (*space.Space, error) {
 	return func() (*space.Space, error) { return nil, test.repo.Delete(context.Background(), id) }
 }
 

--- a/workitem/link/category.go
+++ b/workitem/link/category.go
@@ -4,7 +4,7 @@ import (
 	"github.com/almighty/almighty-core/app"
 	convert "github.com/almighty/almighty-core/convert"
 	"github.com/almighty/almighty-core/gormsupport"
-	satoriuuid "github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 const (
@@ -16,7 +16,7 @@ const (
 type WorkItemLinkCategory struct {
 	gormsupport.Lifecycle
 	// ID
-	ID satoriuuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"`
+	ID uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"`
 	// Name is the unique name of this work item link category.
 	Name string
 	// Description is an optional description of the work item link category

--- a/workitem/link/category_blackbox_test.go
+++ b/workitem/link/category_blackbox_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/almighty/almighty-core/workitem/link"
-	satoriuuid "github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,7 +21,7 @@ func TestWorkItemLinkCategory_Equal(t *testing.T) {
 
 	description := "An example description"
 	a := link.WorkItemLinkCategory{
-		ID:          satoriuuid.FromStringOrNil("0e671e36-871b-43a6-9166-0c4bd573e231"),
+		ID:          uuid.FromStringOrNil("0e671e36-871b-43a6-9166-0c4bd573e231"),
 		Name:        "Example work item link category",
 		Description: &description,
 		Version:     0,
@@ -58,7 +58,7 @@ func TestWorkItemLinkCategory_Equal(t *testing.T) {
 
 	// Test ID
 	c = a
-	c.ID = satoriuuid.FromStringOrNil("33371e36-871b-43a6-9166-0c4bd573e333")
+	c.ID = uuid.FromStringOrNil("33371e36-871b-43a6-9166-0c4bd573e333")
 	require.False(t, a.Equal(c))
 
 	// Test when one Description is nil
@@ -73,7 +73,7 @@ func TestWorkItemLinkCategory_ConvertLinkCategoryFromModel(t *testing.T) {
 
 	description := "An example description"
 	m := link.WorkItemLinkCategory{
-		ID:          satoriuuid.FromStringOrNil("0e671e36-871b-43a6-9166-0c4bd573e231"),
+		ID:          uuid.FromStringOrNil("0e671e36-871b-43a6-9166-0c4bd573e231"),
 		Name:        "Example work item link category",
 		Description: &description,
 		Version:     0,

--- a/workitem/link/category_repository.go
+++ b/workitem/link/category_repository.go
@@ -7,15 +7,15 @@ import (
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/log"
 	"github.com/jinzhu/gorm"
-	satoriuuid "github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 // WorkItemLinkCategoryRepository encapsulates storage & retrieval of work item link categories
 type WorkItemLinkCategoryRepository interface {
 	Create(ctx context.Context, name *string, description *string) (*app.WorkItemLinkCategorySingle, error)
-	Load(ctx context.Context, ID satoriuuid.UUID) (*app.WorkItemLinkCategorySingle, error)
+	Load(ctx context.Context, ID uuid.UUID) (*app.WorkItemLinkCategorySingle, error)
 	List(ctx context.Context) (*app.WorkItemLinkCategoryList, error)
-	Delete(ctx context.Context, ID satoriuuid.UUID) error
+	Delete(ctx context.Context, ID uuid.UUID) error
 	Save(ctx context.Context, linkCat app.WorkItemLinkCategorySingle) (*app.WorkItemLinkCategorySingle, error)
 }
 
@@ -51,7 +51,7 @@ func (r *GormWorkItemLinkCategoryRepository) Create(ctx context.Context, name *s
 
 // Load returns the work item link category for the given ID.
 // Returns NotFoundError, ConversionError or InternalError
-func (r *GormWorkItemLinkCategoryRepository) Load(ctx context.Context, ID satoriuuid.UUID) (*app.WorkItemLinkCategorySingle, error) {
+func (r *GormWorkItemLinkCategoryRepository) Load(ctx context.Context, ID uuid.UUID) (*app.WorkItemLinkCategorySingle, error) {
 	log.Info(ctx, map[string]interface{}{
 		"wilcID": ID,
 	}, "Loading work item link category")
@@ -117,7 +117,7 @@ func (r *GormWorkItemLinkCategoryRepository) List(ctx context.Context) (*app.Wor
 
 // Delete deletes the work item link category with the given id
 // returns NotFoundError or InternalError
-func (r *GormWorkItemLinkCategoryRepository) Delete(ctx context.Context, ID satoriuuid.UUID) error {
+func (r *GormWorkItemLinkCategoryRepository) Delete(ctx context.Context, ID uuid.UUID) error {
 	var cat = WorkItemLinkCategory{
 		ID: ID,
 	}

--- a/workitem/link/link.go
+++ b/workitem/link/link.go
@@ -7,19 +7,19 @@ import (
 	convert "github.com/almighty/almighty-core/convert"
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"
-	satoriuuid "github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 // WorkItemLink represents the connection of two work items as it is stored in the db
 type WorkItemLink struct {
 	gormsupport.Lifecycle
 	// ID
-	ID satoriuuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"`
+	ID uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"`
 	// Version for optimistic concurrency control
 	Version    int
 	SourceID   uint64
 	TargetID   uint64
-	LinkTypeID satoriuuid.UUID `sql:"type:uuid"`
+	LinkTypeID uuid.UUID `sql:"type:uuid"`
 }
 
 // Ensure Fields implements the Equaler interface
@@ -35,7 +35,7 @@ func (l WorkItemLink) Equal(u convert.Equaler) bool {
 	if !l.Lifecycle.Equal(other.Lifecycle) {
 		return false
 	}
-	if !satoriuuid.Equal(l.ID, other.ID) {
+	if !uuid.Equal(l.ID, other.ID) {
 		return false
 	}
 	if l.Version != other.Version {
@@ -56,7 +56,7 @@ func (l WorkItemLink) Equal(u convert.Equaler) bool {
 // CheckValidForCreation returns an error if the work item link
 // cannot be used for the creation of a new work item link.
 func (l *WorkItemLink) CheckValidForCreation() error {
-	if satoriuuid.Equal(l.LinkTypeID, satoriuuid.Nil) {
+	if uuid.Equal(l.LinkTypeID, uuid.Nil) {
 		return errors.NewBadParameterError("link_type_id", l.LinkTypeID)
 	}
 	return nil

--- a/workitem/link/link_blackbox_test.go
+++ b/workitem/link/link_blackbox_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/almighty/almighty-core/workitem/link"
-	satoriuuid "github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,10 +19,10 @@ func TestWorkItemLink_Equal(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 
 	a := link.WorkItemLink{
-		ID:         satoriuuid.FromStringOrNil("0e671e36-871b-43a6-9166-0c4bd573e231"),
+		ID:         uuid.FromStringOrNil("0e671e36-871b-43a6-9166-0c4bd573e231"),
 		SourceID:   1,
 		TargetID:   2,
-		LinkTypeID: satoriuuid.FromStringOrNil("966e982c-615c-4879-961f-56e912cbc4f2"),
+		LinkTypeID: uuid.FromStringOrNil("966e982c-615c-4879-961f-56e912cbc4f2"),
 	}
 
 	// Test equality
@@ -40,7 +40,7 @@ func TestWorkItemLink_Equal(t *testing.T) {
 
 	// Test ID
 	b = a
-	b.ID = satoriuuid.FromStringOrNil("10616dae-0a28-4de5-9d79-c831dbcfd039")
+	b.ID = uuid.FromStringOrNil("10616dae-0a28-4de5-9d79-c831dbcfd039")
 	require.False(t, a.Equal(b))
 
 	// Test Version
@@ -60,7 +60,7 @@ func TestWorkItemLink_Equal(t *testing.T) {
 
 	// Test LinkTypeID
 	b = a
-	b.LinkTypeID = satoriuuid.FromStringOrNil("10a41146-3868-47cd-84ae-f96ea4c9d797")
+	b.LinkTypeID = uuid.FromStringOrNil("10a41146-3868-47cd-84ae-f96ea4c9d797")
 	require.False(t, a.Equal(b))
 }
 
@@ -69,10 +69,10 @@ func TestWorkItemLinkCheckValidForCreation(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 
 	a := link.WorkItemLink{
-		ID:         satoriuuid.FromStringOrNil("0e671e36-871b-43a6-9166-0c4bd573e231"),
+		ID:         uuid.FromStringOrNil("0e671e36-871b-43a6-9166-0c4bd573e231"),
 		SourceID:   1,
 		TargetID:   2,
-		LinkTypeID: satoriuuid.FromStringOrNil("966e982c-615c-4879-961f-56e912cbc4f2"),
+		LinkTypeID: uuid.FromStringOrNil("966e982c-615c-4879-961f-56e912cbc4f2"),
 	}
 
 	// Check valid
@@ -81,6 +81,6 @@ func TestWorkItemLinkCheckValidForCreation(t *testing.T) {
 
 	// Check empty LinkTypeID
 	b = a
-	b.LinkTypeID = satoriuuid.Nil
+	b.LinkTypeID = uuid.Nil
 	require.NotNil(t, b.CheckValidForCreation())
 }

--- a/workitem/link/link_repository.go
+++ b/workitem/link/link_repository.go
@@ -12,7 +12,7 @@ import (
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
-	satoriuuid "github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 const (
@@ -25,13 +25,13 @@ const (
 
 // WorkItemLinkRepository encapsulates storage & retrieval of work item links
 type WorkItemLinkRepository interface {
-	Create(ctx context.Context, sourceID, targetID uint64, linkTypeID satoriuuid.UUID, creatorID satoriuuid.UUID) (*app.WorkItemLinkSingle, error)
-	Load(ctx context.Context, ID satoriuuid.UUID) (*app.WorkItemLinkSingle, error)
+	Create(ctx context.Context, sourceID, targetID uint64, linkTypeID uuid.UUID, creatorID uuid.UUID) (*app.WorkItemLinkSingle, error)
+	Load(ctx context.Context, ID uuid.UUID) (*app.WorkItemLinkSingle, error)
 	List(ctx context.Context) (*app.WorkItemLinkList, error)
 	ListByWorkItemID(ctx context.Context, wiIDStr string) (*app.WorkItemLinkList, error)
-	DeleteRelatedLinks(ctx context.Context, wiIDStr string, suppressorID satoriuuid.UUID) error
-	Delete(ctx context.Context, ID satoriuuid.UUID, suppressorID satoriuuid.UUID) error
-	Save(ctx context.Context, linkCat app.WorkItemLinkSingle, modifierID satoriuuid.UUID) (*app.WorkItemLinkSingle, error)
+	DeleteRelatedLinks(ctx context.Context, wiIDStr string, suppressorID uuid.UUID) error
+	Delete(ctx context.Context, ID uuid.UUID, suppressorID uuid.UUID) error
+	Save(ctx context.Context, linkCat app.WorkItemLinkSingle, modifierID uuid.UUID) (*app.WorkItemLinkSingle, error)
 }
 
 // NewWorkItemLinkRepository creates a work item link repository based on gorm
@@ -57,7 +57,7 @@ type GormWorkItemLinkRepository struct {
 // ValidateCorrectSourceAndTargetType returns an error if the Path of
 // the source WIT as defined by the work item link type is not part of
 // the actual source's WIT; the same applies for the target.
-func (r *GormWorkItemLinkRepository) ValidateCorrectSourceAndTargetType(ctx context.Context, sourceID, targetID uint64, linkTypeID satoriuuid.UUID) error {
+func (r *GormWorkItemLinkRepository) ValidateCorrectSourceAndTargetType(ctx context.Context, sourceID, targetID uint64, linkTypeID uuid.UUID) error {
 	linkType, err := r.workItemLinkTypeRepo.LoadTypeFromDBByID(ctx, linkTypeID)
 	if err != nil {
 		return errs.WithStack(err)
@@ -93,7 +93,7 @@ func (r *GormWorkItemLinkRepository) ValidateCorrectSourceAndTargetType(ctx cont
 
 // Create creates a new work item link in the repository.
 // Returns BadParameterError, ConversionError or InternalError
-func (r *GormWorkItemLinkRepository) Create(ctx context.Context, sourceID, targetID uint64, linkTypeID satoriuuid.UUID, creatorID satoriuuid.UUID) (*app.WorkItemLinkSingle, error) {
+func (r *GormWorkItemLinkRepository) Create(ctx context.Context, sourceID, targetID uint64, linkTypeID uuid.UUID, creatorID uuid.UUID) (*app.WorkItemLinkSingle, error) {
 	link := &WorkItemLink{
 		SourceID:   sourceID,
 		TargetID:   targetID,
@@ -124,7 +124,7 @@ func (r *GormWorkItemLinkRepository) Create(ctx context.Context, sourceID, targe
 
 // Load returns the work item link for the given ID.
 // Returns NotFoundError, ConversionError or InternalError
-func (r *GormWorkItemLinkRepository) Load(ctx context.Context, ID satoriuuid.UUID) (*app.WorkItemLinkSingle, error) {
+func (r *GormWorkItemLinkRepository) Load(ctx context.Context, ID uuid.UUID) (*app.WorkItemLinkSingle, error) {
 	log.Info(ctx, map[string]interface{}{
 		"wilID": ID,
 	}, "Loading work item link")
@@ -201,7 +201,7 @@ func (r *GormWorkItemLinkRepository) List(ctx context.Context) (*app.WorkItemLin
 
 // Delete deletes the work item link with the given id
 // returns NotFoundError or InternalError
-func (r *GormWorkItemLinkRepository) Delete(ctx context.Context, linkID satoriuuid.UUID, suppressorID satoriuuid.UUID) error {
+func (r *GormWorkItemLinkRepository) Delete(ctx context.Context, linkID uuid.UUID, suppressorID uuid.UUID) error {
 	var lnk = WorkItemLink{}
 	tx := r.db.Where("id = ?", linkID).Find(&lnk)
 	if tx.RecordNotFound() {
@@ -213,7 +213,7 @@ func (r *GormWorkItemLinkRepository) Delete(ctx context.Context, linkID satoriuu
 
 // DeleteRelatedLinks deletes all links in which the source or target equals the
 // given work item ID.
-func (r *GormWorkItemLinkRepository) DeleteRelatedLinks(ctx context.Context, wiIDStr string, suppressorID satoriuuid.UUID) error {
+func (r *GormWorkItemLinkRepository) DeleteRelatedLinks(ctx context.Context, wiIDStr string, suppressorID uuid.UUID) error {
 	log.Info(ctx, map[string]interface{}{
 		"workitem_id": wiIDStr,
 	}, "Deleting the links related to work item")
@@ -234,7 +234,7 @@ func (r *GormWorkItemLinkRepository) DeleteRelatedLinks(ctx context.Context, wiI
 
 // Delete deletes the work item link with the given id
 // returns NotFoundError or InternalError
-func (r *GormWorkItemLinkRepository) deleteLink(ctx context.Context, lnk WorkItemLink, suppressorID satoriuuid.UUID) error {
+func (r *GormWorkItemLinkRepository) deleteLink(ctx context.Context, lnk WorkItemLink, suppressorID uuid.UUID) error {
 	log.Info(ctx, map[string]interface{}{
 		"wilID": lnk.ID,
 	}, "Deleting the work item link")
@@ -259,7 +259,7 @@ func (r *GormWorkItemLinkRepository) deleteLink(ctx context.Context, lnk WorkIte
 
 // Save updates the given work item link in storage. Version must be the same as the one int the stored version.
 // returns NotFoundError, VersionConflictError, ConversionError or InternalError
-func (r *GormWorkItemLinkRepository) Save(ctx context.Context, lt app.WorkItemLinkSingle, modifierID satoriuuid.UUID) (*app.WorkItemLinkSingle, error) {
+func (r *GormWorkItemLinkRepository) Save(ctx context.Context, lt app.WorkItemLinkSingle, modifierID uuid.UUID) (*app.WorkItemLinkSingle, error) {
 	res := WorkItemLink{}
 	if lt.Data.ID == nil {
 		return nil, errors.NewBadParameterError("work item link", nil)

--- a/workitem/link/type.go
+++ b/workitem/link/type.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/goadesign/goa"
 	errs "github.com/pkg/errors"
-	satoriuuid "github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 const (
@@ -46,7 +46,7 @@ func strPtrIsNilOrContentIsEqual(l, r *string) bool {
 type WorkItemLinkType struct {
 	gormsupport.Lifecycle
 	// ID
-	ID satoriuuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"`
+	ID uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"`
 	// Name is the unique name of this work item link type.
 	Name string
 	// Description is an optional description of the work item link type
@@ -55,16 +55,16 @@ type WorkItemLinkType struct {
 	Version  int
 	Topology string // Valid values: network, directed_network, dependency, tree
 
-	SourceTypeID satoriuuid.UUID `sql:"type:uuid"`
-	TargetTypeID satoriuuid.UUID `sql:"type:uuid"`
+	SourceTypeID uuid.UUID `sql:"type:uuid"`
+	TargetTypeID uuid.UUID `sql:"type:uuid"`
 
 	ForwardName string
 	ReverseName string
 
-	LinkCategoryID satoriuuid.UUID `sql:"type:uuid"`
+	LinkCategoryID uuid.UUID `sql:"type:uuid"`
 
 	// Reference to one Space
-	SpaceID satoriuuid.UUID `sql:"type:uuid"`
+	SpaceID uuid.UUID `sql:"type:uuid"`
 }
 
 // Ensure Fields implements the Equaler interface
@@ -80,7 +80,7 @@ func (t WorkItemLinkType) Equal(u convert.Equaler) bool {
 	if !t.Lifecycle.Equal(other.Lifecycle) {
 		return false
 	}
-	if !satoriuuid.Equal(t.ID, other.ID) {
+	if !uuid.Equal(t.ID, other.ID) {
 		return false
 	}
 	if t.Name != other.Name {
@@ -95,10 +95,10 @@ func (t WorkItemLinkType) Equal(u convert.Equaler) bool {
 	if t.Topology != other.Topology {
 		return false
 	}
-	if !satoriuuid.Equal(t.SourceTypeID, other.SourceTypeID) {
+	if !uuid.Equal(t.SourceTypeID, other.SourceTypeID) {
 		return false
 	}
-	if !satoriuuid.Equal(t.TargetTypeID, other.TargetTypeID) {
+	if !uuid.Equal(t.TargetTypeID, other.TargetTypeID) {
 		return false
 	}
 	if t.ForwardName != other.ForwardName {
@@ -107,10 +107,10 @@ func (t WorkItemLinkType) Equal(u convert.Equaler) bool {
 	if t.ReverseName != other.ReverseName {
 		return false
 	}
-	if !satoriuuid.Equal(t.LinkCategoryID, other.LinkCategoryID) {
+	if !uuid.Equal(t.LinkCategoryID, other.LinkCategoryID) {
 		return false
 	}
-	if !satoriuuid.Equal(t.SpaceID, other.SpaceID) {
+	if !uuid.Equal(t.SpaceID, other.SpaceID) {
 		return false
 	}
 	return true
@@ -122,10 +122,10 @@ func (t *WorkItemLinkType) CheckValidForCreation() error {
 	if t.Name == "" {
 		return errors.NewBadParameterError("name", t.Name)
 	}
-	if satoriuuid.Equal(t.SourceTypeID, satoriuuid.Nil) {
+	if uuid.Equal(t.SourceTypeID, uuid.Nil) {
 		return errors.NewBadParameterError("source_type_name", t.SourceTypeID)
 	}
-	if satoriuuid.Equal(t.TargetTypeID, satoriuuid.Nil) {
+	if uuid.Equal(t.TargetTypeID, uuid.Nil) {
 		return errors.NewBadParameterError("target_type_name", t.TargetTypeID)
 	}
 	if t.ForwardName == "" {
@@ -137,10 +137,10 @@ func (t *WorkItemLinkType) CheckValidForCreation() error {
 	if err := CheckValidTopology(t.Topology); err != nil {
 		return errs.WithStack(err)
 	}
-	if t.LinkCategoryID == satoriuuid.Nil {
+	if t.LinkCategoryID == uuid.Nil {
 		return errors.NewBadParameterError("link_category_id", t.LinkCategoryID)
 	}
-	if t.SpaceID == satoriuuid.Nil {
+	if t.SpaceID == uuid.Nil {
 		return errors.NewBadParameterError("space_id", t.SpaceID)
 	}
 	return nil

--- a/workitem/link/type_blackbox_test.go
+++ b/workitem/link/type_blackbox_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/almighty/almighty-core/resource"
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/almighty/almighty-core/workitem/link"
-	satoriuuid "github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,7 +21,7 @@ func TestWorkItemLinkType_Equal(t *testing.T) {
 
 	description := "An example description"
 	a := link.WorkItemLinkType{
-		ID:             satoriuuid.FromStringOrNil("0e671e36-871b-43a6-9166-0c4bd573e231"),
+		ID:             uuid.FromStringOrNil("0e671e36-871b-43a6-9166-0c4bd573e231"),
 		Name:           "Example work item link category",
 		Description:    &description,
 		Topology:       "network",
@@ -30,8 +30,8 @@ func TestWorkItemLinkType_Equal(t *testing.T) {
 		TargetTypeID:   workitem.SystemUserStory,
 		ForwardName:    "blocks",
 		ReverseName:    "blocked by",
-		LinkCategoryID: satoriuuid.FromStringOrNil("0e671e36-871b-43a6-9166-0c4bd573eAAA"),
-		SpaceID:        satoriuuid.FromStringOrNil("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+		LinkCategoryID: uuid.FromStringOrNil("0e671e36-871b-43a6-9166-0c4bd573eAAA"),
+		SpaceID:        uuid.FromStringOrNil("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
 	}
 
 	// Test equality
@@ -49,7 +49,7 @@ func TestWorkItemLinkType_Equal(t *testing.T) {
 
 	// Test ID
 	b = a
-	b.ID = satoriuuid.FromStringOrNil("CCC71e36-871b-43a6-9166-0c4bd573eCCC")
+	b.ID = uuid.FromStringOrNil("CCC71e36-871b-43a6-9166-0c4bd573eCCC")
 	require.False(t, a.Equal(b))
 
 	// Test Version
@@ -75,12 +75,12 @@ func TestWorkItemLinkType_Equal(t *testing.T) {
 
 	// Test SourceTypeID
 	b = a
-	b.SourceTypeID = satoriuuid.Nil
+	b.SourceTypeID = uuid.Nil
 	require.False(t, a.Equal(b))
 
 	// Test TargetTypeID
 	b = a
-	b.TargetTypeID = satoriuuid.Nil
+	b.TargetTypeID = uuid.Nil
 	require.False(t, a.Equal(b))
 
 	// Test ForwardName
@@ -95,12 +95,12 @@ func TestWorkItemLinkType_Equal(t *testing.T) {
 
 	// Test LinkCategoryID
 	b = a
-	b.LinkCategoryID = satoriuuid.FromStringOrNil("aaa71e36-871b-43a6-9166-0c4bd573eCCC")
+	b.LinkCategoryID = uuid.FromStringOrNil("aaa71e36-871b-43a6-9166-0c4bd573eCCC")
 	require.False(t, a.Equal(b))
 
 	// Test SpaceID
 	b = a
-	b.SpaceID = satoriuuid.FromStringOrNil("aaa71e36-871b-43a6-9166-0v5ce684dBBB")
+	b.SpaceID = uuid.FromStringOrNil("aaa71e36-871b-43a6-9166-0v5ce684dBBB")
 	require.False(t, a.Equal(b))
 }
 
@@ -110,7 +110,7 @@ func TestWorkItemLinkTypeCheckValidForCreation(t *testing.T) {
 
 	description := "An example description"
 	a := link.WorkItemLinkType{
-		ID:             satoriuuid.FromStringOrNil("0e671e36-871b-43a6-9166-0c4bd573e231"),
+		ID:             uuid.FromStringOrNil("0e671e36-871b-43a6-9166-0c4bd573e231"),
 		Name:           "Example work item link category",
 		Description:    &description,
 		Topology:       link.TopologyNetwork,
@@ -119,8 +119,8 @@ func TestWorkItemLinkTypeCheckValidForCreation(t *testing.T) {
 		TargetTypeID:   workitem.SystemUserStory,
 		ForwardName:    "blocks",
 		ReverseName:    "blocked by",
-		LinkCategoryID: satoriuuid.FromStringOrNil("0e671e36-871b-43a6-9166-0c4bd573eAAA"),
-		SpaceID:        satoriuuid.FromStringOrNil("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+		LinkCategoryID: uuid.FromStringOrNil("0e671e36-871b-43a6-9166-0c4bd573eAAA"),
+		SpaceID:        uuid.FromStringOrNil("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
 	}
 
 	// Check valid
@@ -134,12 +134,12 @@ func TestWorkItemLinkTypeCheckValidForCreation(t *testing.T) {
 
 	// Check empty SourceTypeID
 	b = a
-	b.SourceTypeID = satoriuuid.Nil
+	b.SourceTypeID = uuid.Nil
 	require.NotNil(t, b.CheckValidForCreation())
 
 	// Check empty TargetTypeID
 	b = a
-	b.TargetTypeID = satoriuuid.Nil
+	b.TargetTypeID = uuid.Nil
 	require.NotNil(t, b.CheckValidForCreation())
 
 	// Check empty ForwardName
@@ -159,11 +159,11 @@ func TestWorkItemLinkTypeCheckValidForCreation(t *testing.T) {
 
 	// Check empty LinkCategoryID
 	b = a
-	b.LinkCategoryID = satoriuuid.Nil
+	b.LinkCategoryID = uuid.Nil
 	require.NotNil(t, b.CheckValidForCreation())
 
 	// Check empty SpaceID
 	b = a
-	b.SpaceID = satoriuuid.Nil
+	b.SpaceID = uuid.Nil
 	require.NotNil(t, b.CheckValidForCreation())
 }

--- a/workitem/link/type_repository.go
+++ b/workitem/link/type_repository.go
@@ -14,22 +14,22 @@ import (
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
-	satoriuuid "github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 // WorkItemLinkTypeRepository encapsulates storage & retrieval of work item link types
 type WorkItemLinkTypeRepository interface {
-	Create(ctx context.Context, name string, description *string, sourceTypeID, targetTypeID satoriuuid.UUID, forwardName, reverseName, topology string, linkCategory, spaceID satoriuuid.UUID) (*app.WorkItemLinkTypeSingle, error)
-	Load(ctx context.Context, ID satoriuuid.UUID) (*app.WorkItemLinkTypeSingle, error)
+	Create(ctx context.Context, name string, description *string, sourceTypeID, targetTypeID uuid.UUID, forwardName, reverseName, topology string, linkCategory, spaceID uuid.UUID) (*app.WorkItemLinkTypeSingle, error)
+	Load(ctx context.Context, ID uuid.UUID) (*app.WorkItemLinkTypeSingle, error)
 	List(ctx context.Context) (*app.WorkItemLinkTypeList, error)
-	Delete(ctx context.Context, ID satoriuuid.UUID) error
+	Delete(ctx context.Context, ID uuid.UUID) error
 	Save(ctx context.Context, linkCat app.WorkItemLinkTypeSingle) (*app.WorkItemLinkTypeSingle, error)
 	// ListSourceLinkTypes returns the possible link types for where the given
 	// WIT can be used in the source.
-	ListSourceLinkTypes(ctx context.Context, witID satoriuuid.UUID) (*app.WorkItemLinkTypeList, error)
+	ListSourceLinkTypes(ctx context.Context, witID uuid.UUID) (*app.WorkItemLinkTypeList, error)
 	// ListSourceLinkTypes returns the possible link types for where the given
 	// WIT can be used in the target.
-	ListTargetLinkTypes(ctx context.Context, witID satoriuuid.UUID) (*app.WorkItemLinkTypeList, error)
+	ListTargetLinkTypes(ctx context.Context, witID uuid.UUID) (*app.WorkItemLinkTypeList, error)
 }
 
 // NewWorkItemLinkTypeRepository creates a work item link type repository based on gorm
@@ -44,7 +44,7 @@ type GormWorkItemLinkTypeRepository struct {
 
 // Create creates a new work item link type in the repository.
 // Returns BadParameterError, ConversionError or InternalError
-func (r *GormWorkItemLinkTypeRepository) Create(ctx context.Context, name string, description *string, sourceTypeID, targetTypeID satoriuuid.UUID, forwardName, reverseName, topology string, linkCategoryID, spaceID satoriuuid.UUID) (*app.WorkItemLinkTypeSingle, error) {
+func (r *GormWorkItemLinkTypeRepository) Create(ctx context.Context, name string, description *string, sourceTypeID, targetTypeID uuid.UUID, forwardName, reverseName, topology string, linkCategoryID, spaceID uuid.UUID) (*app.WorkItemLinkTypeSingle, error) {
 	linkType := &WorkItemLinkType{
 		Name:           name,
 		Description:    description,
@@ -90,7 +90,7 @@ func (r *GormWorkItemLinkTypeRepository) Create(ctx context.Context, name string
 
 // Load returns the work item link type for the given ID.
 // Returns NotFoundError, ConversionError or InternalError
-func (r *GormWorkItemLinkTypeRepository) Load(ctx context.Context, ID satoriuuid.UUID) (*app.WorkItemLinkTypeSingle, error) {
+func (r *GormWorkItemLinkTypeRepository) Load(ctx context.Context, ID uuid.UUID) (*app.WorkItemLinkTypeSingle, error) {
 	log.Info(ctx, map[string]interface{}{
 		"wiltID": ID,
 	}, "Loading work item link type")
@@ -113,7 +113,7 @@ func (r *GormWorkItemLinkTypeRepository) Load(ctx context.Context, ID satoriuuid
 
 // LoadTypeFromDB return work item link type for the given name in the correct link category
 // NOTE: Two link types can coexist with different categoryIDs.
-func (r *GormWorkItemLinkTypeRepository) LoadTypeFromDBByNameAndCategory(ctx context.Context, name string, categoryId satoriuuid.UUID) (*WorkItemLinkType, error) {
+func (r *GormWorkItemLinkTypeRepository) LoadTypeFromDBByNameAndCategory(ctx context.Context, name string, categoryId uuid.UUID) (*WorkItemLinkType, error) {
 	log.Info(ctx, map[string]interface{}{
 		"wiltName":   name,
 		"categoryId": categoryId,
@@ -135,7 +135,7 @@ func (r *GormWorkItemLinkTypeRepository) LoadTypeFromDBByNameAndCategory(ctx con
 }
 
 // LoadTypeFromDB return work item link type for the given ID
-func (r *GormWorkItemLinkTypeRepository) LoadTypeFromDBByID(ctx context.Context, ID satoriuuid.UUID) (*WorkItemLinkType, error) {
+func (r *GormWorkItemLinkTypeRepository) LoadTypeFromDBByID(ctx context.Context, ID uuid.UUID) (*WorkItemLinkType, error) {
 	log.Info(ctx, map[string]interface{}{
 		"wiltID": ID.String(),
 	}, "Loading work item link type with ID ", ID)
@@ -179,7 +179,7 @@ func (r *GormWorkItemLinkTypeRepository) List(ctx context.Context) (*app.WorkIte
 
 // Delete deletes the work item link type with the given id
 // returns NotFoundError or InternalError
-func (r *GormWorkItemLinkTypeRepository) Delete(ctx context.Context, ID satoriuuid.UUID) error {
+func (r *GormWorkItemLinkTypeRepository) Delete(ctx context.Context, ID uuid.UUID) error {
 	var cat = WorkItemLinkType{
 		ID: ID,
 	}
@@ -263,7 +263,7 @@ func (r *GormWorkItemLinkTypeRepository) listLinkTypes(ctx context.Context, fetc
 	return &res, nil
 }
 
-func (r *GormWorkItemLinkTypeRepository) ListSourceLinkTypes(ctx context.Context, witID satoriuuid.UUID) (*app.WorkItemLinkTypeList, error) {
+func (r *GormWorkItemLinkTypeRepository) ListSourceLinkTypes(ctx context.Context, witID uuid.UUID) (*app.WorkItemLinkTypeList, error) {
 	return r.listLinkTypes(ctx, func() ([]WorkItemLinkType, error) {
 		db := r.db.Model(WorkItemLinkType{})
 		query := fmt.Sprintf(`
@@ -288,7 +288,7 @@ func (r *GormWorkItemLinkTypeRepository) ListSourceLinkTypes(ctx context.Context
 	})
 }
 
-func (r *GormWorkItemLinkTypeRepository) ListTargetLinkTypes(ctx context.Context, witID satoriuuid.UUID) (*app.WorkItemLinkTypeList, error) {
+func (r *GormWorkItemLinkTypeRepository) ListTargetLinkTypes(ctx context.Context, witID uuid.UUID) (*app.WorkItemLinkTypeList, error) {
 	return r.listLinkTypes(ctx, func() ([]WorkItemLinkType, error) {
 		db := r.db.Model(WorkItemLinkType{})
 		query := fmt.Sprintf(`

--- a/workitem/workitemtype.go
+++ b/workitem/workitemtype.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/goadesign/goa"
 	"github.com/pkg/errors"
-	satoriuuid "github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 // String constants for the local work item types.
@@ -45,21 +45,21 @@ const (
 // Never ever change these UUIDs!!!
 var (
 	// base item type with common fields for planner item types like userstory, experience, bug, feature, etc.
-	SystemPlannerItem      = satoriuuid.FromStringOrNil("86af5178-9b41-469b-9096-57e5155c3f31") // "planneritem"
-	SystemUserStory        = satoriuuid.FromStringOrNil("bbf35418-04b6-426c-a60b-7f80beb0b624") // "userstory"
-	SystemValueProposition = satoriuuid.FromStringOrNil("3194ab60-855b-4155-9005-9dce4a05f1eb") // "valueproposition"
-	SystemFundamental      = satoriuuid.FromStringOrNil("ee7ca005-f81d-4eea-9b9b-1965df0988d0") // "fundamental"
-	SystemExperience       = satoriuuid.FromStringOrNil("b9a71831-c803-4f66-8774-4193fffd1311") // "experience"
-	SystemFeature          = satoriuuid.FromStringOrNil("0a24d3c2-e0a6-4686-8051-ec0ea1915a28") // "feature"
-	SystemScenario         = satoriuuid.FromStringOrNil("71171e90-6d35-498f-a6a7-2083b5267c18") // "scenario"
-	SystemBug              = satoriuuid.FromStringOrNil("26787039-b68f-4e28-8814-c2f93be1ef4e") // "bug"
+	SystemPlannerItem      = uuid.FromStringOrNil("86af5178-9b41-469b-9096-57e5155c3f31") // "planneritem"
+	SystemUserStory        = uuid.FromStringOrNil("bbf35418-04b6-426c-a60b-7f80beb0b624") // "userstory"
+	SystemValueProposition = uuid.FromStringOrNil("3194ab60-855b-4155-9005-9dce4a05f1eb") // "valueproposition"
+	SystemFundamental      = uuid.FromStringOrNil("ee7ca005-f81d-4eea-9b9b-1965df0988d0") // "fundamental"
+	SystemExperience       = uuid.FromStringOrNil("b9a71831-c803-4f66-8774-4193fffd1311") // "experience"
+	SystemFeature          = uuid.FromStringOrNil("0a24d3c2-e0a6-4686-8051-ec0ea1915a28") // "feature"
+	SystemScenario         = uuid.FromStringOrNil("71171e90-6d35-498f-a6a7-2083b5267c18") // "scenario"
+	SystemBug              = uuid.FromStringOrNil("26787039-b68f-4e28-8814-c2f93be1ef4e") // "bug"
 )
 
 // WorkItemType represents a work item type as it is stored in the db
 type WorkItemType struct {
 	gormsupport.Lifecycle
 	// ID
-	ID satoriuuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"`
+	ID uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"`
 	// Name is a human readable name of this work item type
 	Name string
 	// Description is an optional description of the work item type
@@ -73,7 +73,7 @@ type WorkItemType struct {
 	// definitions of the fields this work item type supports
 	Fields FieldDefinitions `sql:"type:jsonb"`
 	// Reference to one Space
-	SpaceID satoriuuid.UUID `sql:"type:uuid"`
+	SpaceID uuid.UUID `sql:"type:uuid"`
 }
 
 // GetTypePathSeparator returns the work item type's path separator "."
@@ -89,7 +89,7 @@ func (wit WorkItemType) LtreeSafeID() string {
 
 // LtreeSafeID returns the ID of the work item type in an postgres ltree safe manner
 // The returned string can be used as an ltree node.
-func LtreeSafeID(witID satoriuuid.UUID) string {
+func LtreeSafeID(witID uuid.UUID) string {
 	return strings.Replace(witID.String(), "-", "_", -1)
 }
 
@@ -124,7 +124,7 @@ func (wit WorkItemType) Equal(u convert.Equaler) bool {
 	if !ok {
 		return false
 	}
-	if !satoriuuid.Equal(wit.ID, other.ID) {
+	if !uuid.Equal(wit.ID, other.ID) {
 		return false
 	}
 	if !wit.Lifecycle.Equal(other.Lifecycle) {
@@ -193,8 +193,8 @@ func (wit WorkItemType) ConvertFromModel(request *goa.RequestData, workItem Work
 // IsTypeOrSubtypeOf returns true if the work item type with the given type ID,
 // is of the same type as the current WIT or of it is a subtype; otherwise false
 // is returned.
-func (wit WorkItemType) IsTypeOrSubtypeOf(typeID satoriuuid.UUID) bool {
+func (wit WorkItemType) IsTypeOrSubtypeOf(typeID uuid.UUID) bool {
 	// Check for complete inclusion (e.g. "bar" is contained in "foo.bar.cake")
 	// and for suffix (e.g. ".cake" is the suffix of "foo.bar.cake").
-	return satoriuuid.Equal(wit.ID, typeID) || strings.Contains(wit.Path, LtreeSafeID(typeID)+pathSep)
+	return uuid.Equal(wit.ID, typeID) || strings.Contains(wit.Path, LtreeSafeID(typeID)+pathSep)
 }


### PR DESCRIPTION
In old code I've been using `satoriuuid` as the import name for the UUID library. In newer code we just use `uuid` as the import name. In order to be consistent., I've changed the import name to `uuid` everywhere.

```diff
-	satoriuuid "github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
```

This was more or less a mechanical change.
