### PR TITLE
Modify unique index on space names.

### DIFF
--- a/controller/space.go
+++ b/controller/space.go
@@ -93,10 +93,7 @@ func (c *SpaceController) Create(ctx *app.CreateSpaceContext) error {
 
 		rSpace, err := appl.Spaces().Create(ctx, &newSpace)
 		if err != nil {
-			// TODO Fix this hack. We return the error directly as we need to rollback this transaction.
-			// application.Transactional will bubble this error up and it will eventually be transformed
-			// to a JSONAPI error.
-			return errs.WithStack(err)
+			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 		/*
 			Should we create the new area

--- a/controller/space.go
+++ b/controller/space.go
@@ -93,7 +93,10 @@ func (c *SpaceController) Create(ctx *app.CreateSpaceContext) error {
 
 		rSpace, err := appl.Spaces().Create(ctx, &newSpace)
 		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, err)
+			// TODO Fix this hack. We return the error directly as we need to rollback this transaction.
+			// application.Transactional will bubble this error up and it will eventually be transformed
+			// to a JSONAPI error.
+			return errs.WithStack(err)
 		}
 		/*
 			Should we create the new area

--- a/controller/space.go
+++ b/controller/space.go
@@ -81,7 +81,8 @@ func (c *SpaceController) Create(ctx *app.CreateSpaceContext) error {
 		SpaceID:      spaceID,
 	}
 
-	return application.Transactional(c.db, func(appl application.Application) error {
+	var res *app.SpaceSingle
+	txnError := application.Transactional(c.db, func(appl application.Application) error {
 		newSpace := space.Space{
 			ID:      spaceID,
 			Name:    spaceName,
@@ -93,7 +94,7 @@ func (c *SpaceController) Create(ctx *app.CreateSpaceContext) error {
 
 		rSpace, err := appl.Spaces().Create(ctx, &newSpace)
 		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, err)
+			return errs.Wrapf(err, "Failed to create space: %s", newSpace.Name)
 		}
 		/*
 			Should we create the new area
@@ -112,7 +113,7 @@ func (c *SpaceController) Create(ctx *app.CreateSpaceContext) error {
 		}
 		err = appl.Areas().Create(ctx, &newArea)
 		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, errs.Wrapf(err, "failed to create area: %s", rSpace.Name))
+			return errs.Wrapf(err, "failed to create area: %s", rSpace.Name)
 		}
 
 		// Similar to above, we create a root iteration for this new space
@@ -123,25 +124,30 @@ func (c *SpaceController) Create(ctx *app.CreateSpaceContext) error {
 		}
 		err = appl.Iterations().Create(ctx, &newIteration)
 		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, errs.Wrapf(err, "failed to create iteration for space: %s", rSpace.Name))
+			return errs.Wrapf(err, "failed to create iteration for space: %s", rSpace.Name)
 		}
 		spaceData, err := ConvertSpaceFromModel(ctx.Context, c.db, ctx.RequestData, *rSpace)
 		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, err)
+			return err
 		}
-		res := &app.SpaceSingle{
+		res = &app.SpaceSingle{
 			Data: spaceData,
 		}
 
 		// Create space resource which will represent the keyclok resource associated with this space
 		_, err = appl.SpaceResources().Create(ctx, spaceResource)
 		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, err)
+			return err
 		}
 
+		return nil
+	})
+	if txnError != nil {
+		return jsonapi.JSONErrorResponse(ctx, txnError)
+	} else {
 		ctx.ResponseData.Header().Set("Location", rest.AbsoluteURL(ctx.RequestData, app.SpaceHref(res.Data.ID)))
 		return ctx.Created(res)
-	})
+	}
 }
 
 // Delete runs the delete action.
@@ -175,7 +181,7 @@ func (c *SpaceController) Delete(ctx *app.DeleteSpaceContext) error {
 	})
 
 	if err != nil {
-		return err
+		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 	c.resourceManager.DeleteResource(ctx, ctx.RequestData, auth.Resource{ResourceID: resourceID, PermissionID: permissionID, PolicyID: policyID})
 	if err != nil {
@@ -188,27 +194,37 @@ func (c *SpaceController) Delete(ctx *app.DeleteSpaceContext) error {
 func (c *SpaceController) List(ctx *app.ListSpaceContext) error {
 	offset, limit := computePagingLimts(ctx.PageOffset, ctx.PageLimit)
 
-	return application.Transactional(c.db, func(appl application.Application) error {
+	var response app.SpaceList
+	txnErr := application.Transactional(c.db, func(appl application.Application) error {
 		spaces, cnt, err := appl.Spaces().List(ctx.Context, &offset, &limit)
 		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, err)
+			return err
 		}
-		return ctx.ConditionalEntities(spaces, c.config.GetCacheControlSpace, func() error {
+		entityErr := ctx.ConditionalEntities(spaces, c.config.GetCacheControlSpace, func() error {
 			count := int(cnt)
 			spaceData, err := ConvertSpacesFromModel(ctx.Context, c.db, ctx.RequestData, spaces)
 			if err != nil {
-				return jsonapi.JSONErrorResponse(ctx, err)
+				return err
 			}
-			response := app.SpaceList{
+			response = app.SpaceList{
 				Links: &app.PagingLinks{},
 				Meta:  &app.SpaceListMeta{TotalCount: count},
 				Data:  spaceData,
 			}
 			setPagingLinks(response.Links, buildAbsoluteURL(ctx.RequestData), len(spaces), offset, limit, count)
-			return ctx.OK(&response)
+			return nil
 		})
+		if entityErr != nil {
+			return entityErr
+		} else {
+			return nil
+		}
 	})
-
+	if txnErr != nil {
+		return jsonapi.JSONErrorResponse(ctx, txnErr)
+	} else {
+		return ctx.OK(&response)
+	}
 }
 
 // Show runs the show action.
@@ -218,23 +234,33 @@ func (c *SpaceController) Show(ctx *app.ShowSpaceContext) error {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
 	}
 
-	return application.Transactional(c.db, func(appl application.Application) error {
+	var result app.SpaceSingle
+	txnErr := application.Transactional(c.db, func(appl application.Application) error {
 		s, err := appl.Spaces().Load(ctx.Context, id)
 		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, err)
+			return err
 		}
 
-		return ctx.ConditionalEntity(*s, c.config.GetCacheControlSpace, func() error {
+		entityErr := ctx.ConditionalEntity(*s, c.config.GetCacheControlSpace, func() error {
 			spaceData, err := ConvertSpaceFromModel(ctx.Context, c.db, ctx.RequestData, *s)
 			if err != nil {
-				return jsonapi.JSONErrorResponse(ctx, err)
+				return err
 			}
-			result := app.SpaceSingle{
+			result = app.SpaceSingle{
 				Data: spaceData,
 			}
-			return ctx.OK(&result)
+			return nil
 		})
+		if entityErr != nil {
+			return entityErr
+		}
+		return nil
 	})
+	if txnErr != nil {
+		return jsonapi.JSONErrorResponse(ctx, txnErr)
+	} else {
+		return ctx.OK(&result)
+	}
 }
 
 // Update runs the update action.
@@ -253,15 +279,16 @@ func (c *SpaceController) Update(ctx *app.UpdateSpaceContext) error {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 
-	return application.Transactional(c.db, func(appl application.Application) error {
+	var response app.SpaceSingle
+	txnErr := application.Transactional(c.db, func(appl application.Application) error {
 		s, err := appl.Spaces().Load(ctx.Context, id)
 		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, err)
+			return err
 		}
 
 		if !uuid.Equal(*currentUser, s.OwnerId) {
 			log.Error(ctx, map[string]interface{}{"currentUser": *currentUser, "owner": s.OwnerId}, "Current user is not owner")
-			return jsonapi.JSONErrorResponse(ctx, goa.NewErrorClass("forbidden", 403)("User is not the space owner"))
+			return goa.NewErrorClass("forbidden", 403)("User is not the space owner")
 		}
 
 		s.Version = *ctx.Payload.Data.Attributes.Version
@@ -274,19 +301,23 @@ func (c *SpaceController) Update(ctx *app.UpdateSpaceContext) error {
 
 		s, err = appl.Spaces().Save(ctx.Context, s)
 		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, err)
+			return err
 		}
 
 		spaceData, err := ConvertSpaceFromModel(ctx.Context, c.db, ctx.RequestData, *s)
 		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, err)
+			return err
 		}
-		response := app.SpaceSingle{
+		response = app.SpaceSingle{
 			Data: spaceData,
 		}
-
-		return ctx.OK(&response)
+		return nil
 	})
+	if txnErr != nil {
+		return jsonapi.JSONErrorResponse(ctx, txnErr)
+	} else {
+		return ctx.OK(&response)
+	}
 }
 
 func validateCreateSpace(ctx *app.CreateSpaceContext) error {

--- a/controller/space_test.go
+++ b/controller/space_test.go
@@ -533,6 +533,7 @@ func (rest *TestSpaceREST) TestSuccessCreateSameSpaceNameDifferentOwners() {
 	assert.NotNil(rest.T(), created2.Data.Attributes)
 	assert.NotNil(rest.T(), created2.Data.Attributes.Name)
 	assert.Equal(rest.T(), name, *created2.Data.Attributes.Name)
+	assert.NotEqual(rest.T(), created.Data.Relationships.OwnedBy.Data.ID, created2.Data.Relationships.OwnedBy.Data.ID)
 }
 
 func (rest *TestSpaceREST) TestFailCreateSameSpaceNameSameOwner() {

--- a/controller/space_test.go
+++ b/controller/space_test.go
@@ -536,6 +536,33 @@ func (rest *TestSpaceREST) TestSuccessCreateSameSpaceNameDifferentOwners() {
 	assert.NotEqual(rest.T(), created.Data.Relationships.OwnedBy.Data.ID, created2.Data.Relationships.OwnedBy.Data.ID)
 }
 
+func (rest *TestSpaceREST) TestFailCreateSameSpaceNameSameOwner() {
+	// given
+	name := "SameName-" + uuid.NewV4().String()
+	description := "Space for TestSuccessCreateSameSpaceNameDifferentOwners"
+	newDescription := "Space for TestSuccessCreateSameSpaceNameDifferentOwners2"
+	// when
+	a := minimumRequiredCreateSpace()
+	a.Data.Attributes.Name = &name
+	a.Data.Attributes.Description = &description
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
+	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, a)
+	// then
+	assert.NotNil(rest.T(), created.Data)
+	assert.NotNil(rest.T(), created.Data.Attributes)
+	assert.NotNil(rest.T(), created.Data.Attributes.Name)
+	assert.Equal(rest.T(), name, *created.Data.Attributes.Name)
+
+	// when
+	b := minimumRequiredCreateSpace()
+	b.Data.Attributes.Name = &name
+	b.Data.Attributes.Description = &newDescription
+	_, err := test.CreateSpaceBadRequest(rest.T(), svc.Context, svc, ctrl, b)
+	// then
+	assert.NotEmpty(rest.T(), err.Errors)
+	assert.Contains(rest.T(), err.Errors[0].Detail, "Bad value for parameter 'Name'", "expected: 'unique'")
+}
+
 func minimumRequiredCreateSpace() *app.CreateSpacePayload {
 	return &app.CreateSpacePayload{
 		Data: &app.Space{

--- a/controller/space_test.go
+++ b/controller/space_test.go
@@ -536,33 +536,6 @@ func (rest *TestSpaceREST) TestSuccessCreateSameSpaceNameDifferentOwners() {
 	assert.NotEqual(rest.T(), created.Data.Relationships.OwnedBy.Data.ID, created2.Data.Relationships.OwnedBy.Data.ID)
 }
 
-func (rest *TestSpaceREST) TestFailCreateSameSpaceNameSameOwner() {
-	// given
-	name := "SameName-" + uuid.NewV4().String()
-	description := "Space for TestSuccessCreateSameSpaceNameDifferentOwners"
-	newDescription := "Space for TestSuccessCreateSameSpaceNameDifferentOwners2"
-	// when
-	a := minimumRequiredCreateSpace()
-	a.Data.Attributes.Name = &name
-	a.Data.Attributes.Description = &description
-	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
-	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, a)
-	// then
-	assert.NotNil(rest.T(), created.Data)
-	assert.NotNil(rest.T(), created.Data.Attributes)
-	assert.NotNil(rest.T(), created.Data.Attributes.Name)
-	assert.Equal(rest.T(), name, *created.Data.Attributes.Name)
-
-	// when
-	b := minimumRequiredCreateSpace()
-	b.Data.Attributes.Name = &name
-	b.Data.Attributes.Description = &newDescription
-	_, err := test.CreateSpaceBadRequest(rest.T(), svc.Context, svc, ctrl, b)
-	// then
-	assert.NotEmpty(rest.T(), err.Errors)
-	assert.Contains(rest.T(), err.Errors[0].Detail, "Bad value for parameter 'Name'", "expected: 'unique'")
-}
-
 func minimumRequiredCreateSpace() *app.CreateSpacePayload {
 	return &app.CreateSpacePayload{
 		Data: &app.Space{

--- a/controller/space_test.go
+++ b/controller/space_test.go
@@ -508,6 +508,33 @@ func (rest *TestSpaceREST) TestListSpacesNotModifiedUsingIfNoneMatchHeader() {
 	test.ListSpaceNotModified(rest.T(), svc.Context, svc, ctrl, nil, nil, nil, &ifNoneMatch)
 }
 
+func (rest *TestSpaceREST) TestSuccessCreateSameSpaceNameDifferentOwners() {
+	// given
+	name := "SameName-" + uuid.NewV4().String()
+	description := "Space for TestSuccessCreateSameSpaceNameDifferentOwners"
+	newDescription := "Space for TestSuccessCreateSameSpaceNameDifferentOwners2"
+	a := minimumRequiredCreateSpace()
+	a.Data.Attributes.Name = &name
+	a.Data.Attributes.Description = &description
+	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
+	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, a)
+	// when
+	b := minimumRequiredCreateSpace()
+	b.Data.Attributes.Name = &name
+	b.Data.Attributes.Description = &newDescription
+	svc2, ctrl2 := rest.SecuredController(testsupport.TestIdentity2)
+	_, created2 := test.CreateSpaceCreated(rest.T(), svc2.Context, svc2, ctrl2, b)
+	// then
+	assert.NotNil(rest.T(), created.Data)
+	assert.NotNil(rest.T(), created.Data.Attributes)
+	assert.NotNil(rest.T(), created.Data.Attributes.Name)
+	assert.Equal(rest.T(), name, *created.Data.Attributes.Name)
+	assert.NotNil(rest.T(), created2.Data)
+	assert.NotNil(rest.T(), created2.Data.Attributes)
+	assert.NotNil(rest.T(), created2.Data.Attributes.Name)
+	assert.Equal(rest.T(), name, *created2.Data.Attributes.Name)
+}
+
 func minimumRequiredCreateSpace() *app.CreateSpacePayload {
 	return &app.CreateSpacePayload{
 		Data: &app.Space{

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -274,7 +274,7 @@ func GetMigrations() Migrations {
 	m = append(m, steps{ExecuteSQLFile("051-modify-work_item_link_types_name_idx.sql")})
 
 	// Version 52
-	m = append(m, steps{executeSQLFile("052-unique-space-names.sql")})
+	m = append(m, steps{ExecuteSQLFile("052-unique-space-names.sql")})
 
 	// Version N
 	//

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -273,6 +273,9 @@ func GetMigrations() Migrations {
 	// Version 51
 	m = append(m, steps{ExecuteSQLFile("051-modify-work_item_link_types_name_idx.sql")})
 
+	// Version 52
+	m = append(m, steps{executeSQLFile("052-unique-space-names.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/052-unique-space-names.sql
+++ b/migration/sql-files/052-unique-space-names.sql
@@ -1,0 +1,4 @@
+-- drop existing unique index
+DROP INDEX spaces_name_idx;
+-- recreate unique index with original index name, on two columns
+CREATE UNIQUE INDEX spaces_name_idx ON spaces (name, owner_id) WHERE deleted_at IS NULL;

--- a/space/space_test.go
+++ b/space/space_test.go
@@ -41,8 +41,17 @@ func (test *repoBBTest) TestCreate() {
 	res, _ := expectSpace(test.create(testSpace), test.requireOk)
 
 	require.Equal(test.T(), res.Name, testSpace)
+}
 
+func (test *repoBBTest) TestCreateFailSpaceNameChecks() {
 	expectSpace(test.create(""), test.assertBadParameter())
+}
+
+func (test *repoBBTest) TestCreateFailSameOwner() {
+	res, _ := expectSpace(test.create(testSpace), test.requireOk)
+
+	require.Equal(test.T(), res.Name, testSpace)
+
 	expectSpace(test.create(testSpace), test.assertBadParameter())
 }
 


### PR DESCRIPTION
The index now checks for uniqueness across owners and space names,
instead of enforcing uniqueness on space names globally.
Fixes #1000