### PR TITLE
Add conditional requests and cache-control headers on the 'spaces' endpoints (#998)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,7 @@ app/controllers.go: $(DESIGNS) $(GOAGEN_BIN) $(VENDOR_DIR)
 	$(GOAGEN_BIN) app -d ${PACKAGE_NAME}/${DESIGN_DIR}
 	$(GOAGEN_BIN) controller -d ${PACKAGE_NAME}/${DESIGN_DIR} -o controller/ --pkg controller --app-pkg app
 	$(GOAGEN_BIN) gen -d ${PACKAGE_NAME}/${DESIGN_DIR} --pkg-path=${PACKAGE_NAME}/goasupport/conditional_request --out app
+	$(GOAGEN_BIN) gen -d ${PACKAGE_NAME}/${DESIGN_DIR} --pkg-path=${PACKAGE_NAME}/goasupport/helper_function --out app
 	$(GOAGEN_BIN) client -d ${PACKAGE_NAME}/${DESIGN_DIR}
 	$(GOAGEN_BIN) swagger -d ${PACKAGE_NAME}/${DESIGN_DIR}
 

--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,7 @@ http.address: 0.0.0.0:8080
 
 cachecontrol.maxage.workitemtype: max-age=86400
 cachecontrol.maxage.workitemlinktype: max-age=86400
+cachecontrol.maxage.space: max-age=86400
 
 #------------------------
 # Misc.

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -67,6 +67,7 @@ const (
 	varTokenPrivateKey                  = "token.privatekey"
 	varCacheControlWorkItemType         = "cachecontrol.workitemtype"
 	varCacheControlWorkItemLinkType     = "cachecontrol.workitemlinktype"
+	varCacheControlSpace                = "cachecontrol.space"
 	defaultConfigFile                   = "config.yaml"
 	varOpenshiftTenantMasterURL         = "openshift.tenant.masterurl"
 	varCheStarterURL                    = "chestarterurl"
@@ -165,6 +166,7 @@ func (c *ConfigurationData) setConfigDefaults() {
 	// HTTP Cache-Control/max-age default
 	c.v.SetDefault(varCacheControlWorkItemType, "max-age=86400")     // 1 day
 	c.v.SetDefault(varCacheControlWorkItemLinkType, "max-age=86400") // 1 day
+	c.v.SetDefault(varCacheControlSpace, "max-age=86400")            // 1 day
 
 	c.v.SetDefault(varKeycloakTesUser2Name, defaultKeycloakTesUser2Name)
 	c.v.SetDefault(varKeycloakTesUser2Secret, defaultKeycloakTesUser2Secret)
@@ -266,6 +268,12 @@ func (c *ConfigurationData) GetCacheControlWorkItemType() string {
 // when returning a work item type (or a list of).
 func (c *ConfigurationData) GetCacheControlWorkItemLinkType() string {
 	return c.v.GetString(varCacheControlWorkItemLinkType)
+}
+
+// GetCacheControlSpace returns the value to set in the "Cache-Control: max-age=%v" HTTP response header
+// when returning spaces.
+func (c *ConfigurationData) GetCacheControlSpace() string {
+	return c.v.GetString(varCacheControlSpace)
 }
 
 // GetTokenPrivateKey returns the private key (as set via config file or environment variable)

--- a/controller/comments_blackbox_test.go
+++ b/controller/comments_blackbox_test.go
@@ -97,7 +97,7 @@ func (s *CommentsSuite) createWorkItem(identity account.Identity) string {
 						ID:   workitem.SystemBug,
 					},
 				},
-				Space: space.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
+				Space: app.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
 			},
 		},
 	}

--- a/controller/namedspaces.go
+++ b/controller/namedspaces.go
@@ -44,7 +44,7 @@ func (c *NamedspacesController) Show(ctx *app.ShowNamedspacesContext) error {
 		}
 
 		resp := app.SpaceSingle{
-			Data: ConvertSpace(ctx.RequestData, s),
+			Data: ConvertSpaceFromModel(ctx.RequestData, *s),
 		}
 
 		return ctx.OK(&resp)
@@ -74,7 +74,7 @@ func (c *NamedspacesController) List(ctx *app.ListNamedspacesContext) error {
 		response := app.SpaceList{
 			Links: &app.PagingLinks{},
 			Meta:  &app.SpaceListMeta{TotalCount: count},
-			Data:  ConvertSpaces(ctx.RequestData, spaces),
+			Data:  ConvertSpacesFromModel(ctx.RequestData, spaces),
 		}
 		setPagingLinks(response.Links, buildAbsoluteURL(ctx.RequestData), len(spaces), offset, limit, count)
 

--- a/controller/namedspaces_test.go
+++ b/controller/namedspaces_test.go
@@ -13,6 +13,7 @@ import (
 	testsupport "github.com/almighty/almighty-core/test"
 	almtoken "github.com/almighty/almighty-core/token"
 	"github.com/goadesign/goa"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -75,7 +76,7 @@ func (rest *TestNamedSpaceREST) TestSuccessQuerySpace() {
 		assert.Fail(t, "Failed to create an identity")
 	}
 
-	name := "Test 24"
+	name := "Test 24" + uuid.NewV4().String()
 
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
@@ -112,7 +113,7 @@ func (rest *TestNamedSpaceREST) TestSuccessListSpaces() {
 		assert.Fail(t, "Failed to create an identity")
 	}
 
-	name := "Test 24"
+	name := "Test 24" + uuid.NewV4().String()
 
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name

--- a/controller/search.go
+++ b/controller/search.go
@@ -89,7 +89,7 @@ func (c *SearchController) Spaces(ctx *app.SpacesSearchContext) error {
 		q = "" // Allow empty query if * specified
 	}
 
-	var result []*space.Space
+	var result []space.Space
 	var count int
 	var err error
 
@@ -118,7 +118,7 @@ func (c *SearchController) Spaces(ctx *app.SpacesSearchContext) error {
 		response := app.SearchSpaceList{
 			Links: &app.PagingLinks{},
 			Meta:  &app.SpaceListMeta{TotalCount: count},
-			Data:  ConvertSpaces(ctx.RequestData, result),
+			Data:  ConvertSpacesFromModel(ctx.RequestData, result),
 		}
 		setPagingLinks(response.Links, buildAbsoluteURL(ctx.RequestData), len(result), offset, limit, count, "q="+q)
 

--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -266,7 +266,7 @@ func (s *searchBlackBoxTest) getWICreatePayload() *app.CreateWorkitemPayload {
 						ID:   workitem.SystemUserStory,
 					},
 				},
-				Space: space.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
+				Space: app.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
 			},
 		},
 	}

--- a/controller/space_test.go
+++ b/controller/space_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"time"
+
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
@@ -51,7 +53,8 @@ type TestSpaceREST struct {
 	clean func()
 }
 
-func TestRunProjectREST(t *testing.T) {
+func TestRunSpaceREST(t *testing.T) {
+	resource.Require(t, resource.Database)
 	suite.Run(t, &TestSpaceREST{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
 }
 
@@ -77,44 +80,38 @@ func (rest *TestSpaceREST) UnSecuredController() (*goa.Service, *SpaceController
 }
 
 func (rest *TestSpaceREST) TestFailCreateSpaceUnsecure() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	p := minimumRequiredCreateSpace()
-
 	svc, ctrl := rest.UnSecuredController()
-	test.CreateSpaceUnauthorized(t, svc.Context, svc, ctrl, p)
+	// when/then
+	test.CreateSpaceUnauthorized(rest.T(), svc.Context, svc, ctrl, p)
 }
 
 func (rest *TestSpaceREST) TestFailCreateSpaceMissingName() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	p := minimumRequiredCreateSpace()
-
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	test.CreateSpaceBadRequest(t, svc.Context, svc, ctrl, p)
+	// when/then
+	test.CreateSpaceBadRequest(rest.T(), svc.Context, svc, ctrl, p)
 }
 
 func (rest *TestSpaceREST) TestSuccessCreateSpace() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
-	name := "Test 24"
-
+	// given
+	name := "Test 24" + uuid.NewV4().String()
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
-
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
-	assert.NotNil(t, created.Data)
-	assert.NotNil(t, created.Data.Attributes)
-	assert.NotNil(t, created.Data.Attributes.CreatedAt)
-	assert.NotNil(t, created.Data.Attributes.UpdatedAt)
-	assert.NotNil(t, created.Data.Attributes.Name)
-	assert.Equal(t, name, *created.Data.Attributes.Name)
-	assert.NotNil(t, created.Data.Links)
-	assert.NotNil(t, created.Data.Links.Self)
+	// when
+	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
+	// then
+	assert.NotNil(rest.T(), created.Data)
+	assert.NotNil(rest.T(), created.Data.Attributes)
+	assert.NotNil(rest.T(), created.Data.Attributes.CreatedAt)
+	assert.NotNil(rest.T(), created.Data.Attributes.UpdatedAt)
+	assert.NotNil(rest.T(), created.Data.Attributes.Name)
+	assert.Equal(rest.T(), name, *created.Data.Attributes.Name)
+	assert.NotNil(rest.T(), created.Data.Links)
+	assert.NotNil(rest.T(), created.Data.Links.Self)
 }
 
 func (rest *TestSpaceREST) SecuredSpaceAreaController(identity account.Identity) (*goa.Service, *SpaceAreasController) {
@@ -124,231 +121,334 @@ func (rest *TestSpaceREST) SecuredSpaceAreaController(identity account.Identity)
 }
 
 func (rest *TestSpaceREST) TestSuccessCreateSpaceAndDefaultArea() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	name := "Test24ForSpaceAndArea2"
-
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
-
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
-	require.NotNil(t, created.Data)
-
+	// when
+	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
+	require.NotNil(rest.T(), created.Data)
 	spaceAreaSvc, spaceAreaCtrl := rest.SecuredSpaceAreaController(testsupport.TestIdentity)
 	createdID := created.Data.ID.String()
-	_, areaList := test.ListSpaceAreasOK(t, spaceAreaSvc.Context, spaceAreaSvc, spaceAreaCtrl, createdID)
-
+	_, areaList := test.ListSpaceAreasOK(rest.T(), spaceAreaSvc.Context, spaceAreaSvc, spaceAreaCtrl, createdID)
+	// then
 	// only 1 default gets created.
-	assert.Len(t, areaList.Data, 1)
-	assert.Equal(t, name, *areaList.Data[0].Attributes.Name)
+	assert.Len(rest.T(), areaList.Data, 1)
+	assert.Equal(rest.T(), name, *areaList.Data[0].Attributes.Name)
 
 }
 
 func (rest *TestSpaceREST) TestSuccessCreateSpaceWithDescription() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
-	name := "Test 24"
+	// given
+	name := "Test 24" + uuid.NewV4().String()
 	description := "Space for Test 24"
-
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	p.Data.Attributes.Description = &description
-
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
-	assert.NotNil(t, created.Data)
-	assert.NotNil(t, created.Data.Attributes)
-	assert.NotNil(t, created.Data.Attributes.CreatedAt)
-	assert.NotNil(t, created.Data.Attributes.UpdatedAt)
-	assert.NotNil(t, created.Data.Attributes.Name)
-	assert.Equal(t, name, *created.Data.Attributes.Name)
-	assert.NotNil(t, created.Data.Attributes.Description)
-	assert.Equal(t, description, *created.Data.Attributes.Description)
-	assert.NotNil(t, created.Data.Links)
-	assert.NotNil(t, created.Data.Links.Self)
+	// when
+	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
+	// then
+	assert.NotNil(rest.T(), created.Data)
+	assert.NotNil(rest.T(), created.Data.Attributes)
+	assert.NotNil(rest.T(), created.Data.Attributes.CreatedAt)
+	assert.NotNil(rest.T(), created.Data.Attributes.UpdatedAt)
+	assert.NotNil(rest.T(), created.Data.Attributes.Name)
+	assert.Equal(rest.T(), name, *created.Data.Attributes.Name)
+	assert.NotNil(rest.T(), created.Data.Attributes.Description)
+	assert.Equal(rest.T(), description, *created.Data.Attributes.Description)
+	assert.NotNil(rest.T(), created.Data.Links)
+	assert.NotNil(rest.T(), created.Data.Links.Self)
 }
 
-func (rest *TestSpaceREST) TestSuccessUpdateProject() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
+func (rest *TestSpaceREST) TestSuccessUpdateSpace() {
+	// given
 	name := "Test 25"
 	description := "Space for Test 25"
 	newName := "Test 26"
 	newDescription := "Space for Test 25"
-
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	p.Data.Attributes.Description = &description
-
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
-
+	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
 	u := minimumRequiredUpdateSpace()
 	u.Data.ID = created.Data.ID
 	u.Data.Attributes.Version = created.Data.Attributes.Version
 	u.Data.Attributes.Name = &newName
 	u.Data.Attributes.Description = &newDescription
-
-	_, updated := test.UpdateSpaceOK(t, svc.Context, svc, ctrl, created.Data.ID.String(), u)
-	assert.Equal(t, newName, *updated.Data.Attributes.Name)
-	assert.Equal(t, newDescription, *updated.Data.Attributes.Description)
+	// when
+	_, updated := test.UpdateSpaceOK(rest.T(), svc.Context, svc, ctrl, created.Data.ID.String(), u)
+	// then
+	assert.Equal(rest.T(), newName, *updated.Data.Attributes.Name)
+	assert.Equal(rest.T(), newDescription, *updated.Data.Attributes.Description)
 }
 
-func (rest *TestSpaceREST) TestFailUpdateProjectDifferentOwner() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
+func (rest *TestSpaceREST) TestFailUpdateSpaceDifferentOwner() {
+	// given
 	name := "Test 25"
 	description := "Space for Test 25"
 	newName := "Test 26"
 	newDescription := "Space for Test 25"
-
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	p.Data.Attributes.Description = &description
-
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
-
+	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
+	// when
 	u := minimumRequiredUpdateSpace()
 	u.Data.ID = created.Data.ID
 	u.Data.Attributes.Version = created.Data.Attributes.Version
 	u.Data.Attributes.Name = &newName
 	u.Data.Attributes.Description = &newDescription
-
 	svc2, ctrl2 := rest.SecuredController(testsupport.TestIdentity2)
-	_, errors := test.UpdateSpaceForbidden(t, svc2.Context, svc2, ctrl2, created.Data.ID.String(), u)
-	assert.NotEmpty(t, errors.Errors)
-	assert.Contains(t, errors.Errors[0].Detail, "User is not the space owner")
+	_, errors := test.UpdateSpaceForbidden(rest.T(), svc2.Context, svc2, ctrl2, created.Data.ID.String(), u)
+	// then
+	assert.NotEmpty(rest.T(), errors.Errors)
+	assert.Contains(rest.T(), errors.Errors[0].Detail, "User is not the space owner")
 }
 
-func (rest *TestSpaceREST) TestFailUpdateProjectUnSecure() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
+func (rest *TestSpaceREST) TestFailUpdateSpaceUnSecure() {
+	// given
 	u := minimumRequiredUpdateSpace()
-
 	svc, ctrl := rest.UnSecuredController()
-	test.UpdateSpaceUnauthorized(t, svc.Context, svc, ctrl, uuid.NewV4().String(), u)
+	// when/then
+	test.UpdateSpaceUnauthorized(rest.T(), svc.Context, svc, ctrl, uuid.NewV4().String(), u)
 }
 
 func (rest *TestSpaceREST) TestFailUpdateSpaceNotFound() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	name := "test"
 	version := 0
 	id := uuid.NewV4()
-
 	u := minimumRequiredUpdateSpace()
 	u.Data.Attributes.Name = &name
 	u.Data.Attributes.Version = &version
 	u.Data.ID = &id
-
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	test.UpdateSpaceNotFound(t, svc.Context, svc, ctrl, id.String(), u)
+	// when/then
+	test.UpdateSpaceNotFound(rest.T(), svc.Context, svc, ctrl, id.String(), u)
 }
 
 func (rest *TestSpaceREST) TestFailUpdateSpaceMissingName() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	name := "Test 25"
-
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
-
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
-
+	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
 	u := minimumRequiredUpdateSpace()
 	u.Data.ID = created.Data.ID
 	u.Data.Attributes.Version = created.Data.Attributes.Version
-
-	test.UpdateSpaceBadRequest(t, svc.Context, svc, ctrl, created.Data.ID.String(), u)
+	// when/then
+	test.UpdateSpaceBadRequest(rest.T(), svc.Context, svc, ctrl, created.Data.ID.String(), u)
 }
 
 func (rest *TestSpaceREST) TestFailUpdateSpaceMissingVersion() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	name := "Test 25"
 	newName := "Test 26"
-
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
-
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
-
+	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
 	u := minimumRequiredUpdateSpace()
 	u.Data.ID = created.Data.ID
 	u.Data.Attributes.Name = &newName
-
-	test.UpdateSpaceBadRequest(t, svc.Context, svc, ctrl, created.Data.ID.String(), u)
+	// when/then
+	test.UpdateSpaceBadRequest(rest.T(), svc.Context, svc, ctrl, created.Data.ID.String(), u)
 }
 
-func (rest *TestSpaceREST) TestSuccessShowProject() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
+func (rest *TestSpaceREST) TestShowSpaceOK() {
+	// given
 	name := "Test 27"
 	description := "Space for Test 27"
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	p.Data.Attributes.Description = &description
-
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
+	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
+	// when
+	res, fetched := test.ShowSpaceOK(rest.T(), svc.Context, svc, ctrl, created.Data.ID.String(), nil, nil)
+	// then
+	assert.Equal(rest.T(), created.Data.ID, fetched.Data.ID)
+	assert.Equal(rest.T(), *created.Data.Attributes.Name, *fetched.Data.Attributes.Name)
+	assert.Equal(rest.T(), *created.Data.Attributes.Description, *fetched.Data.Attributes.Description)
+	assert.Equal(rest.T(), *created.Data.Attributes.Version, *fetched.Data.Attributes.Version)
+	require.NotNil(rest.T(), res.Header()[app.LastModified])
+	assert.Equal(rest.T(), getSpaceUpdatedAt(*created).String(), res.Header()[app.LastModified][0])
+	require.NotNil(rest.T(), res.Header()[app.CacheControl])
+	assert.Equal(rest.T(), app.MaxAge+"=86400", res.Header()[app.CacheControl][0])
+	require.NotNil(rest.T(), res.Header()[app.ETag])
+	assert.Equal(rest.T(), app.GenerateEntityTag(ConvertSpaceToModel(*created.Data)), res.Header()[app.ETag][0])
+}
 
-	_, fetched := test.ShowSpaceOK(t, svc.Context, svc, ctrl, created.Data.ID.String())
-	assert.Equal(t, created.Data.ID, fetched.Data.ID)
-	assert.Equal(t, *created.Data.Attributes.Name, *fetched.Data.Attributes.Name)
-	assert.Equal(t, *created.Data.Attributes.Description, *fetched.Data.Attributes.Description)
-	assert.Equal(t, *created.Data.Attributes.Version, *fetched.Data.Attributes.Version)
+func (rest *TestSpaceREST) TestShowSpaceOKUsingExpiredIfModifiedSinceHeader() {
+	// given
+	name := "Test 27"
+	description := "Space for Test 27"
+	p := minimumRequiredCreateSpace()
+	p.Data.Attributes.Name = &name
+	p.Data.Attributes.Description = &description
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
+	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
+	// when
+	ifModifiedSince := created.Data.Attributes.UpdatedAt.Add(-1 * time.Hour)
+	res, fetched := test.ShowSpaceOK(rest.T(), svc.Context, svc, ctrl, created.Data.ID.String(), &ifModifiedSince, nil)
+	// then
+	assert.Equal(rest.T(), created.Data.ID, fetched.Data.ID)
+	assert.Equal(rest.T(), *created.Data.Attributes.Name, *fetched.Data.Attributes.Name)
+	assert.Equal(rest.T(), *created.Data.Attributes.Description, *fetched.Data.Attributes.Description)
+	assert.Equal(rest.T(), *created.Data.Attributes.Version, *fetched.Data.Attributes.Version)
+	require.NotNil(rest.T(), res.Header()[app.LastModified])
+	assert.Equal(rest.T(), getSpaceUpdatedAt(*created).String(), res.Header()[app.LastModified][0])
+	require.NotNil(rest.T(), res.Header()[app.CacheControl])
+	assert.Equal(rest.T(), app.MaxAge+"=86400", res.Header()[app.CacheControl][0])
+	require.NotNil(rest.T(), res.Header()[app.ETag])
+	assert.Equal(rest.T(), generateSpaceTag(*created), res.Header()[app.ETag][0])
+}
+
+func (rest *TestSpaceREST) TestShowSpaceOKUsingExpiredIfNoneMatchHeader() {
+	// given
+	name := "Test 27"
+	description := "Space for Test 27"
+	p := minimumRequiredCreateSpace()
+	p.Data.Attributes.Name = &name
+	p.Data.Attributes.Description = &description
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
+	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
+	// when
+	ifNoneMatch := "foo_etag"
+	res, fetched := test.ShowSpaceOK(rest.T(), svc.Context, svc, ctrl, created.Data.ID.String(), nil, &ifNoneMatch)
+	// then
+	assert.Equal(rest.T(), created.Data.ID, fetched.Data.ID)
+	assert.Equal(rest.T(), *created.Data.Attributes.Name, *fetched.Data.Attributes.Name)
+	assert.Equal(rest.T(), *created.Data.Attributes.Description, *fetched.Data.Attributes.Description)
+	assert.Equal(rest.T(), *created.Data.Attributes.Version, *fetched.Data.Attributes.Version)
+	require.NotNil(rest.T(), res.Header()[app.LastModified])
+	assert.Equal(rest.T(), getSpaceUpdatedAt(*created).String(), res.Header()[app.LastModified][0])
+	require.NotNil(rest.T(), res.Header()[app.CacheControl])
+	assert.Equal(rest.T(), app.MaxAge+"=86400", res.Header()[app.CacheControl][0])
+	require.NotNil(rest.T(), res.Header()[app.ETag])
+	assert.Equal(rest.T(), generateSpaceTag(*created), res.Header()[app.ETag][0])
+}
+
+func (rest *TestSpaceREST) TestShowSpaceNotModifiedUsingIfModifiedSinceHeader() {
+	// given
+	name := "Test 27"
+	description := "Space for Test 27"
+	p := minimumRequiredCreateSpace()
+	p.Data.Attributes.Name = &name
+	p.Data.Attributes.Description = &description
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
+	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
+	// when/then
+	ifModifiedSince := getSpaceUpdatedAt(*created)
+	test.ShowSpaceNotModified(rest.T(), svc.Context, svc, ctrl, created.Data.ID.String(), &ifModifiedSince, nil)
+}
+
+func (rest *TestSpaceREST) TestShowSpaceNotModifiedUsingIfNoneMatchHeader() {
+	// given
+	name := "Test 27"
+	description := "Space for Test 27"
+	p := minimumRequiredCreateSpace()
+	p.Data.Attributes.Name = &name
+	p.Data.Attributes.Description = &description
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
+	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
+	// when/then
+	ifNoneMatch := generateSpaceTag(*created)
+	test.ShowSpaceNotModified(rest.T(), svc.Context, svc, ctrl, created.Data.ID.String(), nil, &ifNoneMatch)
 }
 
 func (rest *TestSpaceREST) TestFailShowSpaceNotFound() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	svc, ctrl := rest.UnSecuredController()
-	test.ShowSpaceNotFound(t, svc.Context, svc, ctrl, uuid.NewV4().String())
+	// when/then
+	test.ShowSpaceNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4().String(), nil, nil)
 }
 
 func (rest *TestSpaceREST) TestFailShowSpaceNotFoundBadID() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	svc, ctrl := rest.UnSecuredController()
-	test.ShowSpaceNotFound(t, svc.Context, svc, ctrl, "asfasfsaf")
+	// when/then
+	test.ShowSpaceNotFound(rest.T(), svc.Context, svc, ctrl, "asfasfsaf", nil, nil)
 }
 
-func (rest *TestSpaceREST) TestSuccessListSpaces() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
-	name := "Test 24"
-
+func (rest *TestSpaceREST) TestListSpacesOK() {
+	// given
+	name := "Test 24" + uuid.NewV4().String()
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
-
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
-
-	_, list := test.ListSpaceOK(t, svc.Context, svc, ctrl, nil, nil)
-	assert.True(t, len(list.Data) > 0)
+	test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
+	// when
+	_, list := test.ListSpaceOK(rest.T(), svc.Context, svc, ctrl, nil, nil, nil, nil)
+	// then
+	require.NotNil(rest.T(), list)
+	require.NotEmpty(rest.T(), list.Data)
 	for _, spc := range list.Data {
 		subString := fmt.Sprintf("/%s/iterations", spc.ID.String())
-		assert.Contains(t, *spc.Relationships.Iterations.Links.Related, subString)
-
+		assert.Contains(rest.T(), *spc.Relationships.Iterations.Links.Related, subString)
 		subStringAreaUrl := fmt.Sprintf("/%s/areas", spc.ID.String())
-		assert.Contains(t, *spc.Relationships.Areas.Links.Related, subStringAreaUrl)
+		assert.Contains(rest.T(), *spc.Relationships.Areas.Links.Related, subStringAreaUrl)
 	}
+}
+
+func (rest *TestSpaceREST) TestListSpacesOKUsingExpiredIfModifiedSinceHeader() {
+	// given
+	name := "Test 24" + uuid.NewV4().String()
+	p := minimumRequiredCreateSpace()
+	p.Data.Attributes.Name = &name
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
+	test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
+	// when
+	ifModifiedSince := time.Now().Add(-1 * time.Hour)
+	_, list := test.ListSpaceOK(rest.T(), svc.Context, svc, ctrl, nil, nil, &ifModifiedSince, nil)
+	// then
+	require.NotNil(rest.T(), list)
+	require.NotEmpty(rest.T(), list.Data)
+}
+
+func (rest *TestSpaceREST) TestListSpacesOKUsingExpiredIfNoneMatchHeader() {
+	// given
+	name := "Test 24" + uuid.NewV4().String()
+	p := minimumRequiredCreateSpace()
+	p.Data.Attributes.Name = &name
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
+	test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
+	// when
+	ifNoneMatch := "fooo-spaces"
+	_, list := test.ListSpaceOK(rest.T(), svc.Context, svc, ctrl, nil, nil, nil, &ifNoneMatch)
+	// then
+	require.NotNil(rest.T(), list)
+	require.NotEmpty(rest.T(), list.Data)
+}
+
+func (rest *TestSpaceREST) TestListSpacesNotModifiedUsingIfModifiedSinceHeader() {
+	// given
+	name := "Test 24" + uuid.NewV4().String()
+	p := minimumRequiredCreateSpace()
+	p.Data.Attributes.Name = &name
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
+	_, createdSpace := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
+	// when/then
+	ifModifiedSince := createdSpace.Data.Attributes.UpdatedAt
+	test.ListSpaceNotModified(rest.T(), svc.Context, svc, ctrl, nil, nil, ifModifiedSince, nil)
+}
+
+func (rest *TestSpaceREST) TestListSpacesNotModifiedUsingIfNoneMatchHeader() {
+	// given
+	name := "Test 24" + uuid.NewV4().String()
+	p := minimumRequiredCreateSpace()
+	p.Data.Attributes.Name = &name
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
+	test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
+	_, spaceList := test.ListSpaceOK(rest.T(), svc.Context, svc, ctrl, nil, nil, nil, nil)
+	// when/then
+	ifNoneMatch := generateSpacesTag(*spaceList)
+	test.ListSpaceNotModified(rest.T(), svc.Context, svc, ctrl, nil, nil, nil, &ifNoneMatch)
 }
 
 func minimumRequiredCreateSpace() *app.CreateSpacePayload {
@@ -379,4 +479,28 @@ func minimumRequiredUpdateSpace() *app.UpdateSpacePayload {
 			Attributes: &app.SpaceAttributes{},
 		},
 	}
+}
+
+func generateSpacesTag(entities app.SpaceList) string {
+	modelEntities := make([]app.ConditionalResponseEntity, len(entities.Data))
+	for i, entityData := range entities.Data {
+		modelEntities[i] = ConvertSpaceToModel(*entityData)
+	}
+	return app.GenerateEntitiesTag(modelEntities)
+}
+
+func generateSpaceTag(entity app.SpaceSingle) string {
+	return app.GenerateEntityTag(ConvertSpaceToModel(*entity.Data))
+}
+
+func convertSpacesToConditionalEntities(spaceList app.SpaceList) []app.ConditionalResponseEntity {
+	conditionalSpaces := make([]app.ConditionalResponseEntity, len(spaceList.Data))
+	for i, spaceData := range spaceList.Data {
+		conditionalSpaces[i] = ConvertSpaceToModel(*spaceData)
+	}
+	return conditionalSpaces
+}
+
+func getSpaceUpdatedAt(appSpace app.SpaceSingle) time.Time {
+	return appSpace.Data.Attributes.UpdatedAt.Truncate(time.Second).UTC()
 }

--- a/controller/space_test.go
+++ b/controller/space_test.go
@@ -97,7 +97,7 @@ func (rest *TestSpaceREST) TestFailCreateSpaceMissingName() {
 
 func (rest *TestSpaceREST) TestSuccessCreateSpace() {
 	// given
-	name := "Test 24" + uuid.NewV4().String()
+	name := "TestSuccessCreateSpace-" + uuid.NewV4().String()
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
@@ -122,7 +122,7 @@ func (rest *TestSpaceREST) SecuredSpaceAreaController(identity account.Identity)
 
 func (rest *TestSpaceREST) TestSuccessCreateSpaceAndDefaultArea() {
 	// given
-	name := "Test24ForSpaceAndArea2"
+	name := "TestSuccessCreateSpaceAndDefaultArea-" + uuid.NewV4().String()
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
@@ -141,8 +141,8 @@ func (rest *TestSpaceREST) TestSuccessCreateSpaceAndDefaultArea() {
 
 func (rest *TestSpaceREST) TestSuccessCreateSpaceWithDescription() {
 	// given
-	name := "Test 24" + uuid.NewV4().String()
-	description := "Space for Test 24"
+	name := "TestSuccessCreateSpaceWithDescription-" + uuid.NewV4().String()
+	description := "Space for TestSuccessCreateSpaceWithDescription"
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	p.Data.Attributes.Description = &description
@@ -164,10 +164,10 @@ func (rest *TestSpaceREST) TestSuccessCreateSpaceWithDescription() {
 
 func (rest *TestSpaceREST) TestSuccessUpdateSpace() {
 	// given
-	name := "Test 25"
-	description := "Space for Test 25"
-	newName := "Test 26"
-	newDescription := "Space for Test 25"
+	name := "TestSuccessUpdateSpace-" + uuid.NewV4().String()
+	description := "Space for TestSuccessUpdateSpace"
+	newName := "TestSuccessUpdateSpace" + uuid.NewV4().String()
+	newDescription := "Space for TestSuccessUpdateSpace2"
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	p.Data.Attributes.Description = &description
@@ -187,10 +187,10 @@ func (rest *TestSpaceREST) TestSuccessUpdateSpace() {
 
 func (rest *TestSpaceREST) TestFailUpdateSpaceDifferentOwner() {
 	// given
-	name := "Test 25"
-	description := "Space for Test 25"
-	newName := "Test 26"
-	newDescription := "Space for Test 25"
+	name := "TestFailUpdateSpaceDifferentOwner-" + uuid.NewV4().String()
+	description := "Space for TestFailUpdateSpaceDifferentOwner"
+	newName := "TestFailUpdateSpaceDifferentOwner-" + uuid.NewV4().String()
+	newDescription := "Space for TestFailUpdateSpaceDifferentOwner2"
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	p.Data.Attributes.Description = &description
@@ -219,7 +219,7 @@ func (rest *TestSpaceREST) TestFailUpdateSpaceUnSecure() {
 
 func (rest *TestSpaceREST) TestFailUpdateSpaceNotFound() {
 	// given
-	name := "test"
+	name := "TestFailUpdateSpaceNotFound-" + uuid.NewV4().String()
 	version := 0
 	id := uuid.NewV4()
 	u := minimumRequiredUpdateSpace()
@@ -233,7 +233,7 @@ func (rest *TestSpaceREST) TestFailUpdateSpaceNotFound() {
 
 func (rest *TestSpaceREST) TestFailUpdateSpaceMissingName() {
 	// given
-	name := "Test 25"
+	name := "TestFailUpdateSpaceMissingName-" + uuid.NewV4().String()
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
@@ -247,8 +247,8 @@ func (rest *TestSpaceREST) TestFailUpdateSpaceMissingName() {
 
 func (rest *TestSpaceREST) TestFailUpdateSpaceMissingVersion() {
 	// given
-	name := "Test 25"
-	newName := "Test 26"
+	name := "TestFailUpdateSpaceMissingVersion-" + uuid.NewV4().String()
+	newName := "TestFailUpdateSpaceMissingVersion-" + uuid.NewV4().String()
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
@@ -262,8 +262,8 @@ func (rest *TestSpaceREST) TestFailUpdateSpaceMissingVersion() {
 
 func (rest *TestSpaceREST) TestShowSpaceOK() {
 	// given
-	name := "Test 27"
-	description := "Space for Test 27"
+	name := "TestShowSpaceOK-" + uuid.NewV4().String()
+	description := "Space for TestShowSpaceOK"
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	p.Data.Attributes.Description = &description
@@ -286,8 +286,8 @@ func (rest *TestSpaceREST) TestShowSpaceOK() {
 
 func (rest *TestSpaceREST) TestShowSpaceOKUsingExpiredIfModifiedSinceHeader() {
 	// given
-	name := "Test 27"
-	description := "Space for Test 27"
+	name := "TestShowSpaceOKUsingExpiredIfModifiedSinceHeader-" + uuid.NewV4().String()
+	description := "Space for TestShowSpaceOKUsingExpiredIfModifiedSinceHeader"
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	p.Data.Attributes.Description = &description
@@ -311,8 +311,8 @@ func (rest *TestSpaceREST) TestShowSpaceOKUsingExpiredIfModifiedSinceHeader() {
 
 func (rest *TestSpaceREST) TestShowSpaceOKUsingExpiredIfNoneMatchHeader() {
 	// given
-	name := "Test 27"
-	description := "Space for Test 27"
+	name := "TestShowSpaceOKUsingExpiredIfNoneMatchHeader-" + uuid.NewV4().String()
+	description := "Space for TestShowSpaceOKUsingExpiredIfNoneMatchHeader"
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	p.Data.Attributes.Description = &description
@@ -336,8 +336,8 @@ func (rest *TestSpaceREST) TestShowSpaceOKUsingExpiredIfNoneMatchHeader() {
 
 func (rest *TestSpaceREST) TestShowSpaceNotModifiedUsingIfModifiedSinceHeader() {
 	// given
-	name := "Test 27"
-	description := "Space for Test 27"
+	name := "TestShowSpaceNotModifiedUsingIfModifiedSinceHeader-" + uuid.NewV4().String()
+	description := "Space for TestShowSpaceNotModifiedUsingIfModifiedSinceHeader"
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	p.Data.Attributes.Description = &description
@@ -350,8 +350,8 @@ func (rest *TestSpaceREST) TestShowSpaceNotModifiedUsingIfModifiedSinceHeader() 
 
 func (rest *TestSpaceREST) TestShowSpaceNotModifiedUsingIfNoneMatchHeader() {
 	// given
-	name := "Test 27"
-	description := "Space for Test 27"
+	name := "TestShowSpaceNotModifiedUsingIfNoneMatchHeader-" + uuid.NewV4().String()
+	description := "Space for TestShowSpaceNotModifiedUsingIfNoneMatchHeader"
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	p.Data.Attributes.Description = &description
@@ -378,7 +378,7 @@ func (rest *TestSpaceREST) TestFailShowSpaceNotFoundBadID() {
 
 func (rest *TestSpaceREST) TestListSpacesOK() {
 	// given
-	name := "Test 24" + uuid.NewV4().String()
+	name := "TestListSpacesOK-" + uuid.NewV4().String()
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
@@ -403,7 +403,7 @@ func (rest *TestSpaceREST) TestListSpacesOK() {
 
 func (rest *TestSpaceREST) TestListSpacesOKUsingExpiredIfModifiedSinceHeader() {
 	// given
-	name := "Test 24" + uuid.NewV4().String()
+	name := "TestListSpacesOKUsingExpiredIfModifiedSinceHeader-" + uuid.NewV4().String()
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
@@ -418,7 +418,7 @@ func (rest *TestSpaceREST) TestListSpacesOKUsingExpiredIfModifiedSinceHeader() {
 
 func (rest *TestSpaceREST) TestListSpacesOKUsingExpiredIfNoneMatchHeader() {
 	// given
-	name := "Test 24" + uuid.NewV4().String()
+	name := "TestListSpacesOKUsingExpiredIfNoneMatchHeader-" + uuid.NewV4().String()
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
@@ -433,7 +433,7 @@ func (rest *TestSpaceREST) TestListSpacesOKUsingExpiredIfNoneMatchHeader() {
 
 func (rest *TestSpaceREST) TestListSpacesNotModifiedUsingIfModifiedSinceHeader() {
 	// given
-	name := "Test 24" + uuid.NewV4().String()
+	name := "TestListSpacesNotModifiedUsingIfModifiedSinceHeader-" + uuid.NewV4().String()
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
@@ -445,7 +445,7 @@ func (rest *TestSpaceREST) TestListSpacesNotModifiedUsingIfModifiedSinceHeader()
 
 func (rest *TestSpaceREST) TestListSpacesNotModifiedUsingIfNoneMatchHeader() {
 	// given
-	name := "Test 24" + uuid.NewV4().String()
+	name := "TestListSpacesNotModifiedUsingIfNoneMatchHeader-" + uuid.NewV4().String()
 	p := minimumRequiredCreateSpace()
 	p.Data.Attributes.Name = &name
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)

--- a/controller/space_test.go
+++ b/controller/space_test.go
@@ -391,7 +391,7 @@ func (rest *TestSpaceREST) TestListSpacesOK() {
 	for _, spc := range list.Data {
 		// Test that it contains the right link for backlog items
 		subStringBacklogUrl := fmt.Sprintf("/%s/backlog", spc.ID.String())
-		assert.Contains(t, *spc.Links.Backlog, subStringBacklogUrl)
+		assert.Contains(rest.T(), *spc.Links.Backlog, subStringBacklogUrl)
 
 		// Test that it contains the right relationship values
 		subString := fmt.Sprintf("/%s/iterations", spc.ID.String())

--- a/controller/trackerquery_blackbox_test.go
+++ b/controller/trackerquery_blackbox_test.go
@@ -267,7 +267,7 @@ func (rest *TestTrackerQueryREST) TestUpdateTrackerQuery() {
 		Schedule:  tqr.Schedule,
 		TrackerID: result.ID,
 		Relationships: &app.TrackerQueryRelationships{
-			Space: space.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
+			Space: app.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
 		},
 	}
 
@@ -343,7 +343,7 @@ func getCreateTrackerQueryPayload(trackerID string) app.CreateTrackerQueryAltern
 		Schedule:  "15 * * * * *",
 		TrackerID: trackerID,
 		Relationships: &app.TrackerQueryRelationships{
-			Space: space.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
+			Space: app.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
 		},
 	}
 }

--- a/controller/work_item_children_blackbox_test.go
+++ b/controller/work_item_children_blackbox_test.go
@@ -203,7 +203,7 @@ func createParentChildWorkItemLinkType(name string, sourceTypeID, targetTypeID, 
 	reqLong := &goa.RequestData{
 		Request: &http.Request{Host: "api.service.domain.org"},
 	}
-	payload := ConvertLinkTypeFromModel(reqLong, lt)
+	payload := ConvertWorkItemLinkTypeFromModel(reqLong, lt)
 	// The create payload is required during creation. Simply copy data over.
 	return &app.CreateWorkItemLinkTypePayload{
 		Data: payload.Data,

--- a/controller/work_item_link.go
+++ b/controller/work_item_link.go
@@ -138,7 +138,7 @@ func enrichLinkSingle(ctx *workItemLinkContext, appLinks *app.WorkItemLinkSingle
 	if err != nil {
 		return errs.WithStack(err)
 	}
-	appLinkType := ConvertLinkTypeFromModel(ctx.RequestData, *modelLinkType)
+	appLinkType := ConvertWorkItemLinkTypeFromModel(ctx.RequestData, *modelLinkType)
 	appLinks.Included = append(appLinks.Included, appLinkType.Data)
 
 	// include link category

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -245,7 +245,7 @@ func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
 	if ctx.Payload.Data != nil && ctx.Payload.Data.Relationships != nil {
 		// We overwrite or use the space ID in the URL to set the space of this WI
 		spaceSelfURL := rest.AbsoluteURL(goa.ContextRequest(ctx), app.SpaceHref(spaceID.String()))
-		ctx.Payload.Data.Relationships.Space = space.NewSpaceRelation(spaceID, spaceSelfURL)
+		ctx.Payload.Data.Relationships.Space = app.NewSpaceRelation(spaceID, spaceSelfURL)
 	}
 	wi := workitem.WorkItem{
 		Fields: make(map[string]interface{}),
@@ -499,7 +499,7 @@ func ConvertWorkItem(request *goa.RequestData, wi *workitem.WorkItem, additional
 					Type: APIStringTypeWorkItemType,
 				},
 			},
-			Space: space.NewSpaceRelation(wi.SpaceID, spaceSelfURL),
+			Space: app.NewSpaceRelation(wi.SpaceID, spaceSelfURL),
 		},
 		Links: &app.GenericLinksForWorkItem{
 			Self:            &selfURL,

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/almighty/almighty-core/controller"
 	"github.com/almighty/almighty-core/gormapplication"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
+	"github.com/almighty/almighty-core/gormtestsupport"
 	"github.com/almighty/almighty-core/iteration"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/migration"
@@ -60,8 +61,7 @@ func TestSuiteWorkItem1(t *testing.T) {
 }
 
 type WorkItemSuite struct {
-	suite.Suite
-	db             *gorm.DB
+	gormtestsupport.DBTestSuite
 	clean          func()
 	controller     app.WorkitemController
 	pubKey         *rsa.PublicKey
@@ -75,38 +75,38 @@ type WorkItemSuite struct {
 
 func (s *WorkItemSuite) SetupSuite() {
 	var err error
-	s.db, err = gorm.Open("postgres", wibConfiguration.GetPostgresConfigString())
+	s.DB, err = gorm.Open("postgres", wibConfiguration.GetPostgresConfigString())
 	if err != nil {
 		panic("Failed to connect database: " + err.Error())
 	}
 	s.priKey, _ = almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
 	// Make sure the database is populated with the correct types (e.g. bug etc.)
 	if wibConfiguration.GetPopulateCommonTypes() {
-		if err := models.Transactional(s.db, func(tx *gorm.DB) error {
+		if err := models.Transactional(s.DB, func(tx *gorm.DB) error {
 			s.ctx = migration.NewMigrationContext(context.Background())
 			return migration.PopulateCommonTypes(s.ctx, tx, workitem.NewWorkItemTypeRepository(tx))
 		}); err != nil {
 			panic(err.Error())
 		}
 	}
-	s.clean = cleaner.DeleteCreatedEntities(s.db)
+	s.clean = cleaner.DeleteCreatedEntities(s.DB)
 
 	// create a test identity
-	testIdentity, err := testsupport.CreateTestIdentity(s.db, "test user", "test provider")
+	testIdentity, err := testsupport.CreateTestIdentity(s.DB, "test user", "test provider")
 	require.Nil(s.T(), err)
 	s.testIdentity = testIdentity
 }
 
 func (s *WorkItemSuite) TearDownSuite() {
-	s.clean()
-	if s.db != nil {
-		s.db.Close()
+	if s.DB != nil {
+		s.clean()
+		s.DB.Close()
 	}
 }
 
 func (s *WorkItemSuite) SetupTest() {
 	s.svc = testsupport.ServiceAsUser("TestUpdateWI-Service", almtoken.NewManagerWithPrivateKey(s.priKey), s.testIdentity)
-	s.controller = NewWorkitemController(s.svc, gormapplication.NewGormDB(s.db))
+	s.controller = NewWorkitemController(s.svc, gormapplication.NewGormDB(s.DB))
 	payload := minimumRequiredCreateWithType(workitem.SystemBug)
 	payload.Data.Attributes[workitem.SystemTitle] = "Test WI"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
@@ -513,7 +513,7 @@ func (s *WorkItemSuite) TestUnauthorizeWorkItemCUD() {
 	UnauthorizeCreateUpdateDeleteTest(s.T(), getWorkItemTestData, func() *goa.Service {
 		return goa.New("TestUnauthorizedCreateWI-Service")
 	}, func(service *goa.Service) error {
-		controller := NewWorkitemController(service, gormapplication.NewGormDB(s.db))
+		controller := NewWorkitemController(service, gormapplication.NewGormDB(s.DB))
 		app.MountWorkitemController(service, controller)
 		return nil
 	})
@@ -596,7 +596,7 @@ func minimumRequiredUpdatePayload() app.UpdateWorkitemPayload {
 			Type:       APIStringTypeWorkItem,
 			Attributes: map[string]interface{}{},
 			Relationships: &app.WorkItemRelationships{
-				Space: space.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
+				Space: app.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
 			},
 		},
 	}
@@ -632,7 +632,7 @@ func minimumRequiredCreatePayload() app.CreateWorkitemPayload {
 			Type:       APIStringTypeWorkItem,
 			Attributes: map[string]interface{}{},
 			Relationships: &app.WorkItemRelationships{
-				Space: space.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
+				Space: app.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
 			},
 		},
 	}
@@ -738,8 +738,7 @@ func ident(id uuid.UUID) *app.GenericData {
 }
 
 type WorkItem2Suite struct {
-	suite.Suite
-	db             *gorm.DB
+	gormtestsupport.DBTestSuite
 	clean          func()
 	wiCtrl         app.WorkitemController
 	wi2Ctrl        app.WorkitemController
@@ -757,42 +756,35 @@ type WorkItem2Suite struct {
 
 func (s *WorkItem2Suite) SetupSuite() {
 	var err error
-	s.db, err = gorm.Open("postgres", wibConfiguration.GetPostgresConfigString())
+	s.DB, err = gorm.Open("postgres", wibConfiguration.GetPostgresConfigString())
 	if err != nil {
 		panic("Failed to connect database: " + err.Error())
 	}
 	// Make sure the database is populated with the correct types (e.g. bug etc.)
 	if wibConfiguration.GetPopulateCommonTypes() {
-		if err := models.Transactional(s.db, func(tx *gorm.DB) error {
+		if err := models.Transactional(s.DB, func(tx *gorm.DB) error {
 			s.ctx = migration.NewMigrationContext(context.Background())
 			return migration.PopulateCommonTypes(s.ctx, tx, workitem.NewWorkItemTypeRepository(tx))
 		}); err != nil {
 			panic(err.Error())
 		}
 	}
-	s.clean = cleaner.DeleteCreatedEntities(s.db)
+	s.clean = cleaner.DeleteCreatedEntities(s.DB)
 
 	// create identity
-	testIdentity, err := testsupport.CreateTestIdentity(s.db, "test user", "test provider")
+	testIdentity, err := testsupport.CreateTestIdentity(s.DB, "test user", "test provider")
 	require.Nil(s.T(), err)
 	s.priKey, _ = almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
 	s.svc = testsupport.ServiceAsUser("TestUpdateWI2-Service", almtoken.NewManagerWithPrivateKey(s.priKey), testIdentity)
 }
 
-func (s *WorkItem2Suite) TearDownSuite() {
-	s.clean()
-	if s.db != nil {
-		s.db.Close()
-	}
-}
-
 func (s *WorkItem2Suite) SetupTest() {
-	s.wiCtrl = NewWorkitemController(s.svc, gormapplication.NewGormDB(s.db))
-	s.wi2Ctrl = NewWorkitemController(s.svc, gormapplication.NewGormDB(s.db))
-	s.linkCatCtrl = NewWorkItemLinkCategoryController(s.svc, gormapplication.NewGormDB(s.db))
-	s.linkTypeCtrl = NewWorkItemLinkTypeController(s.svc, gormapplication.NewGormDB(s.db))
-	s.linkCtrl = NewWorkItemLinkController(s.svc, gormapplication.NewGormDB(s.db))
-	s.spaceCtrl = NewSpaceController(s.svc, gormapplication.NewGormDB(s.db), wibConfiguration, &DummyResourceManager{})
+	s.wiCtrl = NewWorkitemController(s.svc, gormapplication.NewGormDB(s.DB))
+	s.wi2Ctrl = NewWorkitemController(s.svc, gormapplication.NewGormDB(s.DB))
+	s.linkCatCtrl = NewWorkItemLinkCategoryController(s.svc, gormapplication.NewGormDB(s.DB))
+	s.linkTypeCtrl = NewWorkItemLinkTypeController(s.svc, gormapplication.NewGormDB(s.DB))
+	s.linkCtrl = NewWorkItemLinkController(s.svc, gormapplication.NewGormDB(s.DB))
+	s.spaceCtrl = NewSpaceController(s.svc, gormapplication.NewGormDB(s.DB), s.Configuration, &DummyResourceManager{})
 
 	payload := minimumRequiredCreateWithType(workitem.SystemBug)
 	payload.Data.Attributes[workitem.SystemTitle] = "Test WI"
@@ -928,7 +920,7 @@ func (s *WorkItem2Suite) TestWI2UpdateMultipleScenarios() {
 	s.minimumPayload.Data.Attributes["version"] = updatedWI.Data.Attributes["version"]
 
 	// update assignee relationship and verify
-	newUser := createOneRandomUserIdentity(s.svc.Context, s.db)
+	newUser := createOneRandomUserIdentity(s.svc.Context, s.DB)
 	require.NotNil(s.T(), newUser)
 
 	newUserUUID := newUser.ID.String()
@@ -1178,7 +1170,7 @@ func (s *WorkItem2Suite) TestWI2FailCreateWithEmptyTitle() {
 func (s *WorkItem2Suite) TestWI2SuccessCreateWithAssigneeRelation() {
 	// given
 	userType := "identities"
-	newUser := createOneRandomUserIdentity(s.svc.Context, s.db)
+	newUser := createOneRandomUserIdentity(s.svc.Context, s.DB)
 	newUserId := newUser.ID.String()
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
@@ -1209,9 +1201,9 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWithAssigneeRelation() {
 
 func (s *WorkItem2Suite) TestWI2SuccessCreateWithAssigneesRelation() {
 	// given
-	newUser := createOneRandomUserIdentity(s.svc.Context, s.db)
-	newUser2 := createOneRandomUserIdentity(s.svc.Context, s.db)
-	newUser3 := createOneRandomUserIdentity(s.svc.Context, s.db)
+	newUser := createOneRandomUserIdentity(s.svc.Context, s.DB)
+	newUser2 := createOneRandomUserIdentity(s.svc.Context, s.DB)
+	newUser3 := createOneRandomUserIdentity(s.svc.Context, s.DB)
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
@@ -1258,7 +1250,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWithAssigneesRelation() {
 
 func (s *WorkItem2Suite) TestWI2ListByAssigneeFilter() {
 	// given
-	newUser := createOneRandomUserIdentity(s.svc.Context, s.db)
+	newUser := createOneRandomUserIdentity(s.svc.Context, s.DB)
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
@@ -1365,7 +1357,7 @@ func (s *WorkItem2Suite) TestWI2ListByWorkitemstateFilter() {
 }
 
 func (s *WorkItem2Suite) TestWI2ListByAreaFilter() {
-	tempArea := createOneRandomArea(s.svc.Context, s.db)
+	tempArea := createOneRandomArea(s.svc.Context, s.DB)
 	require.NotNil(s.T(), tempArea)
 	areaID := tempArea.ID.String()
 	c := minimumRequiredCreatePayload()
@@ -1397,7 +1389,7 @@ func (s *WorkItem2Suite) TestWI2ListByAreaFilter() {
 }
 
 func (s *WorkItem2Suite) TestWI2ListByIterationFilter() {
-	tempIteration := createOneRandomIteration(s.svc.Context, s.db)
+	tempIteration := createOneRandomIteration(s.svc.Context, s.DB)
 	require.NotNil(s.T(), tempIteration)
 	iterationID := tempIteration.ID.String()
 	c := minimumRequiredCreatePayload()
@@ -1449,7 +1441,7 @@ func (s *WorkItem2Suite) TestWI2FailCreateInvalidAssignees() {
 }
 
 func (s *WorkItem2Suite) TestWI2FailUpdateInvalidAssignees() {
-	newUser := createOneRandomUserIdentity(s.svc.Context, s.db)
+	newUser := createOneRandomUserIdentity(s.svc.Context, s.DB)
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
@@ -1481,8 +1473,8 @@ func (s *WorkItem2Suite) TestWI2FailUpdateInvalidAssignees() {
 }
 
 func (s *WorkItem2Suite) TestWI2SuccessUpdateWithAssigneesRelation() {
-	newUser := createOneRandomUserIdentity(s.svc.Context, s.db)
-	newUser2 := createOneRandomUserIdentity(s.svc.Context, s.db)
+	newUser := createOneRandomUserIdentity(s.svc.Context, s.DB)
+	newUser2 := createOneRandomUserIdentity(s.svc.Context, s.DB)
 	c := minimumRequiredCreatePayload()
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
@@ -1609,7 +1601,7 @@ func (s *WorkItem2Suite) TestWI2FailMissingDelete() {
 func (s *WorkItem2Suite) TestWI2CreateWithArea() {
 	t := s.T()
 
-	areaInstance := createSpaceAndArea(t, gormapplication.NewGormDB(s.db))
+	areaInstance := createSpaceAndArea(t, gormapplication.NewGormDB(s.DB))
 	areaID := areaInstance.ID.String()
 	arType := area.APIStringTypeAreas
 
@@ -1627,7 +1619,7 @@ func (s *WorkItem2Suite) TestWI2CreateWithArea() {
 				ID:   workitem.SystemBug,
 			},
 		},
-		Space: space.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
+		Space: app.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
 		Area: &app.RelationGeneric{
 			Data: &app.GenericData{
 				Type: &arType,
@@ -1643,7 +1635,7 @@ func (s *WorkItem2Suite) TestWI2CreateWithArea() {
 func (s *WorkItem2Suite) TestWI2UpdateWithArea() {
 	t := s.T()
 
-	areaInstance := createSpaceAndArea(t, gormapplication.NewGormDB(s.db))
+	areaInstance := createSpaceAndArea(t, gormapplication.NewGormDB(s.DB))
 	areaID := areaInstance.ID.String()
 	arType := area.APIStringTypeAreas
 	c := minimumRequiredCreatePayload()
@@ -1705,7 +1697,7 @@ func (s *WorkItem2Suite) TestWI2CreateUnknownArea() {
 func (s *WorkItem2Suite) TestWI2CreateWithIteration() {
 	t := s.T()
 
-	iterationInstance := createSpaceAndIteration(t, gormapplication.NewGormDB(s.db))
+	iterationInstance := createSpaceAndIteration(t, gormapplication.NewGormDB(s.DB))
 	iterationID := iterationInstance.ID.String()
 	itType := iteration.APIStringTypeIteration
 
@@ -1724,7 +1716,7 @@ func (s *WorkItem2Suite) TestWI2CreateWithIteration() {
 				ID:   workitem.SystemBug,
 			},
 		},
-		Space: space.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
+		Space: app.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
 		Iteration: &app.RelationGeneric{
 			Data: &app.GenericData{
 				Type: &itType,
@@ -1740,7 +1732,7 @@ func (s *WorkItem2Suite) TestWI2CreateWithIteration() {
 func (s *WorkItem2Suite) TestWI2UpdateWithIteration() {
 	t := s.T()
 
-	iterationInstance := createSpaceAndIteration(t, gormapplication.NewGormDB(s.db))
+	iterationInstance := createSpaceAndIteration(t, gormapplication.NewGormDB(s.DB))
 	iterationID := iterationInstance.ID.String()
 	itType := iteration.APIStringTypeIteration
 
@@ -1780,7 +1772,7 @@ func (s *WorkItem2Suite) TestWI2UpdateRemoveIteration() {
 
 	t.Skip("iteration.data can't be sent as nil from client libs since it's optionall and is removed during json encoding")
 
-	iterationInstance := createSpaceAndIteration(t, gormapplication.NewGormDB(s.db))
+	iterationInstance := createSpaceAndIteration(t, gormapplication.NewGormDB(s.DB))
 	iterationID := iterationInstance.ID.String()
 	itType := iteration.APIStringTypeIteration
 
@@ -2049,13 +2041,13 @@ func (s *WorkItem2Suite) xTestWI2IfModifiedSince() {
 }
 
 func (s *WorkItem2Suite) TestWI2ListForChildIteration() {
-	grandParentIteration := createOneRandomIteration(s.svc.Context, s.db)
+	grandParentIteration := createOneRandomIteration(s.svc.Context, s.DB)
 	require.NotNil(s.T(), grandParentIteration)
 
-	parentIteration := newChildIteration(s.svc.Context, s.db, grandParentIteration)
+	parentIteration := newChildIteration(s.svc.Context, s.DB, grandParentIteration)
 	require.NotNil(s.T(), parentIteration)
 
-	childIteraiton := newChildIteration(s.svc.Context, s.db, parentIteration)
+	childIteraiton := newChildIteration(s.svc.Context, s.DB, parentIteration)
 	require.NotNil(s.T(), childIteraiton)
 
 	// create 3 work items for grandParentIteration

--- a/controller/workitem_whitebox_test.go
+++ b/controller/workitem_whitebox_test.go
@@ -156,7 +156,7 @@ func prepareWI2(attributes map[string]interface{}) app.WorkItem {
 					ID:   workitem.SystemBug,
 				},
 			},
-			Space: space.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
+			Space: app.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
 		},
 		Attributes: attributes,
 	}

--- a/controller/workitemtype.go
+++ b/controller/workitemtype.go
@@ -116,12 +116,10 @@ func (c *WorkitemtypeController) List(ctx *app.ListWorkitemtypeContext) error {
 	}
 	return application.Transactional(c.db, func(appl application.Application) error {
 		witModels, err := appl.WorkItemTypes().List(ctx.Context, spaceID, start, &limit)
-		logrus.Info("witModels: ", len(witModels))
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "Error listing work item types"))
 		}
 		return ctx.ConditionalEntities(witModels, c.config.GetCacheControlWorkItemType, func() error {
-			logrus.Info("conditional witModels..")
 			// TEMP!!!!! Until Space Template can setup a Space, redirect to SystemSpace WITs if non are found
 			// for the space.
 			if len(witModels) == 0 {
@@ -130,7 +128,6 @@ func (c *WorkitemtypeController) List(ctx *app.ListWorkitemtypeContext) error {
 					return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "Error listing work item types"))
 				}
 			}
-			logrus.Info("witModels: ", len(witModels))
 			// convert from model to app
 			result := &app.WorkItemTypeList{}
 			result.Data = make([]*app.WorkItemTypeData, len(witModels))
@@ -138,7 +135,6 @@ func (c *WorkitemtypeController) List(ctx *app.ListWorkitemtypeContext) error {
 				wit := ConvertWorkItemTypeFromModel(ctx.RequestData, &value)
 				result.Data[index] = &wit
 			}
-			logrus.Info("result: ", len(result.Data))
 			return ctx.OK(result)
 		})
 	})

--- a/controller/workitemtype_blackbox_test.go
+++ b/controller/workitemtype_blackbox_test.go
@@ -155,7 +155,7 @@ func (s *workItemTypeSuite) createWorkItemTypeAnimal() (http.ResponseWriter, *ap
 				},
 			},
 			Relationships: &app.WorkItemTypeRelationships{
-				Space: space.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
+				Space: app.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
 			},
 		},
 	}
@@ -201,7 +201,7 @@ func (s *workItemTypeSuite) createWorkItemTypePerson() (http.ResponseWriter, *ap
 				},
 			},
 			Relationships: &app.WorkItemTypeRelationships{
-				Space: space.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
+				Space: app.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
 			},
 		},
 	}
@@ -242,7 +242,7 @@ func CreateWorkItemType(id uuid.UUID, spaceID uuid.UUID) app.CreateWorkitemtypeP
 				},
 			},
 			Relationships: &app.WorkItemTypeRelationships{
-				Space: space.NewSpaceRelation(spaceID, spaceSelfURL),
+				Space: app.NewSpaceRelation(spaceID, spaceSelfURL),
 			},
 		},
 	}
@@ -293,11 +293,11 @@ func (s *workItemTypeSuite) TestShowWorkItemType200OK() {
 	require.NotNil(s.T(), wit2)
 	assert.EqualValues(s.T(), wit, wit2)
 	require.NotNil(s.T(), res.Header()[app.LastModified])
-	assert.Equal(s.T(), wit.GetLastModified().String(), res.Header()[app.LastModified][0])
+	assert.Equal(s.T(), getWorkItemTypeUpdatedAt(*wit).String(), res.Header()[app.LastModified][0])
 	require.NotNil(s.T(), res.Header()[app.CacheControl])
 	assert.Equal(s.T(), app.MaxAge+"=86400", res.Header()[app.CacheControl][0])
 	require.NotNil(s.T(), res.Header()[app.ETag])
-	assert.Equal(s.T(), app.GenerateETag(wit), res.Header()[app.ETag][0])
+	assert.Equal(s.T(), generateWorkItemTypeTag(*wit), res.Header()[app.ETag][0])
 }
 
 // TestShowWorkItemType200UsingExpiredLastModifiedHeader tests if we can fetch the work item type "animal"
@@ -316,11 +316,11 @@ func (s *workItemTypeSuite) TestShowWorkItemType200UsingExpiredLastModifiedHeade
 	require.NotNil(s.T(), wit2)
 	assert.EqualValues(s.T(), wit, wit2)
 	require.NotNil(s.T(), res.Header()[app.LastModified])
-	assert.Equal(s.T(), wit.GetLastModified().String(), res.Header()[app.LastModified][0])
+	assert.Equal(s.T(), getWorkItemTypeUpdatedAt(*wit).String(), res.Header()[app.LastModified][0])
 	require.NotNil(s.T(), res.Header()[app.CacheControl])
 	assert.Equal(s.T(), app.MaxAge+"=86400", res.Header()[app.CacheControl][0])
 	require.NotNil(s.T(), res.Header()[app.ETag])
-	assert.Equal(s.T(), app.GenerateETag(wit), res.Header()[app.ETag][0])
+	assert.Equal(s.T(), generateWorkItemTypeTag(*wit), res.Header()[app.ETag][0])
 }
 
 // TestShowWorkItemTypeOK200ExpiredETagHeader tests if we can fetch the work item type "animal"
@@ -339,11 +339,11 @@ func (s *workItemTypeSuite) TestShowWorkItemType200UsingExpiredETagHeader() {
 	require.NotNil(s.T(), wit2)
 	assert.EqualValues(s.T(), wit, wit2)
 	require.NotNil(s.T(), res.Header()[app.LastModified])
-	assert.Equal(s.T(), wit.GetLastModified().String(), res.Header()[app.LastModified][0])
+	assert.Equal(s.T(), getWorkItemTypeUpdatedAt(*wit).String(), res.Header()[app.LastModified][0])
 	require.NotNil(s.T(), res.Header()[app.CacheControl])
 	assert.Equal(s.T(), app.MaxAge+"=86400", res.Header()[app.CacheControl][0])
 	require.NotNil(s.T(), res.Header()[app.ETag])
-	assert.Equal(s.T(), app.GenerateETag(wit), res.Header()[app.ETag][0])
+	assert.Equal(s.T(), generateWorkItemTypeTag(*wit), res.Header()[app.ETag][0])
 }
 
 // TestShowWorkItemType304UsingIfModifiedSinceHeader tests
@@ -370,7 +370,7 @@ func (s *workItemTypeSuite) TestShowWorkItemType304UsingIfNoneMatchHeader() {
 	require.NotNil(s.T(), wit.Data)
 	require.NotNil(s.T(), wit.Data.ID)
 	// when/then
-	etag := app.GenerateETag(wit)
+	etag := generateWorkItemTypeTag(*wit)
 	test.ShowWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, wit.Data.Relationships.Space.Data.ID.String(), *wit.Data.ID, nil, &etag)
 }
 
@@ -395,11 +395,11 @@ func (s *workItemTypeSuite) TestListWorkItemType200OK() {
 	assert.Condition(s.T(), lookupWorkItemTypes(*witCollection, *witAnimal, *witPerson),
 		"Not all required work item types (animal and person) where found.")
 	require.NotNil(s.T(), res.Header()[app.LastModified])
-	assert.Equal(s.T(), witPerson.GetLastModified().String(), res.Header()[app.LastModified][0])
+	assert.Equal(s.T(), getWorkItemTypeUpdatedAt(*witPerson).String(), res.Header()[app.LastModified][0])
 	require.NotNil(s.T(), res.Header()[app.CacheControl])
 	assert.Equal(s.T(), app.MaxAge+"=86400", res.Header()[app.CacheControl][0])
 	require.NotNil(s.T(), res.Header()[app.ETag])
-	assert.Equal(s.T(), app.GenerateETag(witCollection), res.Header()[app.ETag][0])
+	assert.Equal(s.T(), generateWorkItemTypesTag(*witCollection), res.Header()[app.ETag][0])
 }
 
 // TestListWorkItemType200UsingExpiredIfModifiedSinceHeader tests if we can find the work item types
@@ -423,11 +423,11 @@ func (s *workItemTypeSuite) TestListWorkItemType200UsingExpiredIfModifiedSinceHe
 	assert.Condition(s.T(), lookupWorkItemTypes(*witCollection, *witAnimal, *witPerson),
 		"Not all required work item types (animal and person) where found.")
 	require.NotNil(s.T(), res.Header()[app.LastModified])
-	assert.Equal(s.T(), witPerson.GetLastModified().String(), res.Header()[app.LastModified][0])
+	assert.Equal(s.T(), getWorkItemTypeUpdatedAt(*witPerson).String(), res.Header()[app.LastModified][0])
 	require.NotNil(s.T(), res.Header()[app.CacheControl])
 	assert.Equal(s.T(), app.MaxAge+"=86400", res.Header()[app.CacheControl][0])
 	require.NotNil(s.T(), res.Header()[app.ETag])
-	assert.Equal(s.T(), app.GenerateETag(witCollection), res.Header()[app.ETag][0])
+	assert.Equal(s.T(), generateWorkItemTypesTag(*witCollection), res.Header()[app.ETag][0])
 }
 
 // TestListWorkItemType200UsingExpiredIfNoneMatchHeader tests if we can find the work item types
@@ -451,11 +451,11 @@ func (s *workItemTypeSuite) TestListWorkItemType200UsingExpiredIfNoneMatchHeader
 	assert.Condition(s.T(), lookupWorkItemTypes(*witCollection, *witAnimal, *witPerson),
 		"Not all required work item types (animal and person) where found.")
 	require.NotNil(s.T(), res.Header()[app.LastModified])
-	assert.Equal(s.T(), witPerson.GetLastModified().String(), res.Header()[app.LastModified][0])
+	assert.Equal(s.T(), getWorkItemTypeUpdatedAt(*witPerson).String(), res.Header()[app.LastModified][0])
 	require.NotNil(s.T(), res.Header()[app.CacheControl])
 	assert.Equal(s.T(), app.MaxAge+"=86400", res.Header()[app.CacheControl][0])
 	require.NotNil(s.T(), res.Header()[app.ETag])
-	assert.Equal(s.T(), app.GenerateETag(witCollection), res.Header()[app.ETag][0])
+	assert.Equal(s.T(), generateWorkItemTypesTag(*witCollection), res.Header()[app.ETag][0])
 }
 
 // TestListWorkItemType304UsingIfModifiedSinceHeader tests if we can find the work item types
@@ -470,7 +470,7 @@ func (s *workItemTypeSuite) TestListWorkItemType304UsingIfModifiedSinceHeader() 
 	// when/then
 	// Fetch a single work item type
 	// Paging in the format <start>,<limit>"
-	lastModified := witPerson.GetLastModified()
+	lastModified := getWorkItemTypeUpdatedAt(*witPerson)
 	page := "0,-1"
 	test.ListWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), &page, &lastModified, nil)
 }
@@ -484,12 +484,13 @@ func (s *workItemTypeSuite) TestListWorkItemType304UsingIfNoneMatchHeader() {
 	require.NotNil(s.T(), witAnimal)
 	_, witPerson := s.createWorkItemTypePerson()
 	require.NotNil(s.T(), witPerson)
+	// Paging in the format <start>,<limit>"
 	page := "0,-1"
 	_, witCollection := test.ListWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), &page, nil, nil)
+	require.NotNil(s.T(), witCollection)
 	// when/then
 	// Fetch a single work item type
-	// Paging in the format <start>,<limit>"
-	ifNoneMatch := app.GenerateETag(witCollection)
+	ifNoneMatch := generateWorkItemTypesTag(*witCollection)
 	test.ListWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), &page, nil, &ifNoneMatch)
 }
 
@@ -544,11 +545,11 @@ func (s *workItemTypeSuite) TestListWorkItemLinkTypeSources200OK() {
 	require.Len(s.T(), wiltCollection.Data, 1)
 	assert.Equal(s.T(), animalLinksToBugStr, *wiltCollection.Data[0].Attributes.Name)
 	require.NotNil(s.T(), res.Header()[app.LastModified])
-	assert.Equal(s.T(), sourceLinkType.GetLastModified().String(), res.Header()[app.LastModified][0])
+	assert.Equal(s.T(), getWorkItemLinkTypeUpdatedAt(sourceLinkType).String(), res.Header()[app.LastModified][0])
 	require.NotNil(s.T(), res.Header()[app.CacheControl])
 	assert.Equal(s.T(), app.MaxAge+"=86400", res.Header()[app.CacheControl][0])
 	require.NotNil(s.T(), res.Header()[app.ETag])
-	assert.Equal(s.T(), app.GenerateETag(sourceLinkType), res.Header()[app.ETag][0])
+	assert.Equal(s.T(), generateWorkItemLinkTypeTag(sourceLinkType), res.Header()[app.ETag][0])
 }
 
 // TestListWorkItemLinkTypeTargets200OK tests if we can find the work item link
@@ -564,11 +565,11 @@ func (s *workItemTypeSuite) TestListWorkItemLinkTypeTargets200OK() {
 	require.Len(s.T(), wiltCollection.Data, 1)
 	assert.Equal(s.T(), bugLinksToAnimalStr, *wiltCollection.Data[0].Attributes.Name)
 	require.NotNil(s.T(), res.Header()[app.LastModified])
-	assert.Equal(s.T(), targetLinkType.GetLastModified().String(), res.Header()[app.LastModified][0])
+	assert.Equal(s.T(), getWorkItemLinkTypeUpdatedAt(targetLinkType).String(), res.Header()[app.LastModified][0])
 	require.NotNil(s.T(), res.Header()[app.CacheControl])
 	assert.Equal(s.T(), app.MaxAge+"=86400", res.Header()[app.CacheControl][0])
 	require.NotNil(s.T(), res.Header()[app.ETag])
-	assert.Equal(s.T(), app.GenerateETag(targetLinkType), res.Header()[app.ETag][0])
+	assert.Equal(s.T(), generateWorkItemLinkTypeTag(targetLinkType), res.Header()[app.ETag][0])
 }
 
 // TestListSourceLinkTypes200UsingExpiredIfModifiedSinceHeader tests if we can find the work item link
@@ -577,19 +578,19 @@ func (s *workItemTypeSuite) TestListSourceLinkTypes200UsingExpiredIfModifiedSinc
 	// given
 	sourceLinkType, _ := s.createWorkitemtypeLinks()
 	// when fetch source link types
-	ifModifiedSince := sourceLinkType.Data.Attributes.UpdatedAt
-	res, wiltCollection := test.ListSourceLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), animalID, ifModifiedSince, nil)
+	ifModifiedSince := sourceLinkType.Data.Attributes.UpdatedAt.Add(-1 * time.Hour)
+	res, wiltCollection := test.ListSourceLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), animalID, &ifModifiedSince, nil)
 	require.NotNil(s.T(), wiltCollection)
 	assert.Nil(s.T(), wiltCollection.Validate())
 	// then check the number of found work item link types
 	require.Len(s.T(), wiltCollection.Data, 1)
 	assert.Equal(s.T(), animalLinksToBugStr, *wiltCollection.Data[0].Attributes.Name)
 	require.NotNil(s.T(), res.Header()[app.LastModified])
-	assert.Equal(s.T(), sourceLinkType.GetLastModified().String(), res.Header()[app.LastModified][0])
+	assert.Equal(s.T(), getWorkItemLinkTypeUpdatedAt(sourceLinkType).String(), res.Header()[app.LastModified][0])
 	require.NotNil(s.T(), res.Header()[app.CacheControl])
 	assert.Equal(s.T(), app.MaxAge+"=86400", res.Header()[app.CacheControl][0])
 	require.NotNil(s.T(), res.Header()[app.ETag])
-	assert.Equal(s.T(), app.GenerateETag(sourceLinkType), res.Header()[app.ETag][0])
+	assert.Equal(s.T(), generateWorkItemLinkTypeTag(sourceLinkType), res.Header()[app.ETag][0])
 }
 
 // TestListTargetLinkTypes200UsingExpiredIfModifiedSinceHeader tests if we can find the work item link
@@ -598,19 +599,19 @@ func (s *workItemTypeSuite) TestListTargetLinkTypes200UsingExpiredIfModifiedSinc
 	// given
 	_, targetLinkType := s.createWorkitemtypeLinks()
 	// When fetch target link types
-	ifModifiedSince := targetLinkType.Data.Attributes.UpdatedAt
-	res, wiltCollection := test.ListTargetLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), animalID, ifModifiedSince, nil)
+	ifModifiedSince := targetLinkType.Data.Attributes.UpdatedAt.Add(-1 * time.Hour)
+	res, wiltCollection := test.ListTargetLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), animalID, &ifModifiedSince, nil)
 	require.NotNil(s.T(), wiltCollection)
 	assert.Nil(s.T(), wiltCollection.Validate())
 	// Then check the number of found work item link types
 	require.Len(s.T(), wiltCollection.Data, 1)
 	assert.Equal(s.T(), bugLinksToAnimalStr, *wiltCollection.Data[0].Attributes.Name)
 	require.NotNil(s.T(), res.Header()[app.LastModified])
-	assert.Equal(s.T(), targetLinkType.GetLastModified().String(), res.Header()[app.LastModified][0])
+	assert.Equal(s.T(), getWorkItemLinkTypeUpdatedAt(targetLinkType).String(), res.Header()[app.LastModified][0])
 	require.NotNil(s.T(), res.Header()[app.CacheControl])
 	assert.Equal(s.T(), app.MaxAge+"=86400", res.Header()[app.CacheControl][0])
 	require.NotNil(s.T(), res.Header()[app.ETag])
-	assert.Equal(s.T(), app.GenerateETag(targetLinkType), res.Header()[app.ETag][0])
+	assert.Equal(s.T(), generateWorkItemLinkTypeTag(targetLinkType), res.Header()[app.ETag][0])
 }
 
 // TestListSourceLinkTypes200UsingExpiredIfNoneMatchHeader tests if we can find the work item link
@@ -627,11 +628,11 @@ func (s *workItemTypeSuite) TestListSourceLinkTypes200UsingExpiredIfNoneMatchHea
 	require.Len(s.T(), wiltCollection.Data, 1)
 	assert.Equal(s.T(), animalLinksToBugStr, *wiltCollection.Data[0].Attributes.Name)
 	require.NotNil(s.T(), res.Header()[app.LastModified])
-	assert.Equal(s.T(), sourceLinkType.GetLastModified().String(), res.Header()[app.LastModified][0])
+	assert.Equal(s.T(), getWorkItemLinkTypeUpdatedAt(sourceLinkType).String(), res.Header()[app.LastModified][0])
 	require.NotNil(s.T(), res.Header()[app.CacheControl])
 	assert.Equal(s.T(), app.MaxAge+"=86400", res.Header()[app.CacheControl][0])
 	require.NotNil(s.T(), res.Header()[app.ETag])
-	assert.Equal(s.T(), app.GenerateETag(sourceLinkType), res.Header()[app.ETag][0])
+	assert.Equal(s.T(), generateWorkItemLinkTypeTag(sourceLinkType), res.Header()[app.ETag][0])
 }
 
 // TestListTargetLinkTypes200UsingExpiredIfNoneMatchHeader tests if we can find the work item link
@@ -648,11 +649,11 @@ func (s *workItemTypeSuite) TestListTargetLinkTypes200UsingExpiredIfNoneMatchHea
 	require.Len(s.T(), wiltCollection.Data, 1)
 	assert.Equal(s.T(), bugLinksToAnimalStr, *wiltCollection.Data[0].Attributes.Name)
 	require.NotNil(s.T(), res.Header()[app.LastModified])
-	assert.Equal(s.T(), targetLinkType.GetLastModified().String(), res.Header()[app.LastModified][0])
+	assert.Equal(s.T(), getWorkItemLinkTypeUpdatedAt(targetLinkType).String(), res.Header()[app.LastModified][0])
 	require.NotNil(s.T(), res.Header()[app.CacheControl])
 	assert.Equal(s.T(), app.MaxAge+"=86400", res.Header()[app.CacheControl][0])
 	require.NotNil(s.T(), res.Header()[app.ETag])
-	assert.Equal(s.T(), app.GenerateETag(targetLinkType), res.Header()[app.ETag][0])
+	assert.Equal(s.T(), generateWorkItemLinkTypeTag(targetLinkType), res.Header()[app.ETag][0])
 }
 
 // TestListSourceLinkTypes200UsingExpiredIfModifiedSinceHeader tests if we can find the work item link
@@ -661,7 +662,7 @@ func (s *workItemTypeSuite) TestListSourceLinkTypes304UsingIfModifiedSinceHeader
 	// given
 	sourceLinkType, _ := s.createWorkitemtypeLinks()
 	// when/then
-	ifModifiedSince := sourceLinkType.GetLastModified()
+	ifModifiedSince := getWorkItemLinkTypeUpdatedAt(sourceLinkType)
 	test.ListSourceLinkTypesWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), animalID, &ifModifiedSince, nil)
 }
 
@@ -671,7 +672,7 @@ func (s *workItemTypeSuite) TestListTargetLinkTypes304UsingIfModifiedSinceHeader
 	// given
 	_, targetLinkType := s.createWorkitemtypeLinks()
 	// When fetch target link types
-	ifModifiedSince := targetLinkType.GetLastModified()
+	ifModifiedSince := getWorkItemLinkTypeUpdatedAt(targetLinkType)
 	test.ListTargetLinkTypesWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), animalID, &ifModifiedSince, nil)
 }
 
@@ -681,7 +682,7 @@ func (s *workItemTypeSuite) TestListSourceLinkTypes304UsingIfNoneMatchHeader() {
 	// given
 	sourceLinkType, _ := s.createWorkitemtypeLinks()
 	// when fetch source link types
-	ifNoneMatch := app.GenerateETag(sourceLinkType)
+	ifNoneMatch := generateWorkItemLinkTypeTag(sourceLinkType)
 	test.ListSourceLinkTypesWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), animalID, nil, &ifNoneMatch)
 }
 
@@ -691,7 +692,7 @@ func (s *workItemTypeSuite) TestListTargetLinkTypes304UsingIfNoneMatchHeader() {
 	// given
 	_, targetLinkType := s.createWorkitemtypeLinks()
 	// When fetch target link types
-	ifNoneMatch := app.GenerateETag(targetLinkType)
+	ifNoneMatch := generateWorkItemLinkTypeTag(targetLinkType)
 	test.ListTargetLinkTypesWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), animalID, nil, &ifNoneMatch)
 }
 
@@ -720,6 +721,56 @@ func (s *workItemTypeSuite) TestListSourceAndTargetLinkTypesNotFound() {
 
 	_, jerrors = test.ListTargetLinkTypesWorkitemtypeNotFound(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), uuid.Nil, nil, nil)
 	require.NotNil(s.T(), jerrors)
+}
+
+// used for testing purpose only
+func convertWorkItemTypeToModel(data app.WorkItemTypeData) workitem.WorkItemType {
+	return workitem.WorkItemType{
+		ID:      *data.ID,
+		Version: *data.Attributes.Version,
+	}
+}
+
+func generateWorkItemTypesTag(entities app.WorkItemTypeList) string {
+	modelEntities := make([]app.ConditionalResponseEntity, len(entities.Data))
+	for i, entityData := range entities.Data {
+		modelEntities[i] = convertWorkItemTypeToModel(*entityData)
+	}
+	return app.GenerateEntitiesTag(modelEntities)
+}
+
+func generateWorkItemTypeTag(entity app.WorkItemTypeSingle) string {
+	return app.GenerateEntityTag(convertWorkItemTypeToModel(*entity.Data))
+}
+
+func generateWorkItemLinkTypesTag(entities app.WorkItemLinkTypeList) string {
+	modelEntities := make([]app.ConditionalResponseEntity, len(entities.Data))
+	for i, entityData := range entities.Data {
+		e, _ := ConvertWorkItemLinkTypeToModel(app.WorkItemLinkTypeSingle{Data: entityData})
+		modelEntities[i] = e
+	}
+	return app.GenerateEntitiesTag(modelEntities)
+}
+
+func generateWorkItemLinkTypeTag(entity app.WorkItemLinkTypeSingle) string {
+	e, _ := ConvertWorkItemLinkTypeToModel(entity)
+	return app.GenerateEntityTag(e)
+}
+
+func convertWorkItemTypesToConditionalEntities(workItemTypeList app.WorkItemTypeList) []app.ConditionalResponseEntity {
+	conditionalWorkItemTypes := make([]app.ConditionalResponseEntity, len(workItemTypeList.Data))
+	for i, data := range workItemTypeList.Data {
+		conditionalWorkItemTypes[i] = convertWorkItemTypeToModel(*data)
+	}
+	return conditionalWorkItemTypes
+}
+
+func getWorkItemTypeUpdatedAt(appWorkItemType app.WorkItemTypeSingle) time.Time {
+	return appWorkItemType.Data.Attributes.UpdatedAt.Truncate(time.Second).UTC()
+}
+
+func getWorkItemLinkTypeUpdatedAt(appWorkItemLinkType app.WorkItemLinkTypeSingle) time.Time {
+	return appWorkItemLinkType.Data.Attributes.UpdatedAt.Truncate(time.Second).UTC()
 }
 
 //-----------------------------------------------------------------------------

--- a/controller/workitemtype_whitebox_test.go
+++ b/controller/workitemtype_whitebox_test.go
@@ -100,12 +100,12 @@ func TestConvertTypeFromModel(t *testing.T) {
 				},
 			},
 			Relationships: &app.WorkItemTypeRelationships{
-				Space: space.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
+				Space: app.NewSpaceRelation(space.SystemSpace, spaceSelfURL),
 			},
 		},
 	}
 	// when
-	result := convertTypeFromModel(reqLong, &a)
+	result := ConvertWorkItemTypeFromModel(reqLong, &a)
 	// then
 	require.NotNil(t, result.ID)
 	assert.True(t, uuid.Equal(*expected.Data.ID, *result.ID))

--- a/design/spaces.go
+++ b/design/spaces.go
@@ -96,9 +96,9 @@ var _ = a.Resource("space", func() {
 		a.Params(func() {
 			a.Param("id", d.String, "ID of the space")
 		})
-		a.Response(d.OK, func() {
-			a.Media(spaceSingle)
-		})
+		a.UseTrait("conditional")
+		a.Response(d.OK, spaceSingle)
+		a.Response(d.NotModified)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
@@ -113,10 +113,9 @@ var _ = a.Resource("space", func() {
 			a.Param("page[offset]", d.String, "Paging start position")
 			a.Param("page[limit]", d.Integer, "Paging size")
 		})
-
-		a.Response(d.OK, func() {
-			a.Media(spaceList)
-		})
+		a.UseTrait("conditional")
+		a.Response(d.OK, spaceList)
+		a.Response(d.NotModified)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 	})

--- a/glide.lock
+++ b/glide.lock
@@ -50,7 +50,6 @@ imports:
   - goagen/codegen
   - goagen/gen_app
   - goagen/gen_controller
-  - goagen/
   - goagen/utils
   - goatest
   - middleware

--- a/goasupport/helper_function/generator.go
+++ b/goasupport/helper_function/generator.go
@@ -1,0 +1,62 @@
+package helperfunctions
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/goagen/codegen"
+)
+
+// Generate adds method to support conditional queries
+func Generate() ([]string, error) {
+	var (
+		ver    string
+		outDir string
+	)
+	set := flag.NewFlagSet("app", flag.PanicOnError)
+	set.String("design", "", "") // Consume design argument so Parse doesn't complain
+	set.StringVar(&ver, "version", "", "")
+	set.StringVar(&outDir, "out", "", "")
+	set.Parse(os.Args[2:])
+	// First check compatibility
+	if err := codegen.CheckVersion(ver); err != nil {
+		return nil, err
+	}
+	return writeFunctions(design.Design, outDir)
+}
+
+// WriteNames creates the names.txt file.
+func writeFunctions(api *design.APIDefinition, outDir string) ([]string, error) {
+	ctxFile := filepath.Join(outDir, "helper_functions.go")
+	ctxWr, err := codegen.SourceFileFor(ctxFile)
+	if err != nil {
+		panic(err) // bug
+	}
+	title := fmt.Sprintf("%s: Helper functions - See goasupport/helper_function/generator.go", api.Context())
+	imports := []*codegen.ImportSpec{
+		codegen.NewImport("uuid", "github.com/satori/go.uuid"),
+	}
+	ctxWr.WriteHeader(title, "app", imports)
+	if err := ctxWr.ExecuteTemplate("newSpaceRelation", newSpaceRelation, nil, nil); err != nil {
+		return nil, err
+	}
+	return []string{ctxFile}, nil
+}
+
+const (
+	newSpaceRelation = `func NewSpaceRelation(id uuid.UUID, selfURL string) *RelationSpaces {
+	spaceType := "spaces"
+	return &RelationSpaces{
+		Data: &RelationSpacesData{
+			Type: &spaceType,
+			ID:   &id,
+		},
+		Links: &GenericLinks{
+			Self: &selfURL,
+		},
+	}
+}`
+)

--- a/remoteworkitem/trackerquery_repository.go
+++ b/remoteworkitem/trackerquery_repository.go
@@ -7,7 +7,6 @@ import (
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/log"
 	"github.com/almighty/almighty-core/rest"
-	"github.com/almighty/almighty-core/space"
 
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
@@ -61,7 +60,7 @@ func (r *GormTrackerQueryRepository) Create(ctx context.Context, query string, s
 		Schedule:  schedule,
 		TrackerID: tracker,
 		Relationships: &app.TrackerQueryRelationships{
-			Space: space.NewSpaceRelation(spaceID, spaceSelfURL),
+			Space: app.NewSpaceRelation(spaceID, spaceSelfURL),
 		},
 	}
 
@@ -101,7 +100,7 @@ func (r *GormTrackerQueryRepository) Load(ctx context.Context, ID string) (*app.
 		Schedule:  res.Schedule,
 		TrackerID: strconv.FormatUint(res.TrackerID, 10),
 		Relationships: &app.TrackerQueryRelationships{
-			Space: space.NewSpaceRelation(res.SpaceID, spaceSelfURL),
+			Space: app.NewSpaceRelation(res.SpaceID, spaceSelfURL),
 		},
 	}
 
@@ -178,7 +177,7 @@ func (r *GormTrackerQueryRepository) Save(ctx context.Context, tq app.TrackerQue
 		Query:     tq.Query,
 		TrackerID: tq.TrackerID,
 		Relationships: &app.TrackerQueryRelationships{
-			Space: space.NewSpaceRelation(*tq.Relationships.Space.Data.ID, spaceSelfURL),
+			Space: app.NewSpaceRelation(*tq.Relationships.Space.Data.ID, spaceSelfURL),
 		},
 	}
 
@@ -222,7 +221,7 @@ func (r *GormTrackerQueryRepository) List(ctx context.Context) ([]*app.TrackerQu
 			Query:     tq.Query,
 			TrackerID: strconv.FormatUint(tq.TrackerID, 10),
 			Relationships: &app.TrackerQueryRelationships{
-				Space: space.NewSpaceRelation(tq.SpaceID, spaceSelfURL),
+				Space: app.NewSpaceRelation(tq.SpaceID, spaceSelfURL),
 			},
 		}
 		result[i] = &t

--- a/space/space_test.go
+++ b/space/space_test.go
@@ -192,6 +192,6 @@ func (test *repoBBTest) delete(id uuid.UUID) func() (*space.Space, error) {
 	return func() (*space.Space, error) { return nil, test.repo.Delete(context.Background(), id) }
 }
 
-func (test *repoBBTest) list(start *int, length *int) ([]*space.Space, uint64, error) {
+func (test *repoBBTest) list(start *int, length *int) ([]space.Space, uint64, error) {
 	return test.repo.List(context.Background(), start, length)
 }

--- a/workitem/link/link.go
+++ b/workitem/link/link.go
@@ -1,6 +1,8 @@
 package link
 
 import (
+	"time"
+
 	convert "github.com/almighty/almighty-core/convert"
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"
@@ -62,4 +64,14 @@ func (l *WorkItemLink) CheckValidForCreation() error {
 // TableName implements gorm.tabler
 func (l WorkItemLink) TableName() string {
 	return "work_item_links"
+}
+
+// GetETagData returns the field values to use to generate the ETag
+func (l WorkItemLink) GetETagData() []interface{} {
+	return []interface{}{l.ID, l.Version}
+}
+
+// GetLastModified returns the last modification time
+func (l WorkItemLink) GetLastModified() time.Time {
+	return l.UpdatedAt.Truncate(time.Second)
 }

--- a/workitem/link/type.go
+++ b/workitem/link/type.go
@@ -1,6 +1,8 @@
 package link
 
 import (
+	"time"
+
 	convert "github.com/almighty/almighty-core/convert"
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"
@@ -155,4 +157,14 @@ func CheckValidTopology(t string) error {
 		return errors.NewBadParameterError("topolgy", t).Expected(TopologyNetwork + "|" + TopologyDirectedNetwork + "|" + TopologyDependency + "|" + TopologyTree)
 	}
 	return nil
+}
+
+// GetETagData returns the field values to use to generate the ETag
+func (t WorkItemLinkType) GetETagData() []interface{} {
+	return []interface{}{t.ID, t.Version}
+}
+
+// GetLastModified returns the last modification time
+func (t WorkItemLinkType) GetLastModified() time.Time {
+	return t.UpdatedAt.Truncate(time.Second)
 }

--- a/workitem/workitemtype.go
+++ b/workitem/workitemtype.go
@@ -3,6 +3,7 @@ package workitem
 import (
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/almighty/almighty-core/convert"
 	"github.com/almighty/almighty-core/gormsupport"
@@ -190,4 +191,14 @@ func (wit WorkItemType) IsTypeOrSubtypeOf(typeID uuid.UUID) bool {
 	// Check for complete inclusion (e.g. "bar" is contained in "foo.bar.cake")
 	// and for suffix (e.g. ".cake" is the suffix of "foo.bar.cake").
 	return uuid.Equal(wit.ID, typeID) || strings.Contains(wit.Path, LtreeSafeID(typeID)+pathSep)
+}
+
+// GetETagData returns the field values to use to generate the ETag
+func (wit WorkItemType) GetETagData() []interface{} {
+	return []interface{}{wit.ID, wit.Version}
+}
+
+// GetLastModified returns the last modification time
+func (wit WorkItemType) GetLastModified() time.Time {
+	return wit.UpdatedAt.Truncate(time.Second)
 }


### PR DESCRIPTION
goa-generate `conditionalEntity` and `conditionalEntities` methods
on the contexts with domain models as arguments.

also introducing a new goa generator for helper function related
to `app.*` structures.

Fixes #998

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
