### PR TITLE
Lower the `max-age` values to 10s for /spaces and /iterations (#1064)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,8 +27,8 @@ http.address: 0.0.0.0:8080
 
 cachecontrol.workitemtype: max-age=86400
 cachecontrol.workitemlinktype: max-age=86400
-cachecontrol.space: max-age=10
-cachecontrol.iteration: max-age=10
+cachecontrol.space: max-age=300
+cachecontrol.iteration: max-age=300
 
 #------------------------
 # Misc.

--- a/config.yaml
+++ b/config.yaml
@@ -27,8 +27,8 @@ http.address: 0.0.0.0:8080
 
 cachecontrol.workitemtype: max-age=86400
 cachecontrol.workitemlinktype: max-age=86400
-cachecontrol.space: max-age=86400
-cachecontrol.iteration: max-age=86400
+cachecontrol.space: max-age=10
+cachecontrol.iteration: max-age=10
 
 #------------------------
 # Misc.

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -167,8 +167,8 @@ func (c *ConfigurationData) setConfigDefaults() {
 	// HTTP Cache-Control/max-age default
 	c.v.SetDefault(varCacheControlWorkItemType, "max-age=86400")     // 1 day
 	c.v.SetDefault(varCacheControlWorkItemLinkType, "max-age=86400") // 1 day
-	c.v.SetDefault(varCacheControlSpace, "max-age=10")
-	c.v.SetDefault(varCacheControlIteration, "max-age=10")
+	c.v.SetDefault(varCacheControlSpace, "max-age=300")
+	c.v.SetDefault(varCacheControlIteration, "max-age=300")
 
 	c.v.SetDefault(varKeycloakTesUser2Name, defaultKeycloakTesUser2Name)
 	c.v.SetDefault(varKeycloakTesUser2Secret, defaultKeycloakTesUser2Secret)

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -167,8 +167,8 @@ func (c *ConfigurationData) setConfigDefaults() {
 	// HTTP Cache-Control/max-age default
 	c.v.SetDefault(varCacheControlWorkItemType, "max-age=86400")     // 1 day
 	c.v.SetDefault(varCacheControlWorkItemLinkType, "max-age=86400") // 1 day
-	c.v.SetDefault(varCacheControlSpace, "max-age=86400")            // 1 day
-	c.v.SetDefault(varCacheControlIteration, "max-age=86400")        // 1 day
+	c.v.SetDefault(varCacheControlSpace, "max-age=10")
+	c.v.SetDefault(varCacheControlIteration, "max-age=10")
 
 	c.v.SetDefault(varKeycloakTesUser2Name, defaultKeycloakTesUser2Name)
 	c.v.SetDefault(varKeycloakTesUser2Secret, defaultKeycloakTesUser2Secret)

--- a/controller/space_test.go
+++ b/controller/space_test.go
@@ -279,7 +279,7 @@ func (rest *TestSpaceREST) TestShowSpaceOK() {
 	require.NotNil(rest.T(), res.Header()[app.LastModified])
 	assert.Equal(rest.T(), getSpaceUpdatedAt(*created).String(), res.Header()[app.LastModified][0])
 	require.NotNil(rest.T(), res.Header()[app.CacheControl])
-	assert.Equal(rest.T(), app.MaxAge+"=10", res.Header()[app.CacheControl][0])
+	assert.Equal(rest.T(), app.MaxAge+"=300", res.Header()[app.CacheControl][0])
 	require.NotNil(rest.T(), res.Header()[app.ETag])
 	assert.Equal(rest.T(), app.GenerateEntityTag(ConvertSpaceToModel(*created.Data)), res.Header()[app.ETag][0])
 }
@@ -304,7 +304,7 @@ func (rest *TestSpaceREST) TestShowSpaceOKUsingExpiredIfModifiedSinceHeader() {
 	require.NotNil(rest.T(), res.Header()[app.LastModified])
 	assert.Equal(rest.T(), getSpaceUpdatedAt(*created).String(), res.Header()[app.LastModified][0])
 	require.NotNil(rest.T(), res.Header()[app.CacheControl])
-	assert.Equal(rest.T(), app.MaxAge+"=10", res.Header()[app.CacheControl][0])
+	assert.Equal(rest.T(), app.MaxAge+"=300", res.Header()[app.CacheControl][0])
 	require.NotNil(rest.T(), res.Header()[app.ETag])
 	assert.Equal(rest.T(), generateSpaceTag(*created), res.Header()[app.ETag][0])
 }
@@ -329,7 +329,7 @@ func (rest *TestSpaceREST) TestShowSpaceOKUsingExpiredIfNoneMatchHeader() {
 	require.NotNil(rest.T(), res.Header()[app.LastModified])
 	assert.Equal(rest.T(), getSpaceUpdatedAt(*created).String(), res.Header()[app.LastModified][0])
 	require.NotNil(rest.T(), res.Header()[app.CacheControl])
-	assert.Equal(rest.T(), app.MaxAge+"=10", res.Header()[app.CacheControl][0])
+	assert.Equal(rest.T(), app.MaxAge+"=300", res.Header()[app.CacheControl][0])
 	require.NotNil(rest.T(), res.Header()[app.ETag])
 	assert.Equal(rest.T(), generateSpaceTag(*created), res.Header()[app.ETag][0])
 }

--- a/controller/space_test.go
+++ b/controller/space_test.go
@@ -279,7 +279,7 @@ func (rest *TestSpaceREST) TestShowSpaceOK() {
 	require.NotNil(rest.T(), res.Header()[app.LastModified])
 	assert.Equal(rest.T(), getSpaceUpdatedAt(*created).String(), res.Header()[app.LastModified][0])
 	require.NotNil(rest.T(), res.Header()[app.CacheControl])
-	assert.Equal(rest.T(), app.MaxAge+"=86400", res.Header()[app.CacheControl][0])
+	assert.Equal(rest.T(), app.MaxAge+"=10", res.Header()[app.CacheControl][0])
 	require.NotNil(rest.T(), res.Header()[app.ETag])
 	assert.Equal(rest.T(), app.GenerateEntityTag(ConvertSpaceToModel(*created.Data)), res.Header()[app.ETag][0])
 }
@@ -304,7 +304,7 @@ func (rest *TestSpaceREST) TestShowSpaceOKUsingExpiredIfModifiedSinceHeader() {
 	require.NotNil(rest.T(), res.Header()[app.LastModified])
 	assert.Equal(rest.T(), getSpaceUpdatedAt(*created).String(), res.Header()[app.LastModified][0])
 	require.NotNil(rest.T(), res.Header()[app.CacheControl])
-	assert.Equal(rest.T(), app.MaxAge+"=86400", res.Header()[app.CacheControl][0])
+	assert.Equal(rest.T(), app.MaxAge+"=10", res.Header()[app.CacheControl][0])
 	require.NotNil(rest.T(), res.Header()[app.ETag])
 	assert.Equal(rest.T(), generateSpaceTag(*created), res.Header()[app.ETag][0])
 }
@@ -329,7 +329,7 @@ func (rest *TestSpaceREST) TestShowSpaceOKUsingExpiredIfNoneMatchHeader() {
 	require.NotNil(rest.T(), res.Header()[app.LastModified])
 	assert.Equal(rest.T(), getSpaceUpdatedAt(*created).String(), res.Header()[app.LastModified][0])
 	require.NotNil(rest.T(), res.Header()[app.CacheControl])
-	assert.Equal(rest.T(), app.MaxAge+"=86400", res.Header()[app.CacheControl][0])
+	assert.Equal(rest.T(), app.MaxAge+"=10", res.Header()[app.CacheControl][0])
 	require.NotNil(rest.T(), res.Header()[app.ETag])
 	assert.Equal(rest.T(), generateSpaceTag(*created), res.Header()[app.ETag][0])
 }


### PR DESCRIPTION
Fixes #1064

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

