### PR TITLE
Add conditional requests and cache-control headers on the 'iterations' endpoints (#1059)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -25,9 +25,10 @@ http.address: 0.0.0.0:8080
 # HTTP Cache-Control
 #------------------------
 
-cachecontrol.maxage.workitemtype: max-age=86400
-cachecontrol.maxage.workitemlinktype: max-age=86400
-cachecontrol.maxage.space: max-age=86400
+cachecontrol.workitemtype: max-age=86400
+cachecontrol.workitemlinktype: max-age=86400
+cachecontrol.space: max-age=86400
+cachecontrol.iteration: max-age=86400
 
 #------------------------
 # Misc.

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -68,6 +68,7 @@ const (
 	varCacheControlWorkItemType         = "cachecontrol.workitemtype"
 	varCacheControlWorkItemLinkType     = "cachecontrol.workitemlinktype"
 	varCacheControlSpace                = "cachecontrol.space"
+	varCacheControlIteration            = "cachecontrol.iteration"
 	defaultConfigFile                   = "config.yaml"
 	varOpenshiftTenantMasterURL         = "openshift.tenant.masterurl"
 	varCheStarterURL                    = "chestarterurl"
@@ -167,6 +168,7 @@ func (c *ConfigurationData) setConfigDefaults() {
 	c.v.SetDefault(varCacheControlWorkItemType, "max-age=86400")     // 1 day
 	c.v.SetDefault(varCacheControlWorkItemLinkType, "max-age=86400") // 1 day
 	c.v.SetDefault(varCacheControlSpace, "max-age=86400")            // 1 day
+	c.v.SetDefault(varCacheControlIteration, "max-age=86400")        // 1 day
 
 	c.v.SetDefault(varKeycloakTesUser2Name, defaultKeycloakTesUser2Name)
 	c.v.SetDefault(varKeycloakTesUser2Secret, defaultKeycloakTesUser2Secret)
@@ -258,22 +260,28 @@ func (c *ConfigurationData) IsPostgresDeveloperModeEnabled() bool {
 	return c.v.GetBool(varDeveloperModeEnabled)
 }
 
-// GetCacheControlWorkItemType returns the value to set in the "Cache-Control: max-age=%v" HTTP response header
+// GetCacheControlWorkItemType returns the value to set in the "Cache-Control" HTTP response header
 // when returning a work item type (or a list of).
 func (c *ConfigurationData) GetCacheControlWorkItemType() string {
 	return c.v.GetString(varCacheControlWorkItemType)
 }
 
-// GetCacheControlWorkItemLinkType returns the value to set in the "Cache-Control: max-age=%v" HTTP response header
+// GetCacheControlWorkItemLinkType returns the value to set in the "Cache-Control" HTTP response header
 // when returning a work item type (or a list of).
 func (c *ConfigurationData) GetCacheControlWorkItemLinkType() string {
 	return c.v.GetString(varCacheControlWorkItemLinkType)
 }
 
-// GetCacheControlSpace returns the value to set in the "Cache-Control: max-age=%v" HTTP response header
+// GetCacheControlSpace returns the value to set in the "Cache-Control" HTTP response header
 // when returning spaces.
 func (c *ConfigurationData) GetCacheControlSpace() string {
 	return c.v.GetString(varCacheControlSpace)
+}
+
+// GetCacheControlIteration returns the value to set in the "Cache-Control" HTTP response header
+// when returning iterations.
+func (c *ConfigurationData) GetCacheControlIteration() string {
+	return c.v.GetString(varCacheControlIteration)
 }
 
 // GetTokenPrivateKey returns the private key (as set via config file or environment variable)

--- a/controller/iteration_test.go
+++ b/controller/iteration_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/almighty/almighty-core/application"
 	. "github.com/almighty/almighty-core/controller"
 	"github.com/almighty/almighty-core/gormapplication"
+	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/gormtestsupport"
 	"github.com/almighty/almighty-core/iteration"
-	"github.com/almighty/almighty-core/resource"
 	"github.com/almighty/almighty-core/space"
 	testsupport "github.com/almighty/almighty-core/test"
 	almtoken "github.com/almighty/almighty-core/token"
@@ -32,12 +32,12 @@ import (
 
 type TestIterationREST struct {
 	gormtestsupport.DBTestSuite
-
 	db    *gormapplication.GormDB
 	clean func()
 }
 
 func TestRunIterationREST(t *testing.T) {
+	// given
 	suite.Run(t, &TestIterationREST{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
 }
 
@@ -54,99 +54,134 @@ func (rest *TestIterationREST) SecuredController() (*goa.Service, *IterationCont
 	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
 
 	svc := testsupport.ServiceAsUser("Iteration-Service", almtoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
-	return svc, NewIterationController(svc, rest.db)
+	return svc, NewIterationController(svc, rest.db, rest.Configuration)
 }
 
 func (rest *TestIterationREST) UnSecuredController() (*goa.Service, *IterationController) {
 	svc := goa.New("Iteration-Service")
-	return svc, NewIterationController(svc, rest.db)
+	return svc, NewIterationController(svc, rest.db, rest.Configuration)
 }
 
 func (rest *TestIterationREST) TestSuccessCreateChildIteration() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
-	parent := createSpaceAndIteration(t, rest.db)
+	// given
+	parent := createSpaceAndIteration(rest.T(), rest.db)
 	parentID := parent.ID
 	name := "Sprint #21"
 	ci := createChildIteration(&name)
-
 	svc, ctrl := rest.SecuredController()
-	_, created := test.CreateChildIterationCreated(t, svc.Context, svc, ctrl, parentID.String(), ci)
-	require.NotNil(t, created)
-	assertChildIterationLinking(t, created.Data)
-	assert.Equal(t, *ci.Data.Attributes.Name, *created.Data.Attributes.Name)
+	// when
+	_, created := test.CreateChildIterationCreated(rest.T(), svc.Context, svc, ctrl, parentID.String(), ci)
+	// then
+	require.NotNil(rest.T(), created)
+	assertChildIterationLinking(rest.T(), created.Data)
+	assert.Equal(rest.T(), *ci.Data.Attributes.Name, *created.Data.Attributes.Name)
 	expectedParentPath := iteration.PathSepInService + parentID.String()
 	expectedResolvedParentPath := iteration.PathSepInService + parent.Name
-	assert.Equal(t, expectedParentPath, *created.Data.Attributes.ParentPath)
-	assert.Equal(t, expectedResolvedParentPath, *created.Data.Attributes.ResolvedParentPath)
-	require.NotNil(t, created.Data.Relationships.Workitems.Meta)
-	assert.Equal(t, 0, created.Data.Relationships.Workitems.Meta["total"])
-	assert.Equal(t, 0, created.Data.Relationships.Workitems.Meta["closed"])
+	assert.Equal(rest.T(), expectedParentPath, *created.Data.Attributes.ParentPath)
+	assert.Equal(rest.T(), expectedResolvedParentPath, *created.Data.Attributes.ResolvedParentPath)
+	require.NotNil(rest.T(), created.Data.Relationships.Workitems.Meta)
+	assert.Equal(rest.T(), 0, created.Data.Relationships.Workitems.Meta["total"])
+	assert.Equal(rest.T(), 0, created.Data.Relationships.Workitems.Meta["closed"])
 }
 
 func (rest *TestIterationREST) TestFailCreateChildIterationMissingName() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
-	parentID := createSpaceAndIteration(t, rest.db).ID
+	// given
+	parentID := createSpaceAndIteration(rest.T(), rest.db).ID
 	ci := createChildIteration(nil)
-
 	svc, ctrl := rest.SecuredController()
-	test.CreateChildIterationBadRequest(t, svc.Context, svc, ctrl, parentID.String(), ci)
+	// when/then
+	test.CreateChildIterationBadRequest(rest.T(), svc.Context, svc, ctrl, parentID.String(), ci)
 }
 
 func (rest *TestIterationREST) TestFailCreateChildIterationMissingParent() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	name := "Sprint #21"
 	ci := createChildIteration(&name)
-
 	svc, ctrl := rest.SecuredController()
-	test.CreateChildIterationNotFound(t, svc.Context, svc, ctrl, uuid.NewV4().String(), ci)
+	// when/then
+	test.CreateChildIterationNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4().String(), ci)
 }
 
 func (rest *TestIterationREST) TestFailCreateChildIterationNotAuthorized() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
-	parentID := createSpaceAndIteration(t, rest.db).ID
+	// when
+	parentID := createSpaceAndIteration(rest.T(), rest.db).ID
 	name := "Sprint #21"
 	ci := createChildIteration(&name)
-
 	svc, ctrl := rest.UnSecuredController()
-	test.CreateChildIterationUnauthorized(t, svc.Context, svc, ctrl, parentID.String(), ci)
+	// when/then
+	test.CreateChildIterationUnauthorized(rest.T(), svc.Context, svc, ctrl, parentID.String(), ci)
 }
 
-func (rest *TestIterationREST) TestSuccessShowIteration() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
-	itrID := createSpaceAndIteration(t, rest.db)
-
+func (rest *TestIterationREST) TestShowIterationOK() {
+	// given
+	itrID := createSpaceAndIteration(rest.T(), rest.db)
 	svc, ctrl := rest.SecuredController()
-	_, created := test.ShowIterationOK(t, svc.Context, svc, ctrl, itrID.ID.String())
-	assertIterationLinking(t, created.Data)
-	require.NotNil(t, created.Data.Relationships.Workitems.Meta)
-	assert.Equal(t, 0, created.Data.Relationships.Workitems.Meta["total"])
-	assert.Equal(t, 0, created.Data.Relationships.Workitems.Meta["closed"])
+	// when
+	_, created := test.ShowIterationOK(rest.T(), svc.Context, svc, ctrl, itrID.ID.String(), nil, nil)
+	// then
+	assertIterationLinking(rest.T(), created.Data)
+	require.NotNil(rest.T(), created.Data.Relationships.Workitems.Meta)
+	assert.Equal(rest.T(), 0, created.Data.Relationships.Workitems.Meta["total"])
+	assert.Equal(rest.T(), 0, created.Data.Relationships.Workitems.Meta["closed"])
+}
+
+func (rest *TestIterationREST) TestShowIterationOKUsingExpiredIfModifiedSinceHeader() {
+	// given
+	itr := createSpaceAndIteration(rest.T(), rest.db)
+	svc, ctrl := rest.SecuredController()
+	// when
+	ifModifiedSinceHeader := itr.UpdatedAt.Add(-1 * time.Hour)
+	_, created := test.ShowIterationOK(rest.T(), svc.Context, svc, ctrl, itr.ID.String(), &ifModifiedSinceHeader, nil)
+	// then
+	assertIterationLinking(rest.T(), created.Data)
+	require.NotNil(rest.T(), created.Data.Relationships.Workitems.Meta)
+	assert.Equal(rest.T(), 0, created.Data.Relationships.Workitems.Meta["total"])
+	assert.Equal(rest.T(), 0, created.Data.Relationships.Workitems.Meta["closed"])
+}
+
+func (rest *TestIterationREST) TestShowIterationOKUsingExpiredIfNoneMatchHeader() {
+	// given
+	itr := createSpaceAndIteration(rest.T(), rest.db)
+	svc, ctrl := rest.SecuredController()
+	// when
+	ifNoneMatch := "foo"
+	_, created := test.ShowIterationOK(rest.T(), svc.Context, svc, ctrl, itr.ID.String(), nil, &ifNoneMatch)
+	// then
+	assertIterationLinking(rest.T(), created.Data)
+	require.NotNil(rest.T(), created.Data.Relationships.Workitems.Meta)
+	assert.Equal(rest.T(), 0, created.Data.Relationships.Workitems.Meta["total"])
+	assert.Equal(rest.T(), 0, created.Data.Relationships.Workitems.Meta["closed"])
+}
+
+func (rest *TestIterationREST) TestShowIterationNotModifiedUsingIfModifiedSinceHeader() {
+	// given
+	itr := createSpaceAndIteration(rest.T(), rest.db)
+	svc, ctrl := rest.SecuredController()
+	// when/then
+	rest.T().Log("Iteration:", itr, " updatedAt: ", itr.UpdatedAt)
+	ifModifiedSinceHeader := itr.UpdatedAt
+	test.ShowIterationNotModified(rest.T(), svc.Context, svc, ctrl, itr.ID.String(), &ifModifiedSinceHeader, nil)
+}
+
+func (rest *TestIterationREST) TestShowIterationNotModifiedUsingIfNoneMatchHeader() {
+	// given
+	itr := createSpaceAndIteration(rest.T(), rest.db)
+	svc, ctrl := rest.SecuredController()
+	// when/then
+	ifNoneMatch := app.GenerateEntityTag(itr)
+	test.ShowIterationNotModified(rest.T(), svc.Context, svc, ctrl, itr.ID.String(), nil, &ifNoneMatch)
 }
 
 func (rest *TestIterationREST) TestFailShowIterationMissing() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	svc, ctrl := rest.SecuredController()
-	test.ShowIterationNotFound(t, svc.Context, svc, ctrl, uuid.NewV4().String())
+	// when/then
+	test.ShowIterationNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4().String(), nil, nil)
 }
 
 func (rest *TestIterationREST) TestSuccessUpdateIteration() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
-	itr := createSpaceAndIteration(t, rest.db)
-
+	// given
+	itr := createSpaceAndIteration(rest.T(), rest.db)
 	newName := "Sprint 1001"
 	newDesc := "New Description"
 	payload := app.UpdateIterationPayload{
@@ -160,20 +195,19 @@ func (rest *TestIterationREST) TestSuccessUpdateIteration() {
 		},
 	}
 	svc, ctrl := rest.SecuredController()
-	_, updated := test.UpdateIterationOK(t, svc.Context, svc, ctrl, itr.ID.String(), &payload)
-	assert.Equal(t, newName, *updated.Data.Attributes.Name)
-	assert.Equal(t, newDesc, *updated.Data.Attributes.Description)
-	require.NotNil(t, updated.Data.Relationships.Workitems.Meta)
-	assert.Equal(t, 0, updated.Data.Relationships.Workitems.Meta["total"])
-	assert.Equal(t, 0, updated.Data.Relationships.Workitems.Meta["closed"])
+	// when
+	_, updated := test.UpdateIterationOK(rest.T(), svc.Context, svc, ctrl, itr.ID.String(), &payload)
+	// then
+	assert.Equal(rest.T(), newName, *updated.Data.Attributes.Name)
+	assert.Equal(rest.T(), newDesc, *updated.Data.Attributes.Description)
+	require.NotNil(rest.T(), updated.Data.Relationships.Workitems.Meta)
+	assert.Equal(rest.T(), 0, updated.Data.Relationships.Workitems.Meta["total"])
+	assert.Equal(rest.T(), 0, updated.Data.Relationships.Workitems.Meta["closed"])
 }
 
 func (rest *TestIterationREST) TestSuccessUpdateIterationWithWICounts() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
-	itr := createSpaceAndIteration(t, rest.db)
-
+	// given
+	itr := createSpaceAndIteration(rest.T(), rest.db)
 	newName := "Sprint 1001"
 	newDesc := "New Description"
 	payload := app.UpdateIterationPayload{
@@ -202,9 +236,9 @@ func (rest *TestIterationREST) TestSuccessUpdateIterationWithWICounts() {
 				workitem.SystemState:     workitem.SystemStateNew,
 				workitem.SystemIteration: itr.ID.String(),
 			}, testIdentity.ID)
-		require.NotNil(t, wi)
-		require.Nil(t, err)
-		require.NotNil(t, wi)
+		require.NotNil(rest.T(), wi)
+		require.Nil(rest.T(), err)
+		require.NotNil(rest.T(), wi)
 	}
 	for i := 0; i < 5; i++ {
 		wi, err := wirepo.Create(
@@ -214,24 +248,25 @@ func (rest *TestIterationREST) TestSuccessUpdateIterationWithWICounts() {
 				workitem.SystemState:     workitem.SystemStateClosed,
 				workitem.SystemIteration: itr.ID.String(),
 			}, testIdentity.ID)
-		require.NotNil(t, wi)
-		require.Nil(t, err)
-		require.NotNil(t, wi)
+		require.NotNil(rest.T(), wi)
+		require.Nil(rest.T(), err)
+		require.NotNil(rest.T(), wi)
 	}
 	svc, ctrl := rest.SecuredController()
-	_, updated := test.UpdateIterationOK(t, svc.Context, svc, ctrl, itr.ID.String(), &payload)
-	require.NotNil(t, updated)
-	assert.Equal(t, newName, *updated.Data.Attributes.Name)
-	assert.Equal(t, newDesc, *updated.Data.Attributes.Description)
-	require.NotNil(t, updated.Data.Relationships.Workitems.Meta)
-	assert.Equal(t, 9, updated.Data.Relationships.Workitems.Meta["total"])
-	assert.Equal(t, 5, updated.Data.Relationships.Workitems.Meta["closed"])
+	// when
+	_, updated := test.UpdateIterationOK(rest.T(), svc.Context, svc, ctrl, itr.ID.String(), &payload)
+	// then
+	require.NotNil(rest.T(), updated)
+	assert.Equal(rest.T(), newName, *updated.Data.Attributes.Name)
+	assert.Equal(rest.T(), newDesc, *updated.Data.Attributes.Description)
+	require.NotNil(rest.T(), updated.Data.Relationships.Workitems.Meta)
+	assert.Equal(rest.T(), 9, updated.Data.Relationships.Workitems.Meta["total"])
+	assert.Equal(rest.T(), 5, updated.Data.Relationships.Workitems.Meta["closed"])
 }
 
 func (rest *TestIterationREST) TestFailUpdateIterationNotFound() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-	itr := createSpaceAndIteration(t, rest.db)
+	// given
+	itr := createSpaceAndIteration(rest.T(), rest.db)
 	itr.ID = uuid.NewV4()
 	payload := app.UpdateIterationPayload{
 		Data: &app.Iteration{
@@ -241,13 +276,13 @@ func (rest *TestIterationREST) TestFailUpdateIterationNotFound() {
 		},
 	}
 	svc, ctrl := rest.SecuredController()
-	test.UpdateIterationNotFound(t, svc.Context, svc, ctrl, itr.ID.String(), &payload)
+	// when/then
+	test.UpdateIterationNotFound(rest.T(), svc.Context, svc, ctrl, itr.ID.String(), &payload)
 }
 
 func (rest *TestIterationREST) TestFailUpdateIterationUnauthorized() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-	itr := createSpaceAndIteration(t, rest.db)
+	// given
+	itr := createSpaceAndIteration(rest.T(), rest.db)
 	payload := app.UpdateIterationPayload{
 		Data: &app.Iteration{
 			Attributes: &app.IterationAttributes{},
@@ -256,16 +291,14 @@ func (rest *TestIterationREST) TestFailUpdateIterationUnauthorized() {
 		},
 	}
 	svc, ctrl := rest.UnSecuredController()
-	test.UpdateIterationUnauthorized(t, svc.Context, svc, ctrl, itr.ID.String(), &payload)
+	// when/then
+	test.UpdateIterationUnauthorized(rest.T(), svc.Context, svc, ctrl, itr.ID.String(), &payload)
 }
 
 func (rest *TestIterationREST) TestIterationStateTransitions() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
-	itr1 := createSpaceAndIteration(t, rest.db)
-	assert.Equal(t, iteration.IterationStateNew, itr1.State)
-
+	// given
+	itr1 := createSpaceAndIteration(rest.T(), rest.db)
+	assert.Equal(rest.T(), iteration.IterationStateNew, itr1.State)
 	startState := iteration.IterationStateStart
 	payload := app.UpdateIterationPayload{
 		Data: &app.Iteration{
@@ -277,16 +310,15 @@ func (rest *TestIterationREST) TestIterationStateTransitions() {
 		},
 	}
 	svc, ctrl := rest.SecuredController()
-	_, updated := test.UpdateIterationOK(t, svc.Context, svc, ctrl, itr1.ID.String(), &payload)
-	assert.Equal(t, startState, *updated.Data.Attributes.State)
-
+	_, updated := test.UpdateIterationOK(rest.T(), svc.Context, svc, ctrl, itr1.ID.String(), &payload)
+	assert.Equal(rest.T(), startState, *updated.Data.Attributes.State)
 	// create another iteration in same space and then change State to start
 	itr2 := iteration.Iteration{
 		Name:    "Spring 123",
 		SpaceID: itr1.SpaceID,
 	}
 	err := rest.db.Iterations().Create(context.Background(), &itr2)
-	require.Nil(t, err)
+	require.Nil(rest.T(), err)
 	payload2 := app.UpdateIterationPayload{
 		Data: &app.Iteration{
 			Attributes: &app.IterationAttributes{
@@ -296,17 +328,15 @@ func (rest *TestIterationREST) TestIterationStateTransitions() {
 			Type: iteration.APIStringTypeIteration,
 		},
 	}
-	test.UpdateIterationBadRequest(t, svc.Context, svc, ctrl, itr2.ID.String(), &payload2)
-
+	test.UpdateIterationBadRequest(rest.T(), svc.Context, svc, ctrl, itr2.ID.String(), &payload2)
 	// now close first iteration
 	closeState := iteration.IterationStateClose
 	payload.Data.Attributes.State = &closeState
-	_, updated = test.UpdateIterationOK(t, svc.Context, svc, ctrl, itr1.ID.String(), &payload)
-	assert.Equal(t, closeState, *updated.Data.Attributes.State)
-
+	_, updated = test.UpdateIterationOK(rest.T(), svc.Context, svc, ctrl, itr1.ID.String(), &payload)
+	assert.Equal(rest.T(), closeState, *updated.Data.Attributes.State)
 	// try to start iteration 2 now
-	_, updated2 := test.UpdateIterationOK(t, svc.Context, svc, ctrl, itr2.ID.String(), &payload2)
-	assert.Equal(t, startState, *updated2.Data.Attributes.State)
+	_, updated2 := test.UpdateIterationOK(rest.T(), svc.Context, svc, ctrl, itr2.ID.String(), &payload2)
+	assert.Equal(rest.T(), startState, *updated2.Data.Attributes.State)
 }
 
 func createChildIteration(name *string) *app.CreateChildIterationPayload {
@@ -344,6 +374,10 @@ func createSpaceAndIteration(t *testing.T, db application.DB) iteration.Iteratio
 		name := "Sprint #2"
 
 		i := iteration.Iteration{
+			Lifecycle: gormsupport.Lifecycle{
+				CreatedAt: p.CreatedAt,
+				UpdatedAt: p.UpdatedAt,
+			},
 			Name:    name,
 			SpaceID: p.ID,
 			StartAt: &start,

--- a/controller/planner_backlog_test.go
+++ b/controller/planner_backlog_test.go
@@ -160,7 +160,7 @@ func (rest *TestPlannerBlacklogREST) TestSuccessEmptyListPlannerBacklogWorkItems
 		repo := app.Iterations()
 
 		newSpace := space.Space{
-			Name: "Test 1",
+			Name: "TestSuccessEmptyListPlannerBacklogWorkItems" + uuid.NewV4().String(),
 		}
 		p, err := app.Spaces().Create(rest.ctx, &newSpace)
 		if err != nil {

--- a/controller/space_iterations_test.go
+++ b/controller/space_iterations_test.go
@@ -11,19 +11,24 @@ import (
 
 	"fmt"
 
+	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
 	"github.com/almighty/almighty-core/application"
 	. "github.com/almighty/almighty-core/controller"
 	"github.com/almighty/almighty-core/gormapplication"
+	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/gormtestsupport"
 	"github.com/almighty/almighty-core/iteration"
+	"github.com/almighty/almighty-core/migration"
+	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/resource"
 	"github.com/almighty/almighty-core/space"
 	testsupport "github.com/almighty/almighty-core/test"
 	almtoken "github.com/almighty/almighty-core/token"
 	"github.com/almighty/almighty-core/workitem"
+	"github.com/jinzhu/gorm"
 
 	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
@@ -34,20 +39,34 @@ import (
 
 type TestSpaceIterationREST struct {
 	gormtestsupport.DBTestSuite
-
-	db    *gormapplication.GormDB
-	clean func()
-	ctx   context.Context
+	db           *gormapplication.GormDB
+	clean        func()
+	ctx          context.Context
+	testIdentity account.Identity
 }
 
 func TestRunSpaceIterationREST(t *testing.T) {
+	resource.Require(t, resource.Database)
 	suite.Run(t, &TestSpaceIterationREST{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
+}
+
+// The SetupSuite method will run before the tests in the suite are run.
+// It sets up a database connection for all the tests in this suite without polluting global space.
+func (rest *TestSpaceIterationREST) SetupSuite() {
+	rest.DBTestSuite.SetupSuite()
+	// Make sure the database is populated with the correct types (e.g. bug etc.)
+	err := models.Transactional(rest.DB, func(tx *gorm.DB) error {
+		return migration.PopulateCommonTypes(context.Background(), tx, workitem.NewWorkItemTypeRepository(tx))
+	})
+	require.Nil(rest.T(), err)
+	testIdentity, err := testsupport.CreateTestIdentity(rest.DB, "test user", "test provider")
+	require.Nil(rest.T(), err)
+	rest.testIdentity = testIdentity
 }
 
 func (rest *TestSpaceIterationREST) SetupTest() {
 	rest.db = gormapplication.NewGormDB(rest.DB)
 	rest.clean = cleaner.DeleteCreatedEntities(rest.DB)
-
 	req := &http.Request{Host: "localhost"}
 	params := url.Values{}
 	rest.ctx = goa.NewContext(context.Background(), nil, req, params)
@@ -61,193 +80,156 @@ func (rest *TestSpaceIterationREST) SecuredController() (*goa.Service, *SpaceIte
 	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
 
 	svc := testsupport.ServiceAsUser("Iteration-Service", almtoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
-	return svc, NewSpaceIterationsController(svc, rest.db)
+	return svc, NewSpaceIterationsController(svc, rest.db, rest.Configuration)
 }
 
 func (rest *TestSpaceIterationREST) UnSecuredController() (*goa.Service, *SpaceIterationsController) {
 	svc := goa.New("Iteration-Service")
-	return svc, NewSpaceIterationsController(svc, rest.db)
+	return svc, NewSpaceIterationsController(svc, rest.db, rest.Configuration)
 }
 
 func (rest *TestSpaceIterationREST) TestSuccessCreateIteration() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	var p *space.Space
 	ci := createSpaceIteration("Sprint #21", nil)
-
-	application.Transactional(rest.db, func(app application.Application) error {
+	err := application.Transactional(rest.db, func(app application.Application) error {
 		repo := app.Spaces()
 		newSpace := space.Space{
-			Name: "Test 1",
+			Name: "TestSuccessCreateIteration" + uuid.NewV4().String(),
 		}
-		p, _ = repo.Create(rest.ctx, &newSpace)
-		return nil
+		createdSpace, err := repo.Create(rest.ctx, &newSpace)
+		p = createdSpace
+		return err
 	})
+	require.Nil(rest.T(), err)
 	svc, ctrl := rest.SecuredController()
-	_, c := test.CreateSpaceIterationsCreated(t, svc.Context, svc, ctrl, p.ID.String(), ci)
-	require.NotNil(t, c.Data.ID)
-	require.NotNil(t, c.Data.Relationships.Space)
-	assert.Equal(t, p.ID.String(), *c.Data.Relationships.Space.Data.ID)
-	assert.Equal(t, iteration.IterationStateNew, *c.Data.Attributes.State)
-	assert.Equal(t, "/", *c.Data.Attributes.ParentPath)
-	require.NotNil(t, c.Data.Relationships.Workitems.Meta)
-	assert.Equal(t, 0, c.Data.Relationships.Workitems.Meta["total"])
-	assert.Equal(t, 0, c.Data.Relationships.Workitems.Meta["closed"])
+	// when
+	_, c := test.CreateSpaceIterationsCreated(rest.T(), svc.Context, svc, ctrl, p.ID.String(), ci)
+	// then
+	require.NotNil(rest.T(), c.Data.ID)
+	require.NotNil(rest.T(), c.Data.Relationships.Space)
+	assert.Equal(rest.T(), p.ID.String(), *c.Data.Relationships.Space.Data.ID)
+	assert.Equal(rest.T(), iteration.IterationStateNew, *c.Data.Attributes.State)
+	assert.Equal(rest.T(), "/", *c.Data.Attributes.ParentPath)
+	require.NotNil(rest.T(), c.Data.Relationships.Workitems.Meta)
+	assert.Equal(rest.T(), 0, c.Data.Relationships.Workitems.Meta["total"])
+	assert.Equal(rest.T(), 0, c.Data.Relationships.Workitems.Meta["closed"])
 }
 
 func (rest *TestSpaceIterationREST) TestSuccessCreateIterationWithOptionalValues() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	var p *space.Space
 	iterationName := "Sprint #22"
 	iterationDesc := "testing description"
 	ci := createSpaceIteration(iterationName, &iterationDesc)
-
 	application.Transactional(rest.db, func(app application.Application) error {
 		repo := app.Spaces()
 		testSpace := space.Space{
-			Name: "Test 1",
+			Name: "TestSuccessCreateIterationWithOptionalValues-" + uuid.NewV4().String(),
 		}
 		p, _ = repo.Create(rest.ctx, &testSpace)
 		return nil
 	})
 	svc, ctrl := rest.SecuredController()
-	_, c := test.CreateSpaceIterationsCreated(t, svc.Context, svc, ctrl, p.ID.String(), ci)
-	assert.NotNil(t, c.Data.ID)
-	assert.NotNil(t, c.Data.Relationships.Space)
-	assert.Equal(t, p.ID.String(), *c.Data.Relationships.Space.Data.ID)
-	assert.Equal(t, *c.Data.Attributes.Name, iterationName)
-	assert.Equal(t, *c.Data.Attributes.Description, iterationDesc)
+	// when
+	_, c := test.CreateSpaceIterationsCreated(rest.T(), svc.Context, svc, ctrl, p.ID.String(), ci)
+	// then
+	assert.NotNil(rest.T(), c.Data.ID)
+	assert.NotNil(rest.T(), c.Data.Relationships.Space)
+	assert.Equal(rest.T(), p.ID.String(), *c.Data.Relationships.Space.Data.ID)
+	assert.Equal(rest.T(), *c.Data.Attributes.Name, iterationName)
+	assert.Equal(rest.T(), *c.Data.Attributes.Description, iterationDesc)
 
 	// create another Iteration with nil description
 	iterationName2 := "Sprint #23"
 	ci = createSpaceIteration(iterationName2, nil)
-	_, c = test.CreateSpaceIterationsCreated(t, svc.Context, svc, ctrl, p.ID.String(), ci)
-	assert.Equal(t, *c.Data.Attributes.Name, iterationName2)
-	assert.Nil(t, c.Data.Attributes.Description)
+	_, c = test.CreateSpaceIterationsCreated(rest.T(), svc.Context, svc, ctrl, p.ID.String(), ci)
+	assert.Equal(rest.T(), *c.Data.Attributes.Name, iterationName2)
+	assert.Nil(rest.T(), c.Data.Attributes.Description)
 }
 
-func (rest *TestSpaceIterationREST) TestListIterationsBySpace() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
-	var spaceID uuid.UUID
-	var fatherIteration, childIteration, grandChildIteration *iteration.Iteration
-	application.Transactional(rest.db, func(app application.Application) error {
-		repo := app.Iterations()
-
-		newSpace := space.Space{
-			Name: "Test 1",
-		}
-		p, err := app.Spaces().Create(rest.ctx, &newSpace)
-		if err != nil {
-			t.Error(err)
-		}
-		spaceID = p.ID
-
-		for i := 0; i < 3; i++ {
-			start := time.Now()
-			end := start.Add(time.Hour * (24 * 8 * 3))
-			name := "Sprint #2" + strconv.Itoa(i)
-
-			i := iteration.Iteration{
-				Name:    name,
-				SpaceID: spaceID,
-				StartAt: &start,
-				EndAt:   &end,
-			}
-			repo.Create(rest.ctx, &i)
-		}
-
-		// create one child iteration and test for relationships.Parent
-		fatherIteration = &iteration.Iteration{
-			Name:    "Parent Iteration",
-			SpaceID: spaceID,
-		}
-		repo.Create(rest.ctx, fatherIteration)
-
-		childIteration = &iteration.Iteration{
-			Name:    "Child Iteration",
-			SpaceID: spaceID,
-			Path:    append(fatherIteration.Path, fatherIteration.ID),
-		}
-		repo.Create(rest.ctx, childIteration)
-
-		grandChildIteration = &iteration.Iteration{
-			Name:    "Grand Child Iteration",
-			SpaceID: spaceID,
-			Path:    append(childIteration.Path, childIteration.ID),
-		}
-		repo.Create(rest.ctx, grandChildIteration)
-
-		return nil
-	})
-
+func (rest *TestSpaceIterationREST) TestListIterationsBySpaceOK() {
+	// given
+	spaceID, fatherIteration, childIteration, grandChildIteration := rest.createIterations()
 	svc, ctrl := rest.UnSecuredController()
-	_, cs := test.ListSpaceIterationsOK(t, svc.Context, svc, ctrl, spaceID.String())
-	assert.Len(t, cs.Data, 6)
-	for _, iterationItem := range cs.Data {
-		subString := fmt.Sprintf("?filter[iteration]=%s", iterationItem.ID.String())
-		require.Contains(t, *iterationItem.Relationships.Workitems.Links.Related, subString)
-		assert.Equal(t, 0, iterationItem.Relationships.Workitems.Meta["total"])
-		assert.Equal(t, 0, iterationItem.Relationships.Workitems.Meta["closed"])
-		if *iterationItem.ID == childIteration.ID {
-			expectedParentPath := iteration.PathSepInService + fatherIteration.ID.String()
-			expectedResolvedParentPath := iteration.PathSepInService + fatherIteration.Name
-			require.NotNil(t, iterationItem.Relationships.Parent)
-			assert.Equal(t, fatherIteration.ID.String(), *iterationItem.Relationships.Parent.Data.ID)
-			assert.Equal(t, expectedParentPath, *iterationItem.Attributes.ParentPath)
-			assert.Equal(t, expectedResolvedParentPath, *iterationItem.Attributes.ResolvedParentPath)
-		}
-		if *iterationItem.ID == grandChildIteration.ID {
-			expectedParentPath := iteration.PathSepInService + fatherIteration.ID.String() + iteration.PathSepInService + childIteration.ID.String()
-			expectedResolvedParentPath := iteration.PathSepInService + fatherIteration.Name + iteration.PathSepInService + childIteration.Name
-			require.NotNil(t, iterationItem.Relationships.Parent)
-			assert.Equal(t, childIteration.ID.String(), *iterationItem.Relationships.Parent.Data.ID)
-			assert.Equal(t, expectedParentPath, *iterationItem.Attributes.ParentPath)
-			assert.Equal(t, expectedResolvedParentPath, *iterationItem.Attributes.ResolvedParentPath)
+	// when
+	_, cs := test.ListSpaceIterationsOK(rest.T(), svc.Context, svc, ctrl, spaceID.String(), nil, nil)
+	// then
+	assertIterations(rest.T(), cs.Data, fatherIteration, childIteration, grandChildIteration)
+}
 
-		}
-	}
+func (rest *TestSpaceIterationREST) TestListIterationsBySpaceOKUsingExpiredIfModifiedSinceHeader() {
+	// given
+	spaceID, fatherIteration, childIteration, grandChildIteration := rest.createIterations()
+	svc, ctrl := rest.UnSecuredController()
+	// when
+	idModifiedSince := fatherIteration.UpdatedAt.Add(-1 * time.Hour)
+	_, cs := test.ListSpaceIterationsOK(rest.T(), svc.Context, svc, ctrl, spaceID.String(), &idModifiedSince, nil)
+	// then
+	assertIterations(rest.T(), cs.Data, fatherIteration, childIteration, grandChildIteration)
+}
+
+func (rest *TestSpaceIterationREST) TestListIterationsBySpaceOKUsingExpiredIfNoneMatchSinceHeader() {
+	// given
+	spaceID, fatherIteration, childIteration, grandChildIteration := rest.createIterations()
+	svc, ctrl := rest.UnSecuredController()
+	// when
+	idNoneMatch := "foo"
+	_, cs := test.ListSpaceIterationsOK(rest.T(), svc.Context, svc, ctrl, spaceID.String(), nil, &idNoneMatch)
+	// then
+	assertIterations(rest.T(), cs.Data, fatherIteration, childIteration, grandChildIteration)
+}
+
+func (rest *TestSpaceIterationREST) TestListIterationsBySpaceNotModifiedIfModifiedSinceHeader() {
+	// given
+	spaceID, _, _, grandChildIteration := rest.createIterations()
+	svc, ctrl := rest.UnSecuredController()
+	// when/then
+	idModifiedSince := grandChildIteration.UpdatedAt
+	test.ListSpaceIterationsNotModified(rest.T(), svc.Context, svc, ctrl, spaceID.String(), &idModifiedSince, nil)
+}
+
+func (rest *TestSpaceIterationREST) TestListIterationsBySpaceNotModifiedIfNoneMatchSinceHeader() {
+	// given
+	spaceID, _, _, _ := rest.createIterations()
+	svc, ctrl := rest.UnSecuredController()
+	// here we need to get all iterations for the spaceId
+	_, iterations := test.ListSpaceIterationsOK(rest.T(), svc.Context, svc, ctrl, spaceID.String(), nil, nil)
+	// when/then
+	idNoneMatch := generateIterationsTag(*iterations)
+	test.ListSpaceIterationsNotModified(rest.T(), svc.Context, svc, ctrl, spaceID.String(), nil, &idNoneMatch)
 }
 
 func (rest *TestSpaceIterationREST) TestCreateIterationMissingSpace() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	ci := createSpaceIteration("Sprint #21", nil)
-
 	svc, ctrl := rest.SecuredController()
-	test.CreateSpaceIterationsNotFound(t, svc.Context, svc, ctrl, uuid.NewV4().String(), ci)
+	// when/then
+	test.CreateSpaceIterationsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4().String(), ci)
 }
 
 func (rest *TestSpaceIterationREST) TestFailCreateIterationNotAuthorized() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	ci := createSpaceIteration("Sprint #21", nil)
-
 	svc, ctrl := rest.UnSecuredController()
-	test.CreateSpaceIterationsUnauthorized(t, svc.Context, svc, ctrl, uuid.NewV4().String(), ci)
+	// when/then
+	test.CreateSpaceIterationsUnauthorized(rest.T(), svc.Context, svc, ctrl, uuid.NewV4().String(), ci)
 }
 
 func (rest *TestSpaceIterationREST) TestFailListIterationsByMissingSpace() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
-
+	// given
 	svc, ctrl := rest.UnSecuredController()
-	test.ListSpaceIterationsNotFound(t, svc.Context, svc, ctrl, uuid.NewV4().String())
+	// when/then
+	test.ListSpaceIterationsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4().String(), nil, nil)
 }
 
 func (rest *TestSpaceIterationREST) TestWICountsWithIterationListBySpace() {
-	t := rest.T()
-	resource.Require(t, resource.Database)
+	// given
+	resource.Require(rest.T(), resource.Database)
 	// create seed data
 	spaceRepo := space.NewRepository(rest.DB)
 	spaceInstance := space.Space{
-		Name: "Testing space" + uuid.NewV4().String(),
+		Name: "TestWICountsWithIterationListBySpace-" + uuid.NewV4().String(),
 	}
 	_, e := spaceRepo.Create(rest.ctx, &spaceInstance)
 	require.Nil(rest.T(), e)
@@ -280,48 +262,54 @@ func (rest *TestSpaceIterationREST) TestWICountsWithIterationListBySpace() {
 				workitem.SystemTitle:     fmt.Sprintf("New issue #%d", i),
 				workitem.SystemState:     workitem.SystemStateNew,
 				workitem.SystemIteration: iteration1.ID.String(),
-			}, uuid.NewV4())
+			}, rest.testIdentity.ID)
 	}
 	for i := 0; i < 2; i++ {
-		wirepo.Create(
+		_, err := wirepo.Create(
 			rest.ctx, iteration1.SpaceID, workitem.SystemBug,
 			map[string]interface{}{
 				workitem.SystemTitle:     fmt.Sprintf("Closed issue #%d", i),
 				workitem.SystemState:     workitem.SystemStateClosed,
 				workitem.SystemIteration: iteration1.ID.String(),
-			}, uuid.NewV4())
+			}, rest.testIdentity.ID)
+		require.Nil(rest.T(), err)
 	}
 	svc, ctrl := rest.UnSecuredController()
-	_, cs := test.ListSpaceIterationsOK(t, svc.Context, svc, ctrl, spaceInstance.ID.String())
-	assert.Len(t, cs.Data, 2)
+	// when
+	_, cs := test.ListSpaceIterationsOK(rest.T(), svc.Context, svc, ctrl, spaceInstance.ID.String(), nil, nil)
+	// then
+	require.Len(rest.T(), cs.Data, 2)
 	for _, iterationItem := range cs.Data {
 		if uuid.Equal(*iterationItem.ID, iteration1.ID) {
-			assert.Equal(t, 5, iterationItem.Relationships.Workitems.Meta["total"])
-			assert.Equal(t, 2, iterationItem.Relationships.Workitems.Meta["closed"])
+			assert.Equal(rest.T(), 5, iterationItem.Relationships.Workitems.Meta["total"])
+			assert.Equal(rest.T(), 2, iterationItem.Relationships.Workitems.Meta["closed"])
 		} else if uuid.Equal(*iterationItem.ID, iteration2.ID) {
-			assert.Equal(t, 0, iterationItem.Relationships.Workitems.Meta["total"])
-			assert.Equal(t, 0, iterationItem.Relationships.Workitems.Meta["closed"])
+			assert.Equal(rest.T(), 0, iterationItem.Relationships.Workitems.Meta["total"])
+			assert.Equal(rest.T(), 0, iterationItem.Relationships.Workitems.Meta["closed"])
 		}
 	}
 	// seed 5 WI to iteration2
 	for i := 0; i < 5; i++ {
-		wirepo.Create(
+		_, err := wirepo.Create(
 			rest.ctx, iteration1.SpaceID, workitem.SystemBug,
 			map[string]interface{}{
 				workitem.SystemTitle:     fmt.Sprintf("New issue #%d", i),
 				workitem.SystemState:     workitem.SystemStateNew,
 				workitem.SystemIteration: iteration2.ID.String(),
-			}, uuid.NewV4())
+			}, rest.testIdentity.ID)
+		require.Nil(rest.T(), err)
 	}
-	_, cs = test.ListSpaceIterationsOK(t, svc.Context, svc, ctrl, spaceInstance.ID.String())
-	assert.Len(t, cs.Data, 2)
+	// when
+	_, cs = test.ListSpaceIterationsOK(rest.T(), svc.Context, svc, ctrl, spaceInstance.ID.String(), nil, nil)
+	// then
+	require.Len(rest.T(), cs.Data, 2)
 	for _, iterationItem := range cs.Data {
 		if uuid.Equal(*iterationItem.ID, iteration1.ID) {
-			assert.Equal(t, 5, iterationItem.Relationships.Workitems.Meta["total"])
-			assert.Equal(t, 2, iterationItem.Relationships.Workitems.Meta["closed"])
+			assert.Equal(rest.T(), 5, iterationItem.Relationships.Workitems.Meta["total"])
+			assert.Equal(rest.T(), 2, iterationItem.Relationships.Workitems.Meta["closed"])
 		} else if uuid.Equal(*iterationItem.ID, iteration2.ID) {
-			assert.Equal(t, 5, iterationItem.Relationships.Workitems.Meta["total"])
-			assert.Equal(t, 0, iterationItem.Relationships.Workitems.Meta["closed"])
+			assert.Equal(rest.T(), 5, iterationItem.Relationships.Workitems.Meta["total"])
+			assert.Equal(rest.T(), 0, iterationItem.Relationships.Workitems.Meta["closed"])
 		}
 	}
 }
@@ -341,4 +329,97 @@ func createSpaceIteration(name string, desc *string) *app.CreateSpaceIterationsP
 			},
 		},
 	}
+}
+
+func (rest *TestSpaceIterationREST) createIterations() (spaceID uuid.UUID, fatherIteration, childIteration, grandChildIteration *iteration.Iteration) {
+	err := application.Transactional(rest.db, func(app application.Application) error {
+		repo := app.Iterations()
+		newSpace := space.Space{
+			Name: "TestListIterationsBySpace-" + uuid.NewV4().String(),
+		}
+		p, err := app.Spaces().Create(rest.ctx, &newSpace)
+		if err != nil {
+			return err
+		}
+		spaceID = p.ID
+		for i := 0; i < 3; i++ {
+			start := time.Now()
+			end := start.Add(time.Hour * (24 * 8 * 3))
+			name := "Sprint Test #" + strconv.Itoa(i)
+			i := iteration.Iteration{
+				Name:    name,
+				SpaceID: spaceID,
+				StartAt: &start,
+				EndAt:   &end,
+			}
+			repo.Create(rest.ctx, &i)
+		}
+		// create one child iteration and test for relationships.Parent
+		fatherIteration = &iteration.Iteration{
+			Name:    "Parent Iteration",
+			SpaceID: spaceID,
+		}
+		repo.Create(rest.ctx, fatherIteration)
+		rest.T().Log("fatherIteration:", fatherIteration.ID, fatherIteration.Name, fatherIteration.Path)
+		childIteration = &iteration.Iteration{
+			Name:    "Child Iteration",
+			SpaceID: spaceID,
+			Path:    append(fatherIteration.Path, fatherIteration.ID),
+		}
+		repo.Create(rest.ctx, childIteration)
+		rest.T().Log("childIteration:", childIteration.ID, childIteration.Name, childIteration.Path)
+		grandChildIteration = &iteration.Iteration{
+			Name:    "Grand Child Iteration",
+			SpaceID: spaceID,
+			Path:    append(childIteration.Path, childIteration.ID),
+		}
+		repo.Create(rest.ctx, grandChildIteration)
+		rest.T().Log("grandChildIteration:", grandChildIteration.ID, grandChildIteration.Name, grandChildIteration.Path)
+
+		return nil
+	})
+	require.Nil(rest.T(), err)
+	return
+}
+
+func assertIterations(t *testing.T, data []*app.Iteration, fatherIteration, childIteration, grandChildIteration *iteration.Iteration) {
+	assert.Len(t, data, 6)
+	for _, iterationItem := range data {
+		subString := fmt.Sprintf("?filter[iteration]=%s", iterationItem.ID.String())
+		require.Contains(t, *iterationItem.Relationships.Workitems.Links.Related, subString)
+		assert.Equal(t, 0, iterationItem.Relationships.Workitems.Meta["total"])
+		assert.Equal(t, 0, iterationItem.Relationships.Workitems.Meta["closed"])
+		if *iterationItem.ID == childIteration.ID {
+			t.Log("childIteration:", iterationItem.ID, *iterationItem.Attributes.Name, *iterationItem.Attributes.ParentPath, *iterationItem.Relationships.Parent.Data.ID)
+			expectedParentPath := iteration.PathSepInService + fatherIteration.ID.String()
+			expectedResolvedParentPath := iteration.PathSepInService + fatherIteration.Name
+			require.NotNil(t, iterationItem.Relationships.Parent)
+			assert.Equal(t, fatherIteration.ID.String(), *iterationItem.Relationships.Parent.Data.ID)
+			assert.Equal(t, expectedParentPath, *iterationItem.Attributes.ParentPath)
+			assert.Equal(t, expectedResolvedParentPath, *iterationItem.Attributes.ResolvedParentPath)
+		}
+		if *iterationItem.ID == grandChildIteration.ID {
+			t.Log("grandChildIteration:", iterationItem.ID, *iterationItem.Attributes.Name, *iterationItem.Attributes.ParentPath, *iterationItem.Relationships.Parent.Data.ID)
+			expectedParentPath := iteration.PathSepInService + fatherIteration.ID.String() + iteration.PathSepInService + childIteration.ID.String()
+			expectedResolvedParentPath := iteration.PathSepInService + fatherIteration.Name + iteration.PathSepInService + childIteration.Name
+			require.NotNil(t, iterationItem.Relationships.Parent)
+			assert.Equal(t, childIteration.ID.String(), *iterationItem.Relationships.Parent.Data.ID)
+			assert.Equal(t, expectedParentPath, *iterationItem.Attributes.ParentPath)
+			assert.Equal(t, expectedResolvedParentPath, *iterationItem.Attributes.ResolvedParentPath)
+
+		}
+	}
+}
+
+func generateIterationsTag(iterations app.IterationList) string {
+	modelEntities := make([]app.ConditionalResponseEntity, len(iterations.Data))
+	for i, entity := range iterations.Data {
+		modelEntities[i] = iteration.Iteration{
+			ID: *entity.ID,
+			Lifecycle: gormsupport.Lifecycle{
+				UpdatedAt: *entity.Attributes.UpdatedAt,
+			},
+		}
+	}
+	return app.GenerateEntitiesTag(modelEntities)
 }

--- a/design/iterations.go
+++ b/design/iterations.go
@@ -27,6 +27,12 @@ var iterationAttributes = a.Type("IterationAttributes", func() {
 	a.Attribute("description", d.String, "Description of the iteration ", func() {
 		a.Example("Sprint #42 focusing on UI and build process improvements")
 	})
+	a.Attribute("createdAt", d.DateTime, "When the iteration was created", func() {
+		a.Example("2016-11-29T23:18:14Z")
+	})
+	a.Attribute("updatedAt", d.DateTime, "When the iteration was updated", func() {
+		a.Example("2016-11-29T23:18:14Z")
+	})
 	a.Attribute("startAt", d.DateTime, "When the iteration starts", func() {
 		a.Example("2016-11-29T23:18:14Z")
 	})
@@ -72,9 +78,9 @@ var _ = a.Resource("iteration", func() {
 		a.Params(func() {
 			a.Param("iterationID", d.String, "Iteration Identifier")
 		})
-		a.Response(d.OK, func() {
-			a.Media(iterationSingle)
-		})
+		a.UseTrait("conditional")
+		a.Response(d.OK, iterationSingle)
+		a.Response(d.NotModified)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
@@ -133,9 +139,9 @@ var _ = a.Resource("space_iterations", func() {
 				a.Param("page[limit]", d.Integer, "Paging size")
 			})
 		*/
-		a.Response(d.OK, func() {
-			a.Media(iterationList)
-		})
+		a.UseTrait("conditional")
+		a.Response(d.OK, iterationList)
+		a.Response(d.NotModified)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)

--- a/goasupport/conditional_request/generator.go
+++ b/goasupport/conditional_request/generator.go
@@ -74,12 +74,14 @@ func init() {
 		"workitemdsl":     "github.com/almighty/almighty-core/workitem",
 		"workitemlinkdsl": "github.com/almighty/almighty-core/workitem/link",
 		"spacedsl":        "github.com/almighty/almighty-core/space",
+		"iterationdsl":    "github.com/almighty/almighty-core/iteration",
 	}
 	structPackages = map[string]string{
 		"WorkItem":         "workitemdsl",
 		"WorkItemType":     "workitemdsl",
 		"WorkItemLinkType": "workitemlinkdsl",
 		"Space":            "spacedsl",
+		"Iteration":        "iterationdsl",
 	}
 
 }

--- a/iteration/iteration.go
+++ b/iteration/iteration.go
@@ -1,6 +1,7 @@
 package iteration
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/almighty/almighty-core/errors"
@@ -38,6 +39,17 @@ type Iteration struct {
 	State       string // this tells if iteration is currently running or not
 }
 
+// GetETagData returns the field values to use to generate the ETag
+func (m Iteration) GetETagData() []interface{} {
+	// using the 'ID' and 'UpdatedAt' (converted to number of seconds since epoch) fields
+	return []interface{}{m.ID, strconv.FormatInt(m.UpdatedAt.Unix(), 10)}
+}
+
+// GetLastModified returns the last modification time
+func (m Iteration) GetLastModified() time.Time {
+	return m.UpdatedAt.Truncate(time.Second)
+}
+
 // TableName overrides the table name settings in Gorm to force a specific table name
 // in the database.
 func (m *Iteration) TableName() string {
@@ -47,13 +59,13 @@ func (m *Iteration) TableName() string {
 // Repository describes interactions with Iterations
 type Repository interface {
 	Create(ctx context.Context, u *Iteration) error
-	List(ctx context.Context, spaceID uuid.UUID) ([]*Iteration, error)
+	List(ctx context.Context, spaceID uuid.UUID) ([]Iteration, error)
 	RootIteration(ctx context.Context, spaceID uuid.UUID) (*Iteration, error)
 	Load(ctx context.Context, id uuid.UUID) (*Iteration, error)
 	Save(ctx context.Context, i Iteration) (*Iteration, error)
 	CanStartIteration(ctx context.Context, i *Iteration) (bool, error)
-	LoadMultiple(ctx context.Context, ids []uuid.UUID) ([]*Iteration, error)
-	LoadChildren(ctx context.Context, parentIterationID uuid.UUID) ([]*Iteration, error)
+	LoadMultiple(ctx context.Context, ids []uuid.UUID) ([]Iteration, error)
+	LoadChildren(ctx context.Context, parentIterationID uuid.UUID) ([]Iteration, error)
 }
 
 // NewIterationRepository creates a new storage type.
@@ -67,9 +79,9 @@ type GormIterationRepository struct {
 }
 
 // LoadMultiple returns multiple instances of iteration.Iteration
-func (m *GormIterationRepository) LoadMultiple(ctx context.Context, ids []uuid.UUID) ([]*Iteration, error) {
+func (m *GormIterationRepository) LoadMultiple(ctx context.Context, ids []uuid.UUID) ([]Iteration, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "iteration", "getmultiple"}, time.Now())
-	var objs []*Iteration
+	var objs []Iteration
 
 	for i := 0; i < len(ids); i++ {
 		m.db = m.db.Or("id = ?", ids[i])
@@ -100,9 +112,9 @@ func (m *GormIterationRepository) Create(ctx context.Context, u *Iteration) erro
 }
 
 // List all Iterations related to a single item
-func (m *GormIterationRepository) List(ctx context.Context, spaceID uuid.UUID) ([]*Iteration, error) {
+func (m *GormIterationRepository) List(ctx context.Context, spaceID uuid.UUID) ([]Iteration, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "iteration", "query"}, time.Now())
-	var objs []*Iteration
+	var objs []Iteration
 
 	err := m.db.Where("space_id = ?", spaceID).Find(&objs).Error
 	if err != nil && err != gorm.ErrRecordNotFound {
@@ -206,13 +218,13 @@ func (m *GormIterationRepository) CanStartIteration(ctx context.Context, i *Iter
 }
 
 // LoadChildren executes - select * from iterations where path <@ 'parent_path.parent_id';
-func (m *GormIterationRepository) LoadChildren(ctx context.Context, parentIterationID uuid.UUID) ([]*Iteration, error) {
+func (m *GormIterationRepository) LoadChildren(ctx context.Context, parentIterationID uuid.UUID) ([]Iteration, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "iteration", "loadchildren"}, time.Now())
 	parentIteration, err := m.Load(ctx, parentIterationID)
 	if err != nil {
 		return nil, errors.NewNotFoundError("iteration", parentIterationID.String())
 	}
-	var objs []*Iteration
+	var objs []Iteration
 	selfPath := parentIteration.Path.Convert()
 	var query string
 	if selfPath != "" {

--- a/main.go
+++ b/main.go
@@ -247,7 +247,7 @@ func main() {
 	searchCtrl := controller.NewSearchController(service, appDB, configuration)
 	app.MountSearchController(service, searchCtrl)
 
-	// Mount "indentity" controller
+	// Mount "identity" controller
 	identityCtrl := controller.NewIdentityController(service, appDB)
 	app.MountIdentityController(service, identityCtrl)
 
@@ -256,11 +256,11 @@ func main() {
 	app.MountUsersController(service, usersCtrl)
 
 	// Mount "iterations" controller
-	iterationCtrl := controller.NewIterationController(service, appDB)
+	iterationCtrl := controller.NewIterationController(service, appDB, configuration)
 	app.MountIterationController(service, iterationCtrl)
 
 	// Mount "spaceiterations" controller
-	spaceIterationCtrl := controller.NewSpaceIterationsController(service, appDB)
+	spaceIterationCtrl := controller.NewSpaceIterationsController(service, appDB, configuration)
 	app.MountSpaceIterationsController(service, spaceIterationCtrl)
 
 	// Mount "userspace" controller


### PR DESCRIPTION
Also added `CreatedAt` and `UpdatedAt` fields on the returned iterations (JSON)

Fixes #1059

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
