### PR TITLE
Add codebase RESt API

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -4,6 +4,8 @@ import (
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/area"
 	"github.com/almighty/almighty-core/auth"
+	"github.com/almighty/almighty-core/codebase"
+
 	"github.com/almighty/almighty-core/comment"
 	"github.com/almighty/almighty-core/iteration"
 	"github.com/almighty/almighty-core/space"
@@ -29,6 +31,7 @@ type Application interface {
 	Users() account.UserRepository
 	Areas() area.Repository
 	OauthStates() auth.OauthStateReferenceRepository
+	Codebases() codebase.Repository
 }
 
 // A Transaction abstracts a database transaction. The repositories created for the transaction object make changes inside the the transaction

--- a/codebase/che/client.go
+++ b/codebase/che/client.go
@@ -1,0 +1,196 @@
+package che
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+
+	"github.com/almighty/almighty-core/log"
+	"github.com/goadesign/goa/middleware"
+	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+)
+
+// NewStarterClient is a helper function to create a new CheStarter client
+// Uses http.DefaultClient
+func NewStarterClient(cheStarterURL, openshiftMasterURL string, namespace string) *StarterClient {
+	return &StarterClient{cheStarterURL: cheStarterURL, openshiftMasterURL: openshiftMasterURL, namespace: namespace, client: http.DefaultClient}
+}
+
+// StarterClient describes the REST interface between Platform and Che Starter
+type StarterClient struct {
+	cheStarterURL      string
+	openshiftMasterURL string
+	namespace          string
+	client             *http.Client
+}
+
+func (cs *StarterClient) targetURL(resource string) string {
+	return fmt.Sprintf("%v/%v?masterUrl=%v&namespace=%v", cs.cheStarterURL, resource, cs.openshiftMasterURL, cs.namespace)
+}
+
+func (cs *StarterClient) setHeaders(ctx context.Context, req *http.Request) {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+goajwt.ContextJWT(ctx).Raw)
+	req.Header.Set(middleware.RequestIDHeader, middleware.ContextRequestID(ctx))
+}
+
+// ListWorkspaces lists the available workspaces for a given user
+func (cs *StarterClient) ListWorkspaces(ctx context.Context, repository string) ([]WorkspaceResponse, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf(cs.targetURL("workspace")+"&repository=%v", repository), nil)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"repository": repository,
+			"err":        err,
+		}, "failed to create request object")
+		return nil, err
+	}
+	cs.setHeaders(ctx, req)
+
+	if log.IsDebug() {
+		b, _ := httputil.DumpRequest(req, true)
+		log.Debug(ctx, map[string]interface{}{
+			"request": string(b),
+		}, "request object")
+	}
+
+	resp, err := cs.client.Do(req)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"repository": repository,
+			"err":        err,
+		}, "failed to list workspace for repository")
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		workspaceErr := WorkspaceError{}
+		err = json.NewDecoder(resp.Body).Decode(&workspaceErr)
+		if err != nil {
+			log.Error(ctx, map[string]interface{}{
+				"repository": repository,
+				"err":        err,
+			}, "failed to decode error response from list workspace for repository")
+			return nil, err
+		}
+		log.Error(ctx, map[string]interface{}{
+			"repository": repository,
+			"err":        workspaceErr.String(),
+		}, "failed to execute list workspace for repository")
+		return nil, &workspaceErr
+	}
+
+	workspaceResp := []WorkspaceResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&workspaceResp)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"repository": repository,
+			"err":        err,
+		}, "failed to decode response from list workspace for repository")
+		return nil, err
+	}
+	return workspaceResp, nil
+}
+
+// CreateWorkspace creates a new Che Workspace based on a repository
+func (cs *StarterClient) CreateWorkspace(ctx context.Context, workspace WorkspaceRequest) (*WorkspaceResponse, error) {
+	body, err := json.Marshal(&workspace)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"workspaceID": workspace.ID,
+			"err":         err,
+		}, "failed to create request object")
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", cs.targetURL("workspace"), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	cs.setHeaders(ctx, req)
+
+	if log.IsDebug() {
+		b, _ := httputil.DumpRequest(req, true)
+		log.Debug(ctx, map[string]interface{}{
+			"request": string(b),
+		}, "request object")
+	}
+
+	resp, err := cs.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		workspaceErr := WorkspaceError{}
+		err = json.NewDecoder(resp.Body).Decode(&workspaceErr)
+		if err != nil {
+			log.Error(ctx, map[string]interface{}{
+				"workspaceID": workspace.ID,
+				"err":         err,
+			}, "failed to decode error response from create workspace for repository")
+			return nil, err
+		}
+		log.Error(ctx, map[string]interface{}{
+			"workspaceID": workspace.ID,
+			"err":         workspaceErr.String(),
+		}, "failed to execute create workspace for repository")
+		return nil, &workspaceErr
+	}
+
+	workspaceResp := WorkspaceResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&workspaceResp)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"workspaceID": workspace.ID,
+			"err":         err,
+		}, "failed to decode response from create workspace for repository")
+		return nil, err
+	}
+	return &workspaceResp, nil
+}
+
+// WorkspaceRequest represents a create workspace request body
+type WorkspaceRequest struct {
+	ID         string `json:"id,omitempty"`
+	Branch     string `json:"branch,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Repository string `json:"repo,omitempty"`
+	StackID    string `json:"stack,omitempty"`
+}
+
+// WorkspaceResponse represents a create workspace response body
+type WorkspaceResponse struct {
+	ID              string `json:"id"`
+	Branch          string `json:"branch"`
+	Description     string `json:"description"`
+	Location        string `json:"location"`
+	Login           string `json:"login"`
+	Name            string `json:"name"`
+	Repository      string `json:"repository"`
+	Status          string `json:"status"`
+	WorkspaceIDEURL string `json:"workspaceIdeUrl"`
+}
+
+type WorkspaceError struct {
+	Status    int    `json:"status"`
+	ErrorMsg  string `json:"error"`
+	Message   string `json:"message"`
+	Timestamp string `json:"timeStamp"`
+	Trace     string `json:"trace"`
+}
+
+func (err *WorkspaceError) Error() string {
+	return err.ErrorMsg
+}
+
+func (err *WorkspaceError) String() string {
+	return fmt.Sprintf("Status %v Error %v Message %v Trace\n%v", err.Status, err.ErrorMsg, err.ErrorMsg, err.Trace)
+}

--- a/codebase/codebase.go
+++ b/codebase/codebase.go
@@ -1,6 +1,18 @@
 package codebase
 
-import "github.com/almighty/almighty-core/errors"
+import (
+	"log"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/almighty/almighty-core/errors"
+	"github.com/almighty/almighty-core/gormsupport"
+	"github.com/goadesign/goa"
+	"github.com/jinzhu/gorm"
+	errs "github.com/pkg/errors"
+	uuid "github.com/satori/go.uuid"
+)
 
 // CodebaseContent defines all parameters those are useful to associate Che Editor's window to a WI
 type CodebaseContent struct {
@@ -86,4 +98,155 @@ func NewCodebaseContentFromValue(value interface{}) (*CodebaseContent, error) {
 	default:
 		return nil, nil
 	}
+}
+
+// Codebase describes a single codebase
+type Codebase struct {
+	gormsupport.Lifecycle
+	ID      uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"` // This is the ID PK field
+	SpaceID uuid.UUID `sql:"type:uuid"`
+	Type    string
+	URL     string
+}
+
+// Repository describes interactions with codebases
+type Repository interface {
+	Create(ctx context.Context, u *Codebase) error
+	//Save(ctx context.Context, codebase *Codebase) (*Codebase, error)
+	List(ctx context.Context, spaceID uuid.UUID, start *int, limit *int) ([]*Codebase, uint64, error)
+	Load(ctx context.Context, id uuid.UUID) (*Codebase, error)
+}
+
+// NewCodebaseRepository creates a new storage type.
+func NewCodebaseRepository(db *gorm.DB) Repository {
+	return &GormCodebaseRepository{db: db}
+}
+
+// GormCodebaseRepository is the implementation of the storage interface for Codebases.
+type GormCodebaseRepository struct {
+	db *gorm.DB
+}
+
+// TableName overrides the table name settings in Gorm to force a specific table name
+// in the database.
+func (m *GormCodebaseRepository) TableName() string {
+	return "codebases"
+}
+
+// Create creates a new record.
+func (m *GormCodebaseRepository) Create(ctx context.Context, codebase *Codebase) error {
+	defer goa.MeasureSince([]string{"goa", "db", "codebase", "create"}, time.Now())
+	codebase.ID = uuid.NewV4()
+
+	if err := m.db.Create(codebase).Error; err != nil {
+		goa.LogError(ctx, "error adding Codebase", "error", err.Error())
+		return errs.WithStack(err)
+	}
+
+	return nil
+}
+
+// Save a single codebase
+func (m *GormCodebaseRepository) Save(ctx context.Context, codebase *Codebase) (*Codebase, error) {
+	c := Codebase{}
+	tx := m.db.Where("id=?", codebase.ID).First(&c)
+	if tx.RecordNotFound() {
+		// treating this as a not found error: the fact that we're using number internal is implementation detail
+		return nil, errors.NewNotFoundError("codebase", codebase.ID.String())
+	}
+	if err := tx.Error; err != nil {
+		return nil, errors.NewInternalError(err.Error())
+	}
+
+	tx = tx.Save(codebase)
+	if err := tx.Error; err != nil {
+		return nil, errors.NewInternalError(err.Error())
+	}
+	log.Printf("updated codebase to %v\n", codebase)
+	return codebase, nil
+}
+
+// List all codebases related to a single item
+func (m *GormCodebaseRepository) List(ctx context.Context, spaceID uuid.UUID, start *int, limit *int) ([]*Codebase, uint64, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "codebase", "query"}, time.Now())
+
+	db := m.db.Model(&Codebase{}).Where("space_id = ?", spaceID)
+	orgDB := db
+	if start != nil {
+		if *start < 0 {
+			return nil, 0, errors.NewBadParameterError("start", *start)
+		}
+		db = db.Offset(*start)
+	}
+	if limit != nil {
+		if *limit <= 0 {
+			return nil, 0, errors.NewBadParameterError("limit", *limit)
+		}
+		db = db.Limit(*limit)
+	}
+	db = db.Select("count(*) over () as cnt2 , *")
+
+	rows, err := db.Rows()
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	result := []*Codebase{}
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, 0, errors.NewInternalError(err.Error())
+	}
+
+	// need to set up a result for Scan() in order to extract total count.
+	var count uint64
+	var ignore interface{}
+	columnValues := make([]interface{}, len(columns))
+
+	for index := range columnValues {
+		columnValues[index] = &ignore
+	}
+	columnValues[0] = &count
+	first := true
+
+	for rows.Next() {
+		value := &Codebase{}
+		db.ScanRows(rows, value)
+		if first {
+			first = false
+			if err = rows.Scan(columnValues...); err != nil {
+				return nil, 0, errors.NewInternalError(err.Error())
+			}
+		}
+		result = append(result, value)
+
+	}
+	if first {
+		// means 0 rows were returned from the first query (maybe becaus of offset outside of total count),
+		// need to do a count(*) to find out total
+		orgDB := orgDB.Select("count(*)")
+		rows2, err := orgDB.Rows()
+		defer rows2.Close()
+		if err != nil {
+			return nil, 0, err
+		}
+		rows2.Next() // count(*) will always return a row
+		rows2.Scan(&count)
+	}
+	return result, count, nil
+}
+
+// Load a single codebase regardless of parent
+func (m *GormCodebaseRepository) Load(ctx context.Context, id uuid.UUID) (*Codebase, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "codebase", "get"}, time.Now())
+	var obj Codebase
+
+	tx := m.db.Where("id=?", id).First(&obj)
+	if tx.RecordNotFound() {
+		return nil, errors.NewNotFoundError("codebase", id.String())
+	}
+	if tx.Error != nil {
+		return nil, errors.NewInternalError(tx.Error.Error())
+	}
+	return &obj, nil
 }

--- a/codebase/codebase.go
+++ b/codebase/codebase.go
@@ -136,7 +136,9 @@ func (m *GormCodebaseRepository) TableName() string {
 // Create creates a new record.
 func (m *GormCodebaseRepository) Create(ctx context.Context, codebase *Codebase) error {
 	defer goa.MeasureSince([]string{"goa", "db", "codebase", "create"}, time.Now())
-	codebase.ID = uuid.NewV4()
+	if codebase.ID == uuid.Nil {
+		codebase.ID = uuid.NewV4()
+	}
 
 	if err := m.db.Create(codebase).Error; err != nil {
 		goa.LogError(ctx, "error adding Codebase", "error", err.Error())

--- a/codebase/codebase_test.go
+++ b/codebase/codebase_test.go
@@ -3,9 +3,17 @@ package codebase_test
 import (
 	"testing"
 
-	"github.com/almighty/almighty-core/codebase"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"golang.org/x/net/context"
+
+	"github.com/almighty/almighty-core/codebase"
+	"github.com/almighty/almighty-core/gormsupport/cleaner"
+	"github.com/almighty/almighty-core/gormtestsupport"
+	"github.com/almighty/almighty-core/resource"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/suite"
 )
 
 func TestCodebaseToMap(t *testing.T) {
@@ -65,4 +73,68 @@ func TestIsValid(t *testing.T) {
 
 	cb = codebase.CodebaseContent{}
 	assert.NotNil(t, cb.IsValid())
+}
+
+type TestCodebaseRepository struct {
+	gormtestsupport.DBTestSuite
+
+	clean func()
+}
+
+func TestRunCodebaseRepository(t *testing.T) {
+	resource.Require(t, resource.Database)
+	suite.Run(t, &TestCodebaseRepository{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
+}
+
+func (test *TestCodebaseRepository) SetupTest() {
+	test.clean = cleaner.DeleteCreatedEntities(test.DB)
+}
+
+func (test *TestCodebaseRepository) TearDownTest() {
+	test.clean()
+}
+
+func newCodebase(spaceID uuid.UUID, repotype, url string) *codebase.Codebase {
+	return &codebase.Codebase{
+		SpaceID: spaceID,
+		Type:    repotype,
+		URL:     url,
+	}
+}
+
+func (test *TestCodebaseRepository) createCodebase(c *codebase.Codebase) {
+	repo := codebase.NewCodebaseRepository(test.DB)
+	err := repo.Create(context.Background(), c)
+	require.Nil(test.T(), err)
+}
+
+func (test *TestCodebaseRepository) TestListCodebases() {
+	// given
+	spaceID := uuid.NewV4()
+	repo := codebase.NewCodebaseRepository(test.DB)
+	codebase1 := newCodebase(spaceID, "git", "git@github.com:almighty/almighty-core.git")
+	codebase2 := newCodebase(spaceID, "git", "git@github.com:aslakknutsen/almighty-core.git")
+
+	test.createCodebase(codebase1)
+	test.createCodebase(codebase2)
+	// when
+	offset := 0
+	limit := 1
+	codebases, _, err := repo.List(context.Background(), spaceID, &offset, &limit)
+	// then
+	require.Nil(test.T(), err)
+	require.Equal(test.T(), 1, len(codebases))
+	assert.Equal(test.T(), codebase1.URL, codebases[0].URL)
+}
+
+func (test *TestCodebaseRepository) TestLoadCodebase() {
+	// given
+	spaceID := uuid.NewV4()
+	repo := codebase.NewCodebaseRepository(test.DB)
+	codebase := newCodebase(spaceID, "git", "git@github.com:aslakknutsen/almighty-core.git")
+	test.createCodebase(codebase)
+	// when
+	loadedCodebase, err := repo.Load(context.Background(), codebase.ID)
+	require.Nil(test.T(), err)
+	assert.Equal(test.T(), codebase.ID, loadedCodebase.ID)
 }

--- a/codebase/codebase_test.go
+++ b/codebase/codebase_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/gormtestsupport"
 	"github.com/almighty/almighty-core/resource"
+	"github.com/almighty/almighty-core/space"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/suite"
 )
@@ -110,7 +111,7 @@ func (test *TestCodebaseRepository) createCodebase(c *codebase.Codebase) {
 
 func (test *TestCodebaseRepository) TestListCodebases() {
 	// given
-	spaceID := uuid.NewV4()
+	spaceID := space.SystemSpace
 	repo := codebase.NewCodebaseRepository(test.DB)
 	codebase1 := newCodebase(spaceID, "git", "git@github.com:almighty/almighty-core.git")
 	codebase2 := newCodebase(spaceID, "git", "git@github.com:aslakknutsen/almighty-core.git")
@@ -129,7 +130,7 @@ func (test *TestCodebaseRepository) TestListCodebases() {
 
 func (test *TestCodebaseRepository) TestLoadCodebase() {
 	// given
-	spaceID := uuid.NewV4()
+	spaceID := space.SystemSpace
 	repo := codebase.NewCodebaseRepository(test.DB)
 	codebase := newCodebase(spaceID, "git", "git@github.com:aslakknutsen/almighty-core.git")
 	test.createCodebase(codebase)

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -66,6 +66,8 @@ const (
 	varTokenPublicKey                   = "token.publickey"
 	varTokenPrivateKey                  = "token.privatekey"
 	defaultConfigFile                   = "config.yaml"
+	varOpenshiftTenantMasterURL         = "openshift.tenant.masterurl"
+	varCheStarterURL                    = "chestarterurl"
 
 	// The host name exception of the api service to be taken into account
 	// when converting it to sso.demo.almighty.io
@@ -169,6 +171,8 @@ func (c *ConfigurationData) setConfigDefaults() {
 	c.v.SetDefault(varKeycloakTesUserSecret, defaultKeycloakTesUserSecret)
 	c.v.SetDefault(varKeycloakTesUser2Name, defaultKeycloakTesUser2Name)
 	c.v.SetDefault(varKeycloakTesUser2Secret, defaultKeycloakTesUser2Secret)
+	c.v.SetDefault(varOpenshiftTenantMasterURL, defaultOpenshiftTenantMasterURL)
+	c.v.SetDefault(varCheStarterURL, defaultCheStarterURL)
 }
 
 // GetPostgresHost returns the postgres host as set via default, config file, or environment variable
@@ -455,6 +459,16 @@ func (c *ConfigurationData) getKeycloakURL(req *goa.RequestData, path string) (s
 	return newURL, nil
 }
 
+// GetCheStarterURL returns the URL for the Che Starter service used by codespaces to initiate code editing
+func (c *ConfigurationData) GetCheStarterURL() string {
+	return c.v.GetString(varCheStarterURL)
+}
+
+// GetOpenshiftTenantMasterURL returns the URL for the openshift cluster where the tenant services are running
+func (c *ConfigurationData) GetOpenshiftTenantMasterURL() string {
+	return c.v.GetString(varOpenshiftTenantMasterURL)
+}
+
 // Auth-related defaults
 
 // RSAPrivateKey for signing JWT Tokens
@@ -515,6 +529,9 @@ var defaultKeycloakTesUserName = "testuser"
 var defaultKeycloakTesUserSecret = "testuser"
 var defaultKeycloakTesUser2Name = "testuser2"
 var defaultKeycloakTesUser2Secret = "testuser2"
+
+var defaultOpenshiftTenantMasterURL = "https://tsrv.devshift.net:8443"
+var defaultCheStarterURL = "che-server"
 
 // Keycloak URL to be used in dev mode. Can be overridden by setting up keycloak.url
 var devModeKeycloakURL = "http://sso.demo.almighty.io"

--- a/controller/codebase.go
+++ b/controller/codebase.go
@@ -1,0 +1,453 @@
+package controller
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/almighty/almighty-core/app"
+	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/codebase"
+	"github.com/almighty/almighty-core/jsonapi"
+	"github.com/almighty/almighty-core/log"
+	"github.com/almighty/almighty-core/login"
+	"github.com/almighty/almighty-core/rest"
+	"github.com/dgrijalva/jwt-go"
+	"github.com/goadesign/goa"
+	"github.com/goadesign/goa/middleware"
+	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+)
+
+const (
+	// APIStringTypeCodebase contains the JSON API type for codebases
+	APIStringTypeCodebase = "codebases"
+	// APIStringTypeWorkspace contains the JSON API type for worksapces
+	APIStringTypeWorkspace = "workspaces"
+)
+
+// CodebaseController implements the codebase resource.
+type CodebaseController struct {
+	*goa.Controller
+	db application.DB
+}
+
+// NewCodebaseController creates a codebase controller.
+func NewCodebaseController(service *goa.Service, db application.DB) *CodebaseController {
+	return &CodebaseController{Controller: service.NewController("CodebaseController"), db: db}
+}
+
+// Show runs the show action.
+func (c *CodebaseController) Show(ctx *app.ShowCodebaseContext) error {
+	return application.Transactional(c.db, func(appl application.Application) error {
+		c, err := appl.Codebases().Load(ctx, ctx.CodebaseID)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
+		}
+
+		res := &app.CodebaseSingle{}
+		res.Data = ConvertCodebase(ctx.RequestData, c)
+
+		return ctx.OK(res)
+	})
+}
+
+// Edit runs the show action.
+func (c *CodebaseController) Edit(ctx *app.EditCodebaseContext) error {
+	_, err := login.ContextIdentity(ctx)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(err.Error()))
+	}
+
+	var cb *codebase.Codebase
+
+	err = application.Transactional(c.db, func(appl application.Application) error {
+		cb, err = appl.Codebases().Load(ctx, ctx.CodebaseID)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
+		}
+		return nil
+	})
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
+	}
+	che := NewCheStarterClient(getClusterURL(), getNamespace(ctx))
+	workspaces, err := che.ListWorkspaces(ctx, cb.URL)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"codebaseID": cb.ID,
+			"err":        err,
+		}, "unable fetch list of workspaces")
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
+	}
+
+	var existingWorkspaces []*app.Workspace
+	for _, workspace := range workspaces {
+		openLink := rest.AbsoluteURL(ctx.RequestData, fmt.Sprintf(app.CodebaseHref(cb.ID)+"/open/%v", workspace.ID))
+		existingWorkspaces = append(existingWorkspaces, &app.Workspace{
+			Attributes: &app.WorkspaceAttributes{
+				Name:        &workspace.Name,
+				Description: &workspace.Description,
+			},
+			Links: &app.WorkspaceLinks{
+				Open: &openLink,
+			},
+		})
+	}
+
+	createLink := rest.AbsoluteURL(ctx.RequestData, app.CodebaseHref(cb.ID)+"/create")
+	resp := &app.WorkspaceList{
+		Data: existingWorkspaces,
+		Links: &app.WorkspaceEditLinks{
+			Create: &createLink,
+		},
+	}
+
+	return ctx.OK(resp)
+}
+
+// Create runs the create action.
+func (c *CodebaseController) Create(ctx *app.CreateCodebaseContext) error {
+	_, err := login.ContextIdentity(ctx)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(err.Error()))
+	}
+	var cb *codebase.Codebase
+	err = application.Transactional(c.db, func(appl application.Application) error {
+		cb, err = appl.Codebases().Load(ctx, ctx.CodebaseID)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
+		}
+		return nil
+	})
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
+	}
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
+	}
+	che := NewCheStarterClient(getClusterURL(), getNamespace(ctx))
+	workspace := WorkspaceRequest{
+		Branch:     "master",
+		Name:       "test2",
+		StackID:    "java-default",
+		Repository: cb.URL,
+	}
+	workspaceResp, err := che.CreateWorkspace(ctx, workspace)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"codebaseID": cb.ID,
+			"err":        err,
+		}, "unable to create workspaces")
+		if werr, ok := err.(*workspaceError); ok {
+			fmt.Println(werr.String())
+		}
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
+	}
+
+	resp := &app.WorkspaceOpen{
+		Links: &app.WorkspaceOpenLinks{
+			Open: &workspaceResp.WorkspaceIDEURL,
+		},
+	}
+	return ctx.OK(resp)
+}
+
+// Open runs the open action.
+func (c *CodebaseController) Open(ctx *app.OpenCodebaseContext) error {
+	_, err := login.ContextIdentity(ctx)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(err.Error()))
+	}
+	var cb *codebase.Codebase
+	err = application.Transactional(c.db, func(appl application.Application) error {
+		cb, err = appl.Codebases().Load(ctx, ctx.CodebaseID)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
+		}
+		return nil
+	})
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
+	}
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
+	}
+	che := NewCheStarterClient(getClusterURL(), getNamespace(ctx))
+	workspace := WorkspaceRequest{
+		ID: ctx.WorkspaceID,
+	}
+	workspaceResp, err := che.CreateWorkspace(ctx, workspace)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"codebaseID": cb.ID,
+			"err":        err,
+		}, "unable to open workspaces")
+		if werr, ok := err.(*workspaceError); ok {
+			fmt.Println(werr.String())
+		}
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
+	}
+
+	resp := &app.WorkspaceOpen{
+		Links: &app.WorkspaceOpenLinks{
+			Open: &workspaceResp.WorkspaceIDEURL,
+		},
+	}
+	return ctx.OK(resp)
+}
+
+// CodebaseConvertFunc is a open ended function to add additional links/data/relations to a Codebase during
+// convertion from internal to API
+type CodebaseConvertFunc func(*goa.RequestData, *codebase.Codebase, *app.Codebase)
+
+// ConvertCodebases converts between internal and external REST representation
+func ConvertCodebases(request *goa.RequestData, codebases []*codebase.Codebase, additional ...CodebaseConvertFunc) []*app.Codebase {
+	var is = []*app.Codebase{}
+	for _, i := range codebases {
+		is = append(is, ConvertCodebase(request, i, additional...))
+	}
+	return is
+}
+
+// ConvertCodebase converts between internal and external REST representation
+func ConvertCodebase(request *goa.RequestData, codebase *codebase.Codebase, additional ...CodebaseConvertFunc) *app.Codebase {
+	codebaseType := APIStringTypeCodebase
+	spaceType := APIStringTypeSpace
+
+	spaceID := codebase.SpaceID.String()
+
+	selfURL := rest.AbsoluteURL(request, app.CodebaseHref(codebase.ID))
+	editURL := rest.AbsoluteURL(request, app.CodebaseHref(codebase.ID)+"/edit")
+	spaceSelfURL := rest.AbsoluteURL(request, app.SpaceHref(spaceID))
+
+	i := &app.Codebase{
+		Type: codebaseType,
+		ID:   &codebase.ID,
+		Attributes: &app.CodebaseAttributes{
+			CreatedAt: &codebase.CreatedAt,
+			Type:      &codebase.Type,
+			URL:       &codebase.URL,
+		},
+		Relationships: &app.CodebaseRelations{
+			Space: &app.RelationGeneric{
+				Data: &app.GenericData{
+					Type: &spaceType,
+					ID:   &spaceID,
+				},
+				Links: &app.GenericLinks{
+					Self: &spaceSelfURL,
+				},
+			},
+		},
+		Links: &app.CodebaseLinks{
+			Self: &selfURL,
+			Edit: &editURL,
+		},
+	}
+	for _, add := range additional {
+		add(request, codebase, i)
+	}
+	return i
+}
+
+// TODO: We need to dynamically get the real che namespace name from the tenant namespace from
+// somewhere more sensible then the token/generate/guess route.
+func getNamespace(ctx context.Context) string {
+	token := goajwt.ContextJWT(ctx)
+	if claims, ok := token.Claims.(jwt.MapClaims); ok {
+		email := claims["email"].(string)
+		return strings.Split(email, "@")[0] + "-dsaas-che"
+	}
+	return ""
+}
+
+func getClusterURL() *url.URL {
+	clusterURL, _ := url.Parse("https://tsrv.devshift.net:8443")
+	return clusterURL
+}
+
+// NewCheStarterClient is a helper function to create a new CheStarter client
+// Uses http.DefaultClient
+func NewCheStarterClient(masterURL *url.URL, namespace string) *CheStarterClient {
+	return &CheStarterClient{masterURL: masterURL, namespace: namespace, client: http.DefaultClient}
+}
+
+// CheStarterClient describes the REST interface between Platform and Che Starter
+type CheStarterClient struct {
+	masterURL *url.URL
+	namespace string
+	client    *http.Client
+}
+
+func (cs *CheStarterClient) targetURL(resource string) string {
+	return fmt.Sprintf("http://che-starter.prod-preview.openshift.io/%v?masterUrl=%v&namespace=%v", resource, cs.masterURL.String(), cs.namespace)
+}
+
+func (cs *CheStarterClient) setHeaders(ctx context.Context, req *http.Request) {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+goajwt.ContextJWT(ctx).Raw)
+	req.Header.Set(middleware.RequestIDHeader, middleware.ContextRequestID(ctx))
+}
+
+// ListWorkspaces lists the available workspaces for a given user
+func (cs *CheStarterClient) ListWorkspaces(ctx context.Context, repository string) ([]WorkspaceResponse, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf(cs.targetURL("workspace")+"&repository=%v", repository), nil)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"repository": repository,
+			"err":        err,
+		}, "failed to create request object")
+		return nil, err
+	}
+	cs.setHeaders(ctx, req)
+
+	if log.IsDebug() {
+		b, _ := httputil.DumpRequest(req, true)
+		log.Debug(ctx, map[string]interface{}{
+			"request": string(b),
+		}, "request object")
+	}
+
+	resp, err := cs.client.Do(req)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"repository": repository,
+			"err":        err,
+		}, "failed to list workspace for repository")
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		workspaceErr := workspaceError{}
+		err = json.NewDecoder(resp.Body).Decode(&workspaceErr)
+		if err != nil {
+			log.Error(ctx, map[string]interface{}{
+				"repository": repository,
+				"err":        err,
+			}, "failed to decode error response from list workspace for repository")
+			return nil, err
+		}
+		log.Error(ctx, map[string]interface{}{
+			"repository": repository,
+			"err":        workspaceErr.String(),
+		}, "failed to execute list workspace for repository")
+		return nil, &workspaceErr
+	}
+
+	workspaceResp := []WorkspaceResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&workspaceResp)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"repository": repository,
+			"err":        err,
+		}, "failed to decode response from list workspace for repository")
+		return nil, err
+	}
+	return workspaceResp, nil
+}
+
+// CreateWorkspace creates a new Che Workspace based on a repository
+func (cs *CheStarterClient) CreateWorkspace(ctx context.Context, workspace WorkspaceRequest) (*WorkspaceResponse, error) {
+	body, err := json.Marshal(&workspace)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"workspaceID": workspace.ID,
+			"err":         err,
+		}, "failed to create request object")
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", cs.targetURL("workspace"), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	cs.setHeaders(ctx, req)
+
+	if log.IsDebug() {
+		b, _ := httputil.DumpRequest(req, true)
+		log.Debug(ctx, map[string]interface{}{
+			"request": string(b),
+		}, "request object")
+	}
+
+	resp, err := cs.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		workspaceErr := workspaceError{}
+		err = json.NewDecoder(resp.Body).Decode(&workspaceErr)
+		if err != nil {
+			log.Error(ctx, map[string]interface{}{
+				"workspaceID": workspace.ID,
+				"err":         err,
+			}, "failed to decode error response from create workspace for repository")
+			return nil, err
+		}
+		log.Error(ctx, map[string]interface{}{
+			"workspaceID": workspace.ID,
+			"err":         workspaceErr.String(),
+		}, "failed to execute create workspace for repository")
+		return nil, &workspaceErr
+	}
+
+	workspaceResp := WorkspaceResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&workspaceResp)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"workspaceID": workspace.ID,
+			"err":         err,
+		}, "failed to decode response from create workspace for repository")
+		return nil, err
+	}
+	return &workspaceResp, nil
+}
+
+// WorkspaceRequest represents a create workspace request body
+type WorkspaceRequest struct {
+	ID         string `json:"id,omitempty"`
+	Branch     string `json:"branch,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Repository string `json:"repo,omitempty"`
+	StackID    string `json:"stack,omitempty"`
+}
+
+// WorkspaceResponse represents a create workspace response body
+type WorkspaceResponse struct {
+	ID              string `json:"id"`
+	Branch          string `json:"branch"`
+	Description     string `json:"description"`
+	Location        string `json:"location"`
+	Login           string `json:"login"`
+	Name            string `json:"name"`
+	Repository      string `json:"repository"`
+	Status          string `json:"status"`
+	WorkspaceIDEURL string `json:"workspaceIdeUrl"`
+}
+
+type workspaceError struct {
+	Status    int    `json:"status"`
+	ErrorMsg  string `json:"error"`
+	Message   string `json:"message"`
+	Timestamp string `json:"timeStamp"`
+	Trace     string `json:"trace"`
+}
+
+func (err *workspaceError) Error() string {
+	return err.ErrorMsg
+}
+
+func (err *workspaceError) String() string {
+	return fmt.Sprintf("Status %v Error %v Message %v Trace\n%v", err.Status, err.ErrorMsg, err.ErrorMsg, err.Trace)
+}

--- a/controller/codebase_blackbox_test.go
+++ b/controller/codebase_blackbox_test.go
@@ -49,14 +49,14 @@ func (s *TestCodebaseREST) TearDownTest() {
 
 func (s *TestCodebaseREST) UnsecuredController() (*goa.Service, *CodebaseController) {
 	svc := goa.New("Codebases-service")
-	return svc, NewCodebaseController(svc, s.db)
+	return svc, NewCodebaseController(svc, s.db, s.Configuration)
 }
 
 func (s *TestCodebaseREST) SecuredControllers(identity account.Identity) (*goa.Service, *CodebaseController) {
 	pub, _ := almtoken.ParsePublicKey([]byte(almtoken.RSAPublicKey))
 
 	svc := testsupport.ServiceAsUser("Codebase-Service", almtoken.NewManager(pub), identity)
-	return svc, controller.NewCodebaseController(svc, s.db)
+	return svc, controller.NewCodebaseController(svc, s.db, s.Configuration)
 }
 
 func (s *TestCodebaseREST) TestSuccessShowCodebaseWithoutAuth() {

--- a/controller/codebase_blackbox_test.go
+++ b/controller/codebase_blackbox_test.go
@@ -1,0 +1,101 @@
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/almighty/almighty-core/app/test"
+	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/codebase"
+
+	"github.com/almighty/almighty-core/account"
+	"github.com/almighty/almighty-core/controller"
+	. "github.com/almighty/almighty-core/controller"
+	"github.com/almighty/almighty-core/gormapplication"
+	"github.com/almighty/almighty-core/gormsupport/cleaner"
+	"github.com/almighty/almighty-core/gormtestsupport"
+	"github.com/almighty/almighty-core/resource"
+	"github.com/almighty/almighty-core/space"
+	testsupport "github.com/almighty/almighty-core/test"
+	almtoken "github.com/almighty/almighty-core/token"
+	"github.com/goadesign/goa"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+// a normal test function that will kick off TestSuiteCodebases
+func TestRunCodebasesTest(t *testing.T) {
+	resource.Require(t, resource.Database)
+	suite.Run(t, &TestCodebaseREST{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
+}
+
+// ========== TestCodebaseREST struct that implements SetupSuite, TearDownSuite, SetupTest, TearDownTest ==========
+type TestCodebaseREST struct {
+	gormtestsupport.DBTestSuite
+
+	db    *gormapplication.GormDB
+	clean func()
+}
+
+func (s *TestCodebaseREST) SetupTest() {
+	s.db = gormapplication.NewGormDB(s.DB)
+	s.clean = cleaner.DeleteCreatedEntities(s.DB)
+}
+
+func (s *TestCodebaseREST) TearDownTest() {
+	s.clean()
+}
+
+func (s *TestCodebaseREST) UnsecuredController() (*goa.Service, *CodebaseController) {
+	svc := goa.New("Codebases-service")
+	return svc, NewCodebaseController(svc, s.db)
+}
+
+func (s *TestCodebaseREST) SecuredControllers(identity account.Identity) (*goa.Service, *CodebaseController) {
+	pub, _ := almtoken.ParsePublicKey([]byte(almtoken.RSAPublicKey))
+
+	svc := testsupport.ServiceAsUser("Codebase-Service", almtoken.NewManager(pub), identity)
+	return svc, controller.NewCodebaseController(svc, s.db)
+}
+
+func (s *TestCodebaseREST) TestSuccessShowCodebaseWithoutAuth() {
+	t := s.T()
+	resource.Require(t, resource.Database)
+
+	cb := requireSpaceAndCodebase(t, s.db)
+
+	svc, ctrl := s.UnsecuredController()
+	_, cbresp := test.ShowCodebaseOK(t, svc.Context, svc, ctrl, cb.ID)
+
+	assert.NotNil(t, cbresp)
+	assert.Equal(t, cb.ID, *cbresp.Data.ID)
+	assert.Equal(t, cb.Type, *cbresp.Data.Attributes.Type)
+	assert.Equal(t, cb.URL, *cbresp.Data.Attributes.URL)
+
+}
+
+func requireSpaceAndCodebase(t *testing.T, db *gormapplication.GormDB) *codebase.Codebase {
+	var c *codebase.Codebase
+	application.Transactional(db, func(appl application.Application) error {
+
+		s := &space.Space{
+			Name: "Test Space 1" + uuid.NewV4().String(),
+		}
+		p, err := appl.Spaces().Create(context.Background(), s)
+		if err != nil {
+			t.Error(err)
+		}
+		c = &codebase.Codebase{
+			SpaceID: p.ID,
+			Type:    "git",
+			URL:     "https://github.com/almighty/almighty-core.git",
+		}
+		err = appl.Codebases().Create(context.Background(), c)
+		if err != nil {
+			t.Error(err)
+		}
+		return nil
+	})
+	return c
+}

--- a/controller/space.go
+++ b/controller/space.go
@@ -19,7 +19,9 @@ import (
 )
 
 const (
-	spaceResourceType = "space"
+	// APIStringTypeCodebase contains the JSON API type for codebases
+	APIStringTypeSpace = "spaces"
+	spaceResourceType  = "space"
 )
 
 var scopes = []string{"read:space", "admin:space"}
@@ -309,9 +311,11 @@ func ConvertSpace(request *goa.RequestData, p *space.Space, additional ...SpaceC
 	selfURL := rest.AbsoluteURL(request, app.SpaceHref(p.ID))
 	relatedIterationList := rest.AbsoluteURL(request, fmt.Sprintf("/api/spaces/%s/iterations", p.ID.String()))
 	relatedAreaList := rest.AbsoluteURL(request, fmt.Sprintf("/api/spaces/%s/areas", p.ID.String()))
+	relatedCodebasesList := rest.AbsoluteURL(request, fmt.Sprintf("/api/spaces/%s/codebases", p.ID.String()))
+
 	return &app.Space{
 		ID:   &p.ID,
-		Type: "spaces",
+		Type: APIStringTypeSpace,
 		Attributes: &app.SpaceAttributes{
 			Name:        &p.Name,
 			Description: &p.Description,
@@ -337,6 +341,11 @@ func ConvertSpace(request *goa.RequestData, p *space.Space, additional ...SpaceC
 			Areas: &app.RelationGeneric{
 				Links: &app.GenericLinks{
 					Related: &relatedAreaList,
+				},
+			},
+			Codebases: &app.RelationGeneric{
+				Links: &app.GenericLinks{
+					Related: &relatedCodebasesList,
 				},
 			},
 		},

--- a/controller/space_codebases.go
+++ b/controller/space_codebases.go
@@ -1,0 +1,101 @@
+package controller
+
+import (
+	"github.com/almighty/almighty-core/app"
+	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/codebase"
+	"github.com/almighty/almighty-core/errors"
+	"github.com/almighty/almighty-core/jsonapi"
+	"github.com/almighty/almighty-core/login"
+	"github.com/almighty/almighty-core/rest"
+	"github.com/goadesign/goa"
+	uuid "github.com/satori/go.uuid"
+)
+
+// SpaceCodebasesController implements the space-codebases resource.
+type SpaceCodebasesController struct {
+	*goa.Controller
+	db application.DB
+}
+
+// NewSpaceCodebasesController creates a space-codebases controller.
+func NewSpaceCodebasesController(service *goa.Service, db application.DB) *SpaceCodebasesController {
+	return &SpaceCodebasesController{Controller: service.NewController("SpaceCodebasesController"), db: db}
+}
+
+// Create runs the create action.
+func (c *SpaceCodebasesController) Create(ctx *app.CreateSpaceCodebasesContext) error {
+	_, err := login.ContextIdentity(ctx)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(err.Error()))
+	}
+	spaceID, err := uuid.FromString(ctx.ID)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
+	}
+
+	// Validate Request
+	if ctx.Payload.Data == nil {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("data", nil).Expected("not nil"))
+	}
+	reqIter := ctx.Payload.Data
+	if reqIter.Attributes.Type == nil {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("data.attributes.type", nil).Expected("not nil"))
+	}
+	if reqIter.Attributes.URL == nil {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("data.attributes.url", nil).Expected("not nil"))
+	}
+
+	return application.Transactional(c.db, func(appl application.Application) error {
+		_, err = appl.Spaces().Load(ctx, spaceID)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
+		}
+
+		newCodeBase := codebase.Codebase{
+			SpaceID: spaceID,
+			Type:    *reqIter.Attributes.Type,
+			URL:     *reqIter.Attributes.URL,
+		}
+		err = appl.Codebases().Create(ctx, &newCodeBase)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, err)
+		}
+
+		res := &app.CodebaseSingle{
+			Data: ConvertCodebase(ctx.RequestData, &newCodeBase),
+		}
+		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData, app.CodebaseHref(res.Data.ID)))
+		return ctx.Created(res)
+	})
+}
+
+// List runs the list action.
+func (c *SpaceCodebasesController) List(ctx *app.ListSpaceCodebasesContext) error {
+	offset, limit := computePagingLimts(ctx.PageOffset, ctx.PageLimit)
+	spaceID, err := uuid.FromString(ctx.ID)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
+	}
+	return application.Transactional(c.db, func(appl application.Application) error {
+		_, err = appl.Spaces().Load(ctx, spaceID)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
+		}
+
+		res := &app.CodebaseList{}
+		res.Data = []*app.Codebase{}
+
+		codebases, tc, err := appl.Codebases().List(ctx, spaceID, &offset, &limit)
+		count := int(tc)
+		if err != nil {
+			return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
+		}
+		res.Meta = &app.CodebaseListMeta{TotalCount: count}
+		res.Data = ConvertCodebases(ctx.RequestData, codebases)
+		res.Links = &app.PagingLinks{}
+		setPagingLinks(res.Links, buildAbsoluteURL(ctx.RequestData), len(codebases), offset, limit, count)
+
+		return ctx.OK(res)
+	})
+}

--- a/controller/space_codebases_test.go
+++ b/controller/space_codebases_test.go
@@ -1,0 +1,208 @@
+package controller_test
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/almighty/almighty-core/app"
+	"github.com/almighty/almighty-core/app/test"
+	"github.com/almighty/almighty-core/application"
+	. "github.com/almighty/almighty-core/controller"
+	"github.com/almighty/almighty-core/gormapplication"
+	"github.com/almighty/almighty-core/gormsupport/cleaner"
+	"github.com/almighty/almighty-core/gormtestsupport"
+
+	"github.com/almighty/almighty-core/resource"
+	"github.com/almighty/almighty-core/space"
+	testsupport "github.com/almighty/almighty-core/test"
+	almtoken "github.com/almighty/almighty-core/token"
+	"github.com/goadesign/goa"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type TestSpaceCodebaseREST struct {
+	gormtestsupport.DBTestSuite
+
+	db    *gormapplication.GormDB
+	clean func()
+}
+
+func TestRunSpaceCodebaseREST(t *testing.T) {
+	pwd, err := os.Getwd()
+	if err != nil {
+		require.Nil(t, err)
+	}
+	suite.Run(t, &TestSpaceCodebaseREST{DBTestSuite: gormtestsupport.NewDBTestSuite(pwd + "/../config.yaml")})
+}
+
+func (rest *TestSpaceCodebaseREST) SetupTest() {
+	rest.db = gormapplication.NewGormDB(rest.DB)
+	rest.clean = cleaner.DeleteCreatedEntities(rest.DB)
+}
+
+func (rest *TestSpaceCodebaseREST) TearDownTest() {
+	rest.clean()
+}
+
+func (rest *TestSpaceCodebaseREST) SecuredController() (*goa.Service, *SpaceCodebasesController) {
+	pub, _ := almtoken.ParsePublicKey([]byte(almtoken.RSAPublicKey))
+	//priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
+
+	svc := testsupport.ServiceAsUser("SpaceCodebase-Service", almtoken.NewManager(pub), testsupport.TestIdentity)
+	return svc, NewSpaceCodebasesController(svc, rest.db)
+}
+
+func (rest *TestSpaceCodebaseREST) UnSecuredController() (*goa.Service, *SpaceCodebasesController) {
+	svc := goa.New("SpaceCodebase-Service")
+	return svc, NewSpaceCodebasesController(svc, rest.db)
+}
+
+func (rest *TestSpaceCodebaseREST) TestSuccessCreateCodebase() {
+	t := rest.T()
+
+	resource.Require(t, resource.Database)
+
+	repo := "https://github.com/almighty/almighty-core.git"
+
+	var p *space.Space
+	ci := createSpaceCodebase(repo)
+
+	application.Transactional(rest.db, func(app application.Application) error {
+		repo := app.Spaces()
+		newSpace := &space.Space{
+			Name: "Test 1" + uuid.NewV4().String(),
+		}
+		p, _ = repo.Create(context.Background(), newSpace)
+		return nil
+	})
+	svc, ctrl := rest.SecuredController()
+	_, c := test.CreateSpaceCodebasesCreated(t, svc.Context, svc, ctrl, p.ID.String(), ci)
+	require.NotNil(t, c.Data.ID)
+	require.NotNil(t, c.Data.Relationships.Space)
+	assert.Equal(t, p.ID.String(), *c.Data.Relationships.Space.Data.ID)
+	assert.Equal(t, repo, *c.Data.Attributes.URL)
+}
+
+func (rest *TestSpaceCodebaseREST) TestListCodebase() {
+	t := rest.T()
+	resource.Require(t, resource.Database)
+
+	// Create a new space where we'll create 3 areas
+	var s *space.Space
+
+	// Create another space where we'll create 1 area.
+	var anotherSpace *space.Space
+
+	application.Transactional(rest.db, func(app application.Application) error {
+		var err error
+		repo := app.Spaces()
+		newSpace := &space.Space{
+			Name: "Test Space 1" + uuid.NewV4().String(),
+		}
+		s, err = repo.Create(context.Background(), newSpace)
+		require.Nil(t, err)
+
+		newSpace = &space.Space{
+			Name: "Another space" + uuid.NewV4().String(),
+		}
+		anotherSpace, err = repo.Create(context.Background(), newSpace)
+		require.Nil(t, err)
+		return nil
+	})
+
+	repo := "https://github.com/almighty/almighty-core.git"
+
+	svc, ctrl := rest.SecuredController()
+	spaceId := s.ID
+	anotherSpaceId := anotherSpace.ID
+	var createdSpacesUuids1 []uuid.UUID
+
+	for i := 0; i < 3; i++ {
+		repoURL := strings.Replace(repo, "core", "core"+strconv.Itoa(i), -1)
+		spaceCodebaseContext := createSpaceCodebase(repoURL)
+		_, c := test.CreateSpaceCodebasesCreated(t, svc.Context, svc, ctrl, spaceId.String(), spaceCodebaseContext)
+		require.NotNil(t, c.Data.ID)
+		require.NotNil(t, c.Data.Relationships.Space)
+		createdSpacesUuids1 = append(createdSpacesUuids1, *c.Data.ID)
+	}
+
+	otherRepo := "https://github.com/fabric8io/fabric8-planner.git"
+	anotherSpaceCodebaseContext := createSpaceCodebase(otherRepo)
+	_, createdCodebase := test.CreateSpaceCodebasesCreated(t, svc.Context, svc, ctrl, anotherSpaceId.String(), anotherSpaceCodebaseContext)
+	require.NotNil(t, createdCodebase)
+
+	offset := "0"
+	limit := 100
+
+	svc, ctrl = rest.UnSecuredController()
+	_, codebaseList := test.ListSpaceCodebasesOK(t, svc.Context, svc, ctrl, spaceId.String(), &limit, &offset)
+	assert.Len(t, codebaseList.Data, 3)
+	for i := 0; i < len(createdSpacesUuids1); i++ {
+		assert.NotNil(t, searchInCodebaseSlice(createdSpacesUuids1[i], codebaseList))
+	}
+
+	_, anotherCodebaseList := test.ListSpaceCodebasesOK(t, svc.Context, svc, ctrl, anotherSpaceId.String(), &limit, &offset)
+	assert.Len(t, anotherCodebaseList.Data, 1)
+	assert.Equal(t, anotherCodebaseList.Data[0].ID, createdCodebase.Data.ID)
+
+}
+
+func (rest *TestSpaceCodebaseREST) TestCreateCodebaseMissingSpace() {
+	t := rest.T()
+	resource.Require(t, resource.Database)
+
+	ci := createSpaceCodebase("https://github.com/fabric8io/fabric8-planner.git")
+
+	svc, ctrl := rest.SecuredController()
+	test.CreateSpaceCodebasesNotFound(t, svc.Context, svc, ctrl, uuid.NewV4().String(), ci)
+}
+
+func (rest *TestSpaceCodebaseREST) TestFailCreateCodebaseNotAuthorized() {
+	t := rest.T()
+	resource.Require(t, resource.Database)
+
+	ci := createSpaceCodebase("https://github.com/fabric8io/fabric8-planner.git")
+
+	svc, ctrl := rest.UnSecuredController()
+	test.CreateSpaceCodebasesUnauthorized(t, svc.Context, svc, ctrl, uuid.NewV4().String(), ci)
+}
+
+func (rest *TestSpaceCodebaseREST) TestFailListCodebaseByMissingSpace() {
+	t := rest.T()
+	resource.Require(t, resource.Database)
+
+	offset := "0"
+	limit := 100
+
+	svc, ctrl := rest.UnSecuredController()
+	test.ListSpaceCodebasesNotFound(t, svc.Context, svc, ctrl, uuid.NewV4().String(), &limit, &offset)
+}
+
+func searchInCodebaseSlice(searchKey uuid.UUID, codebaseList *app.CodebaseList) *app.Codebase {
+	for i := 0; i < len(codebaseList.Data); i++ {
+		if searchKey == *codebaseList.Data[i].ID {
+			return codebaseList.Data[i]
+		}
+	}
+	return nil
+}
+
+func createSpaceCodebase(url string) *app.CreateSpaceCodebasesPayload {
+	repoType := "git"
+	return &app.CreateSpaceCodebasesPayload{
+		Data: &app.Codebase{
+			Type: APIStringTypeCodebase,
+			Attributes: &app.CodebaseAttributes{
+				Type: &repoType,
+				URL:  &url,
+			},
+		},
+	}
+}

--- a/controller/space_codebases_test.go
+++ b/controller/space_codebases_test.go
@@ -94,10 +94,10 @@ func (rest *TestSpaceCodebaseREST) TestListCodebase() {
 	t := rest.T()
 	resource.Require(t, resource.Database)
 
-	// Create a new space where we'll create 3 areas
+	// Create a new space where we'll create 3 codebase
 	var s *space.Space
 
-	// Create another space where we'll create 1 area.
+	// Create another space where we'll create 1 codebase.
 	var anotherSpace *space.Space
 
 	application.Transactional(rest.db, func(app application.Application) error {
@@ -149,7 +149,7 @@ func (rest *TestSpaceCodebaseREST) TestListCodebase() {
 	}
 
 	_, anotherCodebaseList := test.ListSpaceCodebasesOK(t, svc.Context, svc, ctrl, anotherSpaceId.String(), &limit, &offset)
-	assert.Len(t, anotherCodebaseList.Data, 1)
+	require.Len(t, anotherCodebaseList.Data, 1)
 	assert.Equal(t, anotherCodebaseList.Data[0].ID, createdCodebase.Data.ID)
 
 }

--- a/controller/user_test.go
+++ b/controller/user_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/area"
 	"github.com/almighty/almighty-core/auth"
+	"github.com/almighty/almighty-core/codebase"
 	"github.com/almighty/almighty-core/comment"
 	. "github.com/almighty/almighty-core/controller"
 	"github.com/almighty/almighty-core/iteration"
@@ -252,6 +253,11 @@ func (g *GormTestBase) Areas() area.Repository {
 }
 
 func (g *GormTestBase) OauthStates() auth.OauthStateReferenceRepository {
+	return nil
+}
+
+// Codebases returns a codebase repository
+func (g *GormTestBase) Codebases() codebase.Repository {
 	return nil
 }
 

--- a/design/api.go
+++ b/design/api.go
@@ -26,6 +26,12 @@ var _ = a.API("alm", func() {
 		a.Credentials()
 	})
 
+	a.Trait("GenericLinksTrait", func() {
+		a.Attribute("self", d.String)
+		a.Attribute("related", d.String)
+		a.Attribute("meta", a.HashOf(d.String, d.Any))
+	})
+
 	a.Trait("jsonapi-media-type", func() {
 		a.ContentType("application/vnd.api+json")
 	})

--- a/design/codebases.go
+++ b/design/codebases.go
@@ -1,0 +1,213 @@
+package design
+
+import (
+	d "github.com/goadesign/goa/design"
+	a "github.com/goadesign/goa/design/apidsl"
+)
+
+var codebase = a.Type("Codebase", func() {
+	a.Description(`JSONAPI store for the data of a codebase.  See also http://jsonapi.org/format/#document-resource-object`)
+	a.Attribute("type", d.String, func() {
+		a.Enum("codebases")
+	})
+	a.Attribute("id", d.UUID, "ID of codebase", func() {
+		a.Example("40bbdd3d-8b5d-4fd6-ac90-7236b669af04")
+	})
+	a.Attribute("attributes", codebaseAttributes)
+	a.Attribute("relationships", codebaseRelationships)
+	a.Attribute("links", codebaseLinks)
+	a.Required("type", "attributes")
+})
+
+var codebaseAttributes = a.Type("CodebaseAttributes", func() {
+	a.Description(`JSONAPI store for all the "attributes" of a codebase. +See also see http://jsonapi.org/format/#document-resource-object-attributes`)
+	a.Attribute("type", d.String, "The codebase type", func() {
+		a.Example("git")
+	})
+	a.Attribute("url", d.String, "The URL of the codebase ", func() {
+		a.Example("git@github.com:almighty/almighty-core.git")
+	})
+	a.Attribute("createdAt", d.DateTime, "When the codebase was created", func() {
+		a.Example("2016-11-29T23:18:14Z")
+	})
+})
+
+var codebaseLinks = a.Type("CodebaseLinks", func() {
+	a.UseTrait("GenericLinksTrait")
+	a.Attribute("edit", d.String)
+})
+var codebaseRelationships = a.Type("CodebaseRelations", func() {
+	a.Attribute("space", relationGeneric, "This defines the owning space")
+})
+
+var codebaseListMeta = a.Type("CodebaseListMeta", func() {
+	a.Attribute("totalCount", d.Integer)
+	a.Required("totalCount")
+})
+
+var workspace = a.Type("Workspace", func() {
+	a.Description(`JSONAPI store for the data of a workspace.  See also http://jsonapi.org/format/#document-resource-object`)
+	a.Attribute("type", d.String, func() {
+		a.Enum("workspaces")
+	})
+	a.Attribute("attributes", workspaceAttributes)
+	a.Attribute("links", workspaceLinks)
+	a.Required("type", "attributes")
+})
+
+var workspaceAttributes = a.Type("WorkspaceAttributes", func() {
+	a.Description(`JSONAPI store for all the "attributes" of a workspace. +See also see http://jsonapi.org/format/#document-resource-object-attributes`)
+	a.Attribute("name", d.String, "The workspace name", func() {
+		a.Example("test")
+	})
+	a.Attribute("description", d.String, "The URL of the codebase ", func() {
+		a.Example("")
+	})
+})
+
+var workspaceLinks = a.Type("WorkspaceLinks", func() {
+	a.Attribute("open", d.String)
+})
+
+var workspaceEditLinks = a.Type("WorkspaceEditLinks", func() {
+	a.Attribute("create", d.String)
+})
+
+var workspaceOpenLinks = a.Type("WorkspaceOpenLinks", func() {
+	a.Attribute("open", d.String)
+})
+
+var codebaseList = JSONList(
+	"Codebase", "Holds the list of codebases",
+	codebase,
+	pagingLinks,
+	codebaseListMeta)
+
+var codebaseSingle = JSONSingle(
+	"Codebase", "Holds a single codebase",
+	codebase,
+	nil)
+
+var workspaceList = JSONList(
+	"Workspace", "Holds the list of workspaces related to a codebase",
+	workspace,
+	workspaceEditLinks,
+	nil)
+
+var workspaceOpen = a.MediaType("application/vnd.workspaceopen+json", func() {
+	a.TypeName("WorkspaceOpen")
+	a.Description(`JSONAPI store for the links of a workspace.  See also http://jsonapi.org/format/#document-resource-object`)
+	a.Attribute("links", workspaceOpenLinks)
+	a.View("default", func() {
+		a.Attribute("links")
+	})
+})
+
+// new version of "list" for migration
+var _ = a.Resource("codebase", func() {
+	a.BasePath("/codebases")
+	a.Action("show", func() {
+		a.Routing(
+			a.GET("/:codebaseID"),
+		)
+		a.Description("Retrieve codebase with given id.")
+		a.Params(func() {
+			a.Param("codebaseID", d.UUID, "Codebase Identifier")
+		})
+		a.Response(d.OK, func() {
+			a.Media(codebaseSingle)
+		})
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+	})
+	a.Action("edit", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.GET("/:codebaseID/edit"),
+		)
+		a.Description("Trigger edit of a given codebase.")
+		a.Params(func() {
+			a.Param("codebaseID", d.UUID, "Codebase Identifier")
+		})
+		a.Response(d.OK, func() {
+			a.Media(workspaceList)
+		})
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+	})
+	a.Action("create", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.POST("/:codebaseID/create"),
+		)
+		a.Description("Trigger create a worksapce for a codebase.")
+		a.Params(func() {
+			a.Param("codebaseID", d.UUID, "Codebase Identifier")
+		})
+		a.Response(d.OK, func() {
+			a.Media(workspaceOpen)
+		})
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+	})
+	a.Action("open", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.POST("/:codebaseID/open/:workspaceID"),
+		)
+		a.Description("Trigger open of a given worksapce for a codebase.")
+		a.Params(func() {
+			a.Param("codebaseID", d.UUID, "Codebase Identifier")
+			a.Param("workspaceID", d.String, "Workspace Identifier")
+		})
+		a.Response(d.OK, func() {
+			a.Media(workspaceOpen)
+		})
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+	})
+})
+
+// new version of "list" for migration
+var _ = a.Resource("space_codebases", func() {
+	a.Parent("space")
+
+	a.Action("list", func() {
+		a.Routing(
+			a.GET("codebases"),
+		)
+		a.Description("List codebases.")
+		a.Params(func() {
+			a.Param("page[offset]", d.String, "Paging start position")
+			a.Param("page[limit]", d.Integer, "Paging size")
+		})
+		a.Response(d.OK, func() {
+			a.Media(codebaseList)
+		})
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+	})
+	a.Action("create", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.POST("codebases"),
+		)
+		a.Description("Create codebase.")
+		a.Payload(codebaseSingle)
+		a.Response(d.Created, "/codebases/.*", func() {
+			a.Media(codebaseSingle)
+		})
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+	})
+})

--- a/design/spaces.go
+++ b/design/spaces.go
@@ -25,6 +25,7 @@ var spaceRelationships = a.Type("SpaceRelationships", func() {
 	a.Attribute("workitemlinktypes", relationGeneric, "Space can have one or many work item link types")
 	a.Attribute("workitemtypes", relationGeneric, "Space can have one or many work item types")
 	a.Attribute("workitems", relationGeneric, "Space can have one or many work items")
+	a.Attribute("codebases", relationGeneric, "Space can have one or many codebases")
 })
 
 var spaceOwnedBy = a.Type("SpaceOwnedBy", func() {

--- a/design/workitems.go
+++ b/design/workitems.go
@@ -136,7 +136,6 @@ var _ = a.Resource("workitem", func() {
 			a.Param("filter[workitemtype]", d.UUID, "ID of work item type to filter work items by")
 			a.Param("filter[area]", d.String, "AreaID to filter work items")
 			a.Param("filter[workitemstate]", d.String, "work item state to filter work items by")
-
 		})
 		a.Response(d.OK, func() {
 			a.Media(workItemList)

--- a/gormapplication/application.go
+++ b/gormapplication/application.go
@@ -8,6 +8,7 @@ import (
 	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/area"
 	"github.com/almighty/almighty-core/auth"
+	"github.com/almighty/almighty-core/codebase"
 	"github.com/almighty/almighty-core/comment"
 	"github.com/almighty/almighty-core/iteration"
 	"github.com/almighty/almighty-core/remoteworkitem"
@@ -36,7 +37,7 @@ const (
 	TXIsoLevelRepeatableRead
 
 	// TXIsoLevelSerializable means "All statements of the current transaction can only see rows committed
-	// before the first query or data-modification statement was executed in this transaction.
+	w // before the first query or data-modification statement was executed in this transaction.
 	// If a pattern of reads and writes among concurrent serializable transactions would create a
 	// situation which could not have occurred for any serial (one-at-a-time) execution of those
 	// transactions, one of them will be rolled back with a serialization_failure error."
@@ -135,6 +136,11 @@ func (g *GormBase) Areas() area.Repository {
 // OauthStates returns an oauth state reference repository
 func (g *GormBase) OauthStates() auth.OauthStateReferenceRepository {
 	return auth.NewOauthStateReferenceRepository(g.db)
+}
+
+// Codebases returns a codebase repository
+func (g *GormBase) Codebases() codebase.Repository {
+	return codebase.NewCodebaseRepository(g.db)
 }
 
 func (g *GormBase) DB() *gorm.DB {

--- a/gormapplication/application.go
+++ b/gormapplication/application.go
@@ -37,7 +37,7 @@ const (
 	TXIsoLevelRepeatableRead
 
 	// TXIsoLevelSerializable means "All statements of the current transaction can only see rows committed
-	w // before the first query or data-modification statement was executed in this transaction.
+	// before the first query or data-modification statement was executed in this transaction.
 	// If a pattern of reads and writes among concurrent serializable transactions would create a
 	// situation which could not have occurred for any serial (one-at-a-time) execution of those
 	// transactions, one of them will be rolled back with a serialization_failure error."

--- a/log/log.go
+++ b/log/log.go
@@ -2,10 +2,11 @@ package log
 
 import (
 	"errors"
-	log "github.com/Sirupsen/logrus"
 	"os"
 	"runtime"
 	"strings"
+
+	log "github.com/Sirupsen/logrus"
 
 	"golang.org/x/net/context"
 )
@@ -86,6 +87,13 @@ func NewCustomizedLogger(level string, developerModeFlag bool) (*log.Logger, err
 // Logger returns the current logger object.
 func Logger() *log.Logger {
 	return logger
+}
+
+// IsDebug returns true if logger is set at DebugLevel.
+// Useful if you need to do extra work that takes time to build the log statement
+// that is not required as part of normal execution flow
+func IsDebug() bool {
+	return logger.Level >= log.DebugLevel
 }
 
 // Error logs an error message that might contain the following attributes: pid,

--- a/main.go
+++ b/main.go
@@ -285,6 +285,14 @@ func main() {
 	namedSpacesCtrl := controller.NewNamedspacesController(service, appDB)
 	app.MountNamedspacesController(service, namedSpacesCtrl)
 
+	// Mount "codebase" controller
+	codebaseCtrl := controller.NewCodebaseController(service, appDB)
+	app.MountCodebaseController(service, codebaseCtrl)
+
+	// Mount "spacecodebases" controller
+	spaceCodebaseCtrl := controller.NewSpaceCodebasesController(service, appDB)
+	app.MountSpaceCodebasesController(service, spaceCodebaseCtrl)
+
 	log.Logger().Infoln("Git Commit SHA: ", controller.Commit)
 	log.Logger().Infoln("UTC Build Time: ", controller.BuildTime)
 	log.Logger().Infoln("UTC Start Time: ", controller.StartTime)

--- a/main.go
+++ b/main.go
@@ -286,7 +286,7 @@ func main() {
 	app.MountNamedspacesController(service, namedSpacesCtrl)
 
 	// Mount "codebase" controller
-	codebaseCtrl := controller.NewCodebaseController(service, appDB)
+	codebaseCtrl := controller.NewCodebaseController(service, appDB, configuration)
 	app.MountCodebaseController(service, codebaseCtrl)
 
 	// Mount "spacecodebases" controller

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -257,6 +257,9 @@ func getMigrations() migrations {
 	// Version 46
 	m = append(m, steps{executeSQLFile("046-oauth-states.sql")})
 
+	// Version 47
+	m = append(m, steps{executeSQLFile("047-codebases.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/047-codebases.sql
+++ b/migration/sql-files/047-codebases.sql
@@ -1,0 +1,11 @@
+CREATE TABLE codebases (
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone,
+    deleted_at timestamp with time zone,
+    id uuid primary key DEFAULT uuid_generate_v4() NOT NULL,
+    space_id uuid,
+    type text,
+    url text
+);
+
+CREATE INDEX ix_codebases_space_id ON codebases USING btree (space_id);

--- a/migration/sql-files/047-codebases.sql
+++ b/migration/sql-files/047-codebases.sql
@@ -3,7 +3,7 @@ CREATE TABLE codebases (
     updated_at timestamp with time zone,
     deleted_at timestamp with time zone,
     id uuid primary key DEFAULT uuid_generate_v4() NOT NULL,
-    space_id uuid,
+    space_id uuid NOT NULL REFERENCES spaces (id) ON DELETE CASCADE,
     type text,
     url text
 );

--- a/test/db.go
+++ b/test/db.go
@@ -5,6 +5,7 @@ import (
 	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/area"
 	"github.com/almighty/almighty-core/auth"
+	"github.com/almighty/almighty-core/codebase"
 	"github.com/almighty/almighty-core/comment"
 	"github.com/almighty/almighty-core/iteration"
 	"github.com/almighty/almighty-core/space"
@@ -72,6 +73,10 @@ func (db *MockDB) Areas() area.Repository {
 }
 
 func (g *MockDB) OauthStates() auth.OauthStateReferenceRepository {
+	return nil
+}
+
+func (db *MockDB) Codebases() codebase.Repository {
 	return nil
 }
 


### PR DESCRIPTION
Codebase is tied to a Space. Each codebase represents some
form of repository.

Provide edit/create API via Che-Starter targeting the tenant services.

Che-Starter interaction is undertested. Needs semi-stable api to produce a api recording. 