### PR TITLE
Update dev SSO server to prod-preview

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -501,4 +501,4 @@ var defaultKeycloakTesUser2Name = "testuser2"
 var defaultKeycloakTesUser2Secret = "testuser2"
 
 // Keycloak URL to be used in dev mode. Can be overridden by setting up keycloak.url
-var devModeKeycloakURL = "http://sso.demo.almighty.io"
+var devModeKeycloakURL = "http://sso.prod-preview.openshift.io"

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -89,7 +89,7 @@ func TestGetKeycloakEndpointSetByUrlEnvVaribaleOK(t *testing.T) {
 func TestGetKeycloakEndpointAdminDevModeOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
-	checkGetKeycloakEndpointOK(t, "http://sso.demo.almighty.io/auth/admin/realms/fabric8", config.GetKeycloakEndpointAdmin)
+	checkGetKeycloakEndpointOK(t, "http://sso.prod-preview.openshift.io/auth/admin/realms/fabric8", config.GetKeycloakEndpointAdmin)
 }
 
 func TestGetKeycloakEndpointAdminSetByEnvVaribaleOK(t *testing.T) {
@@ -100,7 +100,7 @@ func TestGetKeycloakEndpointAdminSetByEnvVaribaleOK(t *testing.T) {
 func TestGetKeycloakEndpointAuthzResourcesetDevModeOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
-	checkGetKeycloakEndpointOK(t, "http://sso.demo.almighty.io/auth/realms/fabric8/authz/protection/resource_set", config.GetKeycloakEndpointAuthzResourceset)
+	checkGetKeycloakEndpointOK(t, "http://sso.prod-preview.openshift.io/auth/realms/fabric8/authz/protection/resource_set", config.GetKeycloakEndpointAuthzResourceset)
 }
 
 func TestGetKeycloakEndpointAuthzResourcesetSetByEnvVaribaleOK(t *testing.T) {
@@ -111,7 +111,7 @@ func TestGetKeycloakEndpointAuthzResourcesetSetByEnvVaribaleOK(t *testing.T) {
 func TestGetKeycloakEndpointClientsDevModeOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
-	checkGetKeycloakEndpointOK(t, "http://sso.demo.almighty.io/auth/admin/realms/fabric8/clients", config.GetKeycloakEndpointClients)
+	checkGetKeycloakEndpointOK(t, "http://sso.prod-preview.openshift.io/auth/admin/realms/fabric8/clients", config.GetKeycloakEndpointClients)
 }
 
 func TestGetKeycloakEndpoinClientsSetByEnvVaribaleOK(t *testing.T) {
@@ -122,7 +122,7 @@ func TestGetKeycloakEndpoinClientsSetByEnvVaribaleOK(t *testing.T) {
 func TestGetKeycloakEndpointAuthDevModeOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
-	checkGetKeycloakEndpointOK(t, "http://sso.demo.almighty.io/auth/realms/fabric8/protocol/openid-connect/auth", config.GetKeycloakEndpointAuth)
+	checkGetKeycloakEndpointOK(t, "http://sso.prod-preview.openshift.io/auth/realms/fabric8/protocol/openid-connect/auth", config.GetKeycloakEndpointAuth)
 }
 
 func TestGetKeycloakEndpointAuthSetByEnvVaribaleOK(t *testing.T) {
@@ -133,7 +133,7 @@ func TestGetKeycloakEndpointAuthSetByEnvVaribaleOK(t *testing.T) {
 func TestGetKeycloakEndpointTokenOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
-	checkGetKeycloakEndpointOK(t, "http://sso.demo.almighty.io/auth/realms/fabric8/protocol/openid-connect/token", config.GetKeycloakEndpointToken)
+	checkGetKeycloakEndpointOK(t, "http://sso.prod-preview.openshift.io/auth/realms/fabric8/protocol/openid-connect/token", config.GetKeycloakEndpointToken)
 }
 
 func TestGetKeycloakEndpointTokenSetByEnvVaribaleOK(t *testing.T) {
@@ -144,7 +144,7 @@ func TestGetKeycloakEndpointTokenSetByEnvVaribaleOK(t *testing.T) {
 func TestGetKeycloakEndpointUserInfoOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
-	checkGetKeycloakEndpointOK(t, "http://sso.demo.almighty.io/auth/realms/fabric8/protocol/openid-connect/userinfo", config.GetKeycloakEndpointUserInfo)
+	checkGetKeycloakEndpointOK(t, "http://sso.prod-preview.openshift.io/auth/realms/fabric8/protocol/openid-connect/userinfo", config.GetKeycloakEndpointUserInfo)
 }
 
 func TestGetKeycloakEndpointUserInfoSetByEnvVaribaleOK(t *testing.T) {
@@ -155,7 +155,7 @@ func TestGetKeycloakEndpointUserInfoSetByEnvVaribaleOK(t *testing.T) {
 func TestGetKeycloakEndpointEntitlementOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
-	checkGetKeycloakEndpointOK(t, "http://sso.demo.almighty.io/auth/realms/fabric8/authz/entitlement/fabric8-online-platform", config.GetKeycloakEndpointEntitlement)
+	checkGetKeycloakEndpointOK(t, "http://sso.prod-preview.openshift.io/auth/realms/fabric8/authz/entitlement/fabric8-online-platform", config.GetKeycloakEndpointEntitlement)
 }
 
 func TestGetKeycloakEndpointEntitlementSetByEnvVaribaleOK(t *testing.T) {

--- a/configuration/configuration_whitebox_test.go
+++ b/configuration/configuration_whitebox_test.go
@@ -68,17 +68,17 @@ func TestGetKeycloakURLForTooShortHostFails(t *testing.T) {
 
 func TestDemoApiAlmightyIoExceptionOK(t *testing.T) {
 	// demo.api.almighty.io doesn't follow the service name convention <serviceName>.<domain>
-	// The correct name would be something like API.demo.almighty.io which is to be converted to SSO.demo.almighty.io
+	// The correct name would be something like API.demo.almighty.io which is to be converted to sso.prod-preview.openshift.io
 	// So, it should be treated as an exception
 
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
 
 	r := &goa.RequestData{
-		Request: &http.Request{Host: "demo.api.almighty.io"},
+		Request: &http.Request{Host: "sso.prod-preview.openshift.io"},
 	}
 
 	url, err := config.getKeycloakURL(r, "somepath3")
 	assert.Nil(t, err)
-	assert.Equal(t, "http://sso.demo.almighty.io/somepath3", url)
+	assert.Equal(t, "http://sso.prod-preview.openshift.io/somepath3", url)
 }


### PR DESCRIPTION
- sso.prod-preview.openshift.io runs a higher version of keycloak.
- It runs the build made out of master + merges-needed-by-fabric8 
- in the upcoming week, changes to user profile api would need this sso server.

fixes #1019

