### PR TITLE
Add Keycloak real name used in dev mode

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -89,7 +89,7 @@ token.publickey : |
 keycloak.client.id : fabric8-online-platform
 keycloak.secret : 7a3d5a00-7f80-40cf-8781-b5b6f2dfd1bd
 keycloak.domain.prefix : sso
-keycloak.realm : fabric8-test
+keycloak.realm : fabric8
 keycloak.testuser.name : testuser
 keycloak.testuser.secret : testuser
 keycloak.testuser2.name : testuser2

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -538,7 +538,7 @@ ZwIDAQAB
 	devModeKeycloakRealm = "fabric8-test"
 
 	defaultOpenshiftTenantMasterURL = "https://tsrv.devshift.net:8443"
-	defaultCheStarterURL = "che-server"
+	defaultCheStarterURL            = "che-server"
 )
 
 // ActualToken is actual OAuth access token of github

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -70,15 +70,6 @@ const (
 	defaultConfigFile                   = "config.yaml"
 	varOpenshiftTenantMasterURL         = "openshift.tenant.masterurl"
 	varCheStarterURL                    = "chestarterurl"
-
-	// The host name exception of the api service to be taken into account
-	// when converting it to sso.demo.almighty.io
-	// demo.api.almighty.io doesn't follow the service name convention <serviceName>.<domain>
-	// The correct name would be something like API.demo.almighty.io which is to be converted to SSO.demo.almighty.io
-	// So, we need to treat it as an exception
-
-	apiHostNameException = "demo.api.almighty.io"
-	ssoHostNameException = "sso.demo.almighty.io"
 )
 
 // ConfigurationData encapsulates the Viper configuration object which stores the configuration data in-memory.
@@ -168,7 +159,6 @@ func (c *ConfigurationData) setConfigDefaults() {
 	c.v.SetDefault(varKeycloakSecret, defaultKeycloakSecret)
 	c.v.SetDefault(varGithubAuthToken, defaultActualToken)
 	c.v.SetDefault(varKeycloakDomainPrefix, defaultKeycloakDomainPrefix)
-	c.v.SetDefault(varKeycloakRealm, defaultKeycloakRealm)
 	c.v.SetDefault(varKeycloakTesUserName, defaultKeycloakTesUserName)
 	c.v.SetDefault(varKeycloakTesUserSecret, defaultKeycloakTesUserSecret)
 
@@ -484,11 +474,12 @@ func (c *ConfigurationData) GetOpenshiftTenantMasterURL() string {
 	return c.v.GetString(varOpenshiftTenantMasterURL)
 }
 
-// Auth-related defaults
+const (
+	// Auth-related defaults
 
-// RSAPrivateKey for signing JWT Tokens
-// ssh-keygen -f alm_rsa
-var defaultTokenPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
+	// RSAPrivateKey for signing JWT Tokens
+	// ssh-keygen -f alm_rsa
+	defaultTokenPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
 MIIEpQIBAAKCAQEAnwrjH5iTSErw9xUptp6QSFoUfpHUXZ+PaslYSUrpLjw1q27O
 DSFwmhV4+dAaTMO5chFv/kM36H3ZOyA146nwxBobS723okFaIkshRrf6qgtD6coT
 HlVUSBTAcwKEjNn4C9jtEpyOl+eSgxhMzRH3bwTIFlLlVMiZf7XVE7P3yuOCpqkk
@@ -516,9 +507,9 @@ BA/cKaLPqUF+08Tz/9MPBw51UH4GYfppA/x0ktc8998984FeIpfIFX6I2U9yUnoQ
 OCCAgsB8g8yTB4qntAYyfofEoDiseKrngQT5DSdxd51A/jw7B8WyBK8=
 -----END RSA PRIVATE KEY-----`
 
-// RSAPublicKey for verifying JWT Tokens
-// openssl rsa -in alm_rsa -pubout -out alm_rsa.pub
-var defaultTokenPublicKey = `-----BEGIN PUBLIC KEY-----
+	// RSAPublicKey for verifying JWT Tokens
+	// openssl rsa -in alm_rsa -pubout -out alm_rsa.pub
+	defaultTokenPublicKey = `-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArlscGA2NfO4ZkGzJgZE8
 e/WGHCFANE28DzU1aftOssKi4jCn++umFWPDWxTwLfQdiwc8Bbhn9/8udPMXrZ84
 L8OgVNbDXOle37QE0+GEAX/DnzkvOg2sm7F0IzKck9YNvo3ZUYj7dyW9s2zatCwu
@@ -528,26 +519,27 @@ gDDTv2JaguNwlgbHLFWU08D03j2F5Yj4TO8LexRJwCYrKp1icQrvC+WGhRAlttbx
 ZwIDAQAB
 -----END PUBLIC KEY-----`
 
-var defaultKeycloakClientID = "fabric8-online-platform"
-var defaultKeycloakSecret = "7a3d5a00-7f80-40cf-8781-b5b6f2dfd1bd"
+	defaultKeycloakClientID = "fabric8-online-platform"
+	defaultKeycloakSecret   = "7a3d5a00-7f80-40cf-8781-b5b6f2dfd1bd"
 
-var defaultKeycloakDomainPrefix = "sso"
-var defaultKeycloakRealm = "fabric8"
+	defaultKeycloakDomainPrefix = "sso"
+	defaultKeycloakRealm        = "fabric8"
 
-// Github does not allow committing actual OAuth tokens no matter how less privilege the token has
-var camouflagedAccessToken = "751e16a8b39c0985066-AccessToken-4871777f2c13b32be8550"
+	// Github does not allow committing actual OAuth tokens no matter how less privilege the token has
+	camouflagedAccessToken = "751e16a8b39c0985066-AccessToken-4871777f2c13b32be8550"
+
+	defaultKeycloakTesUserName    = "testuser"
+	defaultKeycloakTesUserSecret  = "testuser"
+	defaultKeycloakTesUser2Name   = "testuser2"
+	defaultKeycloakTesUser2Secret = "testuser2"
+
+	// Keycloak vars to be used in dev mode. Can be overridden by setting up keycloak.url & keycloak.realm
+	devModeKeycloakURL   = "http://sso.prod-preview.openshift.io"
+	devModeKeycloakRealm = "fabric8-test"
+
+	defaultOpenshiftTenantMasterURL = "https://tsrv.devshift.net:8443"
+	defaultCheStarterURL = "che-server"
+)
 
 // ActualToken is actual OAuth access token of github
 var defaultActualToken = strings.Split(camouflagedAccessToken, "-AccessToken-")[0] + strings.Split(camouflagedAccessToken, "-AccessToken-")[1]
-
-var defaultKeycloakTesUserName = "testuser"
-var defaultKeycloakTesUserSecret = "testuser"
-var defaultKeycloakTesUser2Name = "testuser2"
-var defaultKeycloakTesUser2Secret = "testuser2"
-
-var defaultOpenshiftTenantMasterURL = "https://tsrv.devshift.net:8443"
-var defaultCheStarterURL = "che-server"
-
-// Keycloak vars to be used in dev mode. Can be overridden by setting up keycloak.url & keycloak.realm
-var devModeKeycloakURL = "http://sso.prod-preview.openshift.io"
-var devModeKeycloakRealm = "fabric8-test"

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -314,7 +314,13 @@ func (c *ConfigurationData) GetKeycloakDomainPrefix() string {
 
 // GetKeycloakRealm returns the keyclaok realm name
 func (c *ConfigurationData) GetKeycloakRealm() string {
-	return c.v.GetString(varKeycloakRealm)
+	if c.v.IsSet(varKeycloakRealm) {
+		return c.v.GetString(varKeycloakRealm)
+	}
+	if c.IsPostgresDeveloperModeEnabled() {
+		return devModeKeycloakRealm
+	}
+	return defaultKeycloakRealm
 }
 
 // GetKeycloakTestUserName returns the keycloak test user name used to obtain a test token (as set via config file or environment variable)
@@ -526,7 +532,7 @@ var defaultKeycloakClientID = "fabric8-online-platform"
 var defaultKeycloakSecret = "7a3d5a00-7f80-40cf-8781-b5b6f2dfd1bd"
 
 var defaultKeycloakDomainPrefix = "sso"
-var defaultKeycloakRealm = "fabric8-test"
+var defaultKeycloakRealm = "fabric8"
 
 // Github does not allow committing actual OAuth tokens no matter how less privilege the token has
 var camouflagedAccessToken = "751e16a8b39c0985066-AccessToken-4871777f2c13b32be8550"
@@ -542,5 +548,6 @@ var defaultKeycloakTesUser2Secret = "testuser2"
 var defaultOpenshiftTenantMasterURL = "https://tsrv.devshift.net:8443"
 var defaultCheStarterURL = "che-server"
 
-// Keycloak URL to be used in dev mode. Can be overridden by setting up keycloak.url
+// Keycloak vars to be used in dev mode. Can be overridden by setting up keycloak.url & keycloak.realm
 var devModeKeycloakURL = "http://sso.prod-preview.openshift.io"
+var devModeKeycloakRealm = "fabric8-test"

--- a/configuration/configuration_whitebox_test.go
+++ b/configuration/configuration_whitebox_test.go
@@ -3,6 +3,7 @@ package configuration
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/almighty/almighty-core/resource"
@@ -64,4 +65,24 @@ func TestGetKeycloakURLForTooShortHostFails(t *testing.T) {
 	}
 	_, err := config.getKeycloakURL(r, "somepath")
 	assert.NotNil(t, err)
+}
+
+func TestKeycloakRealmInDevModeCanBeOverridden(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+
+	key := "ALMIGHTY_KEYCLOAK_REALM"
+	realEnvValue := os.Getenv(key)
+
+	os.Unsetenv(key)
+	defer func() {
+		os.Setenv(key, realEnvValue)
+		resetConfiguration()
+	}()
+
+	assert.Equal(t, devModeKeycloakRealm, config.GetKeycloakRealm())
+
+	os.Setenv(key, "somecustomrealm")
+	resetConfiguration()
+
+	assert.Equal(t, "somecustomrealm", config.GetKeycloakRealm())
 }

--- a/login/service_blackbox_test.go
+++ b/login/service_blackbox_test.go
@@ -70,13 +70,24 @@ func (s *serviceBlackBoxTest) SetupSuite() {
 		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
 	}
 
+	req := &goa.RequestData{
+		Request: &http.Request{Host: "api.service.domain.org"},
+	}
+	authEndpoint, err := s.configuration.GetKeycloakEndpointAuth(req)
+	if err != nil {
+		panic(err)
+	}
+	tokenEndpoint, err := s.configuration.GetKeycloakEndpointToken(req)
+	if err != nil {
+		panic(err)
+	}
 	s.oauth = &oauth2.Config{
 		ClientID:     s.configuration.GetKeycloakClientID(),
 		ClientSecret: s.configuration.GetKeycloakSecret(),
 		Scopes:       []string{"user:email"},
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  s.configuration.GetKeycloakDevModeURL() + "/auth/realms/fabric8/protocol/openid-connect/auth",
-			TokenURL: s.configuration.GetKeycloakDevModeURL() + "/auth/realms/fabric8/protocol/openid-connect/token",
+			AuthURL:  authEndpoint,
+			TokenURL: tokenEndpoint,
 		},
 	}
 	privateKey, err := token.ParsePrivateKey([]byte(token.RSAPrivateKey))


### PR DESCRIPTION
This PR introducing a new realm name var used in devmode. So we don't need to set up realm name vars in production and devmode. The default ones will be used.
