### PR TITLE
Switch to prod-preview test Keycloak realm

### DIFF
--- a/auth/authz_blackbox_test.go
+++ b/auth/authz_blackbox_test.go
@@ -227,7 +227,7 @@ func (s *TestAuthSuite) TestGetEntitlement() {
 
 func (s *TestAuthSuite) TestGetClientIDOK() {
 	id, _ := getClientIDAndEndpoint(s.T())
-	assert.Equal(s.T(), "cd7bfaad-b81f-4952-87a0-72ca1ed2e321", id)
+	assert.Equal(s.T(), "65d23f35-c532-4493-a860-39e851abe397", id)
 }
 
 func (s *TestAuthSuite) TestGetProtectedAPITokenOK() {

--- a/config.yaml
+++ b/config.yaml
@@ -73,13 +73,13 @@ token.privatekey : |
 
 token.publickey : |
                     -----BEGIN PUBLIC KEY-----
-                    MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiRd6pdNjiwQFH2xmNugn
-                    TkVhkF+TdJw19Kpj3nRtsoUe4/6gIureVi7FWqcb+2t/E0dv8rAAs6vl+d7roz3R
-                    SkAzBjPxVW5+hi5AJjUbAxtFX/aYJpZePVhK0Dv8StCPSv9GC3T6bUSF3q3E9R9n
-                    G1SZFkN9m2DhL+45us4THzX2eau6s0bISjAUqEGNifPyYYUzKVmXmHS9fiZJR61h
-                    6TulPwxv68DUSk+7iIJvJfQ3lH/XNWlxWNMMehetcmdy8EDR2IkJCCAbjx9yxgKV
-                    JXdQ7zylRlpaLopock0FGiZrJhEaAh6BGuaoUWLiMEvqrLuyZnJYEg9f/vyxUJSD
-                    JwIDAQAB
+                    MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArlscGA2NfO4ZkGzJgZE8
+                    e/WGHCFANE28DzU1aftOssKi4jCn++umFWPDWxTwLfQdiwc8Bbhn9/8udPMXrZ84
+                    L8OgVNbDXOle37QE0+GEAX/DnzkvOg2sm7F0IzKck9YNvo3ZUYj7dyW9s2zatCwu
+                    QyUsHJmbMdwtDOueHBHwXiAiU0kprtUjNsvK4SBvascBdCmLLIWkhj2lu5S6BGrH
+                    gDDTv2JaguNwlgbHLFWU08D03j2F5Yj4TO8LexRJwCYrKp1icQrvC+WGhRAlttbx
+                    51MKRiCnqhFJ8LYtCbPt5Xm5+FR2fHFCMyCqQsScu+dwsx+mb4JGAsdVEaUdcmOF
+                    ZwIDAQAB
                     -----END PUBLIC KEY-----
 
 # ----------------------------
@@ -87,13 +87,13 @@ token.publickey : |
 # ----------------------------
 
 keycloak.client.id : fabric8-online-platform
-keycloak.secret : 08a8bcd1-f362-446a-9d2b-d34b8d464185
+keycloak.secret : 7a3d5a00-7f80-40cf-8781-b5b6f2dfd1bd
 keycloak.domain.prefix : sso
-keycloak.realm : fabric8
+keycloak.realm : fabric8-test
 keycloak.testuser.name : testuser
 keycloak.testuser.secret : testuser
 keycloak.testuser2.name : testuser2
 keycloak.testuser2.secret : testuser2
 
 # Uncomment if FQDN URL's should be used instead of relative URL's:
-# keycloak.url : http://sso.demo.almighty.io
+# keycloak.url : http://sso.prod-preview.openshift.io

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -68,15 +68,6 @@ const (
 	varCacheControlWorkItemType         = "cachecontrol.workitemtype"
 	varCacheControlWorkItemLinkType     = "cachecontrol.workitemlinktype"
 	defaultConfigFile                   = "config.yaml"
-
-	// The host name exception of the api service to be taken into account
-	// when converting it to sso.demo.almighty.io
-	// demo.api.almighty.io doesn't follow the service name convention <serviceName>.<domain>
-	// The correct name would be something like API.demo.almighty.io which is to be converted to SSO.demo.almighty.io
-	// So, we need to treat it as an exception
-
-	apiHostNameException = "demo.api.almighty.io"
-	ssoHostNameException = "sso.demo.almighty.io"
 )
 
 // ConfigurationData encapsulates the Viper configuration object which stores the configuration data in-memory.
@@ -455,19 +446,9 @@ func (c *ConfigurationData) getKeycloakURL(req *goa.RequestData, path string) (s
 	if req.TLS != nil { // isHTTPS
 		scheme = "https"
 	}
-	currentHost := req.Host
-	var newHost string
-	var err error
-	if currentHost == apiHostNameException {
-		// demo.api.almighty.io doesn't follow the service name convention <serviceName>.<domain>
-		// The correct name would be something like API.demo.almighty.io which is to be converted to SSO.demo.almighty.io
-		// So, we need to treat it as an exception
-		newHost = ssoHostNameException
-	} else {
-		newHost, err = rest.ReplaceDomainPrefix(currentHost, c.GetKeycloakDomainPrefix())
-		if err != nil {
-			return "", err
-		}
+	newHost, err := rest.ReplaceDomainPrefix(req.Host, c.GetKeycloakDomainPrefix())
+	if err != nil {
+		return "", err
 	}
 	newURL := fmt.Sprintf("%s://%s/%s", scheme, newHost, path)
 
@@ -509,20 +490,20 @@ OCCAgsB8g8yTB4qntAYyfofEoDiseKrngQT5DSdxd51A/jw7B8WyBK8=
 // RSAPublicKey for verifying JWT Tokens
 // openssl rsa -in alm_rsa -pubout -out alm_rsa.pub
 var defaultTokenPublicKey = `-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiRd6pdNjiwQFH2xmNugn
-TkVhkF+TdJw19Kpj3nRtsoUe4/6gIureVi7FWqcb+2t/E0dv8rAAs6vl+d7roz3R
-SkAzBjPxVW5+hi5AJjUbAxtFX/aYJpZePVhK0Dv8StCPSv9GC3T6bUSF3q3E9R9n
-G1SZFkN9m2DhL+45us4THzX2eau6s0bISjAUqEGNifPyYYUzKVmXmHS9fiZJR61h
-6TulPwxv68DUSk+7iIJvJfQ3lH/XNWlxWNMMehetcmdy8EDR2IkJCCAbjx9yxgKV
-JXdQ7zylRlpaLopock0FGiZrJhEaAh6BGuaoUWLiMEvqrLuyZnJYEg9f/vyxUJSD
-JwIDAQAB
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArlscGA2NfO4ZkGzJgZE8
+e/WGHCFANE28DzU1aftOssKi4jCn++umFWPDWxTwLfQdiwc8Bbhn9/8udPMXrZ84
+L8OgVNbDXOle37QE0+GEAX/DnzkvOg2sm7F0IzKck9YNvo3ZUYj7dyW9s2zatCwu
+QyUsHJmbMdwtDOueHBHwXiAiU0kprtUjNsvK4SBvascBdCmLLIWkhj2lu5S6BGrH
+gDDTv2JaguNwlgbHLFWU08D03j2F5Yj4TO8LexRJwCYrKp1icQrvC+WGhRAlttbx
+51MKRiCnqhFJ8LYtCbPt5Xm5+FR2fHFCMyCqQsScu+dwsx+mb4JGAsdVEaUdcmOF
+ZwIDAQAB
 -----END PUBLIC KEY-----`
 
 var defaultKeycloakClientID = "fabric8-online-platform"
-var defaultKeycloakSecret = "08a8bcd1-f362-446a-9d2b-d34b8d464185"
+var defaultKeycloakSecret = "7a3d5a00-7f80-40cf-8781-b5b6f2dfd1bd"
 
 var defaultKeycloakDomainPrefix = "sso"
-var defaultKeycloakRealm = "fabric8"
+var defaultKeycloakRealm = "fabric8-test"
 
 // Github does not allow committing actual OAuth tokens no matter how less privilege the token has
 var camouflagedAccessToken = "751e16a8b39c0985066-AccessToken-4871777f2c13b32be8550"
@@ -536,4 +517,4 @@ var defaultKeycloakTesUser2Name = "testuser2"
 var defaultKeycloakTesUser2Secret = "testuser2"
 
 // Keycloak URL to be used in dev mode. Can be overridden by setting up keycloak.url
-var devModeKeycloakURL = "http://sso.demo.almighty.io"
+var devModeKeycloakURL = "http://sso.prod-preview.openshift.io"

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -63,33 +63,33 @@ func TestGetKeycloakEndpointSetByUrlEnvVaribaleOK(t *testing.T) {
 
 	url, err := config.GetKeycloakEndpointAuth(reqLong)
 	require.Nil(t, err)
-	require.Equal(t, "http://xyz.io/auth/realms/fabric8/protocol/openid-connect/auth", url)
+	require.Equal(t, "http://xyz.io/auth/realms/"+config.GetKeycloakRealm()+"/protocol/openid-connect/auth", url)
 
 	url, err = config.GetKeycloakEndpointToken(reqLong)
 	require.Nil(t, err)
-	require.Equal(t, "http://xyz.io/auth/realms/fabric8/protocol/openid-connect/token", url)
+	require.Equal(t, "http://xyz.io/auth/realms/"+config.GetKeycloakRealm()+"/protocol/openid-connect/token", url)
 
 	url, err = config.GetKeycloakEndpointUserInfo(reqLong)
 	require.Nil(t, err)
-	require.Equal(t, "http://xyz.io/auth/realms/fabric8/protocol/openid-connect/userinfo", url)
+	require.Equal(t, "http://xyz.io/auth/realms/"+config.GetKeycloakRealm()+"/protocol/openid-connect/userinfo", url)
 
 	url, err = config.GetKeycloakEndpointAuthzResourceset(reqLong)
 	require.Nil(t, err)
-	require.Equal(t, "http://xyz.io/auth/realms/fabric8/authz/protection/resource_set", url)
+	require.Equal(t, "http://xyz.io/auth/realms/"+config.GetKeycloakRealm()+"/authz/protection/resource_set", url)
 
 	url, err = config.GetKeycloakEndpointClients(reqLong)
 	require.Nil(t, err)
-	require.Equal(t, "http://xyz.io/auth/admin/realms/fabric8/clients", url)
+	require.Equal(t, "http://xyz.io/auth/admin/realms/"+config.GetKeycloakRealm()+"/clients", url)
 
 	url, err = config.GetKeycloakEndpointEntitlement(reqLong)
 	require.Nil(t, err)
-	require.Equal(t, "http://xyz.io/auth/realms/fabric8/authz/entitlement/fabric8-online-platform", url)
+	require.Equal(t, "http://xyz.io/auth/realms/"+config.GetKeycloakRealm()+"/authz/entitlement/fabric8-online-platform", url)
 }
 
 func TestGetKeycloakEndpointAdminDevModeOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
-	checkGetKeycloakEndpointOK(t, config.GetKeycloakDevModeURL()+"/auth/admin/realms/fabric8", config.GetKeycloakEndpointAdmin)
+	checkGetKeycloakEndpointOK(t, config.GetKeycloakDevModeURL()+"/auth/admin/realms/"+config.GetKeycloakRealm(), config.GetKeycloakEndpointAdmin)
 }
 
 func TestGetKeycloakEndpointAdminSetByEnvVaribaleOK(t *testing.T) {
@@ -100,7 +100,7 @@ func TestGetKeycloakEndpointAdminSetByEnvVaribaleOK(t *testing.T) {
 func TestGetKeycloakEndpointAuthzResourcesetDevModeOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
-	checkGetKeycloakEndpointOK(t, config.GetKeycloakDevModeURL()+"/auth/realms/fabric8/authz/protection/resource_set", config.GetKeycloakEndpointAuthzResourceset)
+	checkGetKeycloakEndpointOK(t, config.GetKeycloakDevModeURL()+"/auth/realms/"+config.GetKeycloakRealm()+"/authz/protection/resource_set", config.GetKeycloakEndpointAuthzResourceset)
 }
 
 func TestGetKeycloakEndpointAuthzResourcesetSetByEnvVaribaleOK(t *testing.T) {
@@ -111,7 +111,7 @@ func TestGetKeycloakEndpointAuthzResourcesetSetByEnvVaribaleOK(t *testing.T) {
 func TestGetKeycloakEndpointClientsDevModeOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
-	checkGetKeycloakEndpointOK(t, config.GetKeycloakDevModeURL()+"/auth/admin/realms/fabric8/clients", config.GetKeycloakEndpointClients)
+	checkGetKeycloakEndpointOK(t, config.GetKeycloakDevModeURL()+"/auth/admin/realms/"+config.GetKeycloakRealm()+"/clients", config.GetKeycloakEndpointClients)
 }
 
 func TestGetKeycloakEndpoinClientsSetByEnvVaribaleOK(t *testing.T) {
@@ -122,7 +122,7 @@ func TestGetKeycloakEndpoinClientsSetByEnvVaribaleOK(t *testing.T) {
 func TestGetKeycloakEndpointAuthDevModeOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
-	checkGetKeycloakEndpointOK(t, config.GetKeycloakDevModeURL()+"/auth/realms/fabric8/protocol/openid-connect/auth", config.GetKeycloakEndpointAuth)
+	checkGetKeycloakEndpointOK(t, config.GetKeycloakDevModeURL()+"/auth/realms/"+config.GetKeycloakRealm()+"/protocol/openid-connect/auth", config.GetKeycloakEndpointAuth)
 }
 
 func TestGetKeycloakEndpointAuthSetByEnvVaribaleOK(t *testing.T) {
@@ -133,7 +133,7 @@ func TestGetKeycloakEndpointAuthSetByEnvVaribaleOK(t *testing.T) {
 func TestGetKeycloakEndpointTokenOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
-	checkGetKeycloakEndpointOK(t, config.GetKeycloakDevModeURL()+"/auth/realms/fabric8/protocol/openid-connect/token", config.GetKeycloakEndpointToken)
+	checkGetKeycloakEndpointOK(t, config.GetKeycloakDevModeURL()+"/auth/realms/"+config.GetKeycloakRealm()+"/protocol/openid-connect/token", config.GetKeycloakEndpointToken)
 }
 
 func TestGetKeycloakEndpointTokenSetByEnvVaribaleOK(t *testing.T) {
@@ -144,7 +144,7 @@ func TestGetKeycloakEndpointTokenSetByEnvVaribaleOK(t *testing.T) {
 func TestGetKeycloakEndpointUserInfoOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
-	checkGetKeycloakEndpointOK(t, config.GetKeycloakDevModeURL()+"/auth/realms/fabric8/protocol/openid-connect/userinfo", config.GetKeycloakEndpointUserInfo)
+	checkGetKeycloakEndpointOK(t, config.GetKeycloakDevModeURL()+"/auth/realms/"+config.GetKeycloakRealm()+"/protocol/openid-connect/userinfo", config.GetKeycloakEndpointUserInfo)
 }
 
 func TestGetKeycloakEndpointUserInfoSetByEnvVaribaleOK(t *testing.T) {
@@ -155,7 +155,7 @@ func TestGetKeycloakEndpointUserInfoSetByEnvVaribaleOK(t *testing.T) {
 func TestGetKeycloakEndpointEntitlementOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
-	checkGetKeycloakEndpointOK(t, config.GetKeycloakDevModeURL()+"/auth/realms/fabric8/authz/entitlement/fabric8-online-platform", config.GetKeycloakEndpointEntitlement)
+	checkGetKeycloakEndpointOK(t, config.GetKeycloakDevModeURL()+"/auth/realms/"+config.GetKeycloakRealm()+"/authz/entitlement/fabric8-online-platform", config.GetKeycloakEndpointEntitlement)
 }
 
 func TestGetKeycloakEndpointEntitlementSetByEnvVaribaleOK(t *testing.T) {
@@ -166,7 +166,7 @@ func TestGetKeycloakEndpointEntitlementSetByEnvVaribaleOK(t *testing.T) {
 func TestGetKeycloakEndpointBrokerOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	t.Parallel()
-	checkGetKeycloakEndpointOK(t, config.GetKeycloakDevModeURL()+"/auth/realms/fabric8/broker", config.GetKeycloakEndpointBroker)
+	checkGetKeycloakEndpointOK(t, config.GetKeycloakDevModeURL()+"/auth/realms/"+config.GetKeycloakRealm()+"/broker", config.GetKeycloakEndpointBroker)
 }
 
 func TestGetKeycloakEndpointBrokerSetByEnvVaribaleOK(t *testing.T) {

--- a/configuration/configuration_whitebox_test.go
+++ b/configuration/configuration_whitebox_test.go
@@ -39,7 +39,7 @@ func TestOpenIDConnectPathOK(t *testing.T) {
 	t.Parallel()
 
 	path := config.openIDConnectPath("somesufix")
-	assert.Equal(t, "auth/realms/fabric8/protocol/openid-connect/somesufix", path)
+	assert.Equal(t, "auth/realms/"+config.GetKeycloakRealm()+"/protocol/openid-connect/somesufix", path)
 }
 
 func TestGetKeycloakURLOK(t *testing.T) {
@@ -64,21 +64,4 @@ func TestGetKeycloakURLForTooShortHostFails(t *testing.T) {
 	}
 	_, err := config.getKeycloakURL(r, "somepath")
 	assert.NotNil(t, err)
-}
-
-func TestDemoApiAlmightyIoExceptionOK(t *testing.T) {
-	// demo.api.almighty.io doesn't follow the service name convention <serviceName>.<domain>
-	// The correct name would be something like API.demo.almighty.io which is to be converted to SSO.demo.almighty.io
-	// So, it should be treated as an exception
-
-	resource.Require(t, resource.UnitTest)
-	t.Parallel()
-
-	r := &goa.RequestData{
-		Request: &http.Request{Host: "demo.api.almighty.io"},
-	}
-
-	url, err := config.getKeycloakURL(r, "somepath3")
-	assert.Nil(t, err)
-	assert.Equal(t, devModeKeycloakURL+"/somepath3", url)
 }


### PR DESCRIPTION
- Switch to sso.prod-preview
- Use the test realm by default

We will also need to add the test realm URI to the list of valid redirect URIs in the tsrv cluster 

Fixes https://github.com/almighty/almighty-core/issues/1019
