### PR TITLE
Fixes storage of ExecutionOrder on Update

### DIFF
--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -332,15 +332,14 @@ func (s *WorkItemSuite) TestUpdateWorkitemWithoutReorder() {
 	payload := minimumRequiredCreateWithType(workitem.SystemBug)
 	payload.Data.Attributes[workitem.SystemTitle] = "Test WI"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
-
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, &payload)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
 
 	// Update the workitem
 	wi.Data.Attributes[workitem.SystemTitle] = "Updated Test WI"
 	payload2 := minimumRequiredUpdatePayload()
 	payload2.Data.ID = wi.Data.ID
 	payload2.Data.Attributes = wi.Data.Attributes
-	_, updated := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.controller, *wi.Data.ID, &payload2)
+	_, updated := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), *wi.Data.ID, &payload2)
 
 	assert.Equal(s.T(), *wi.Data.ID, *updated.Data.ID)
 	assert.Equal(s.T(), (s.wi.Attributes["version"].(int) + 1), updated.Data.Attributes["version"])

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -325,6 +325,31 @@ func (s *WorkItemSuite) TestReorderWorkitemNotFoundOK() {
 	test.ReorderWorkitemNotFound(s.T(), s.svc.Context, s.svc, s.controller, &payload2)
 }
 
+// TestUpdateWorkitemWithoutReorder tests that when workitem is updated, execution order of workitem doesnot change.
+func (s *WorkItemSuite) TestUpdateWorkitemWithoutReorder() {
+
+	// Create new workitem
+	payload := minimumRequiredCreateWithType(workitem.SystemBug)
+	payload.Data.Attributes[workitem.SystemTitle] = "Test WI"
+	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
+
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, &payload)
+
+	// Update the workitem
+	wi.Data.Attributes[workitem.SystemTitle] = "Updated Test WI"
+	payload2 := minimumRequiredUpdatePayload()
+	payload2.Data.ID = wi.Data.ID
+	payload2.Data.Attributes = wi.Data.Attributes
+	_, updated := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.controller, *wi.Data.ID, &payload2)
+
+	assert.Equal(s.T(), *wi.Data.ID, *updated.Data.ID)
+	assert.Equal(s.T(), (s.wi.Attributes["version"].(int) + 1), updated.Data.Attributes["version"])
+	assert.Equal(s.T(), wi.Data.Attributes[workitem.SystemTitle], updated.Data.Attributes[workitem.SystemTitle])
+
+	// Check the execution order
+	assert.Equal(s.T(), wi.Data.Attributes[workitem.SystemOrder], updated.Data.Attributes[workitem.SystemOrder])
+}
+
 func (s *WorkItemSuite) TestCreateWorkItemWithoutContext() {
 	// given
 	s.svc = goa.New("TestCreateWorkItemWithoutContext-Service")

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -397,7 +397,7 @@ func (r *GormWorkItemRepository) Save(ctx context.Context, wi app.WorkItem, modi
 	res.Version = res.Version + 1
 	res.Type = wi.Type
 	res.Fields = Fields{}
-	res.ExecutionOrder = wi.ExecutionOrder
+	res.ExecutionOrder = wi.Fields[SystemOrder].(float64)
 	for fieldName, fieldDef := range wiType.Fields {
 		if fieldName == SystemCreatedAt || fieldName == SystemUpdatedAt || fieldName == SystemOrder {
 			continue


### PR DESCRIPTION
[1] fixes #1024 

Before this commit, when a workitem was updated, the execution_order would automatically get set to 0 because of wrong handling of execution_order. This commit aims to fix it. Now, if a workitem is just updated (and not reordered), its execution_order is not changed.