### PR TITLE
Add redirect param to login endpoint

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -74,6 +74,7 @@ const (
 	defaultConfigFile                   = "config.yaml"
 	varOpenshiftTenantMasterURL         = "openshift.tenant.masterurl"
 	varCheStarterURL                    = "chestarterurl"
+	varValidRedirectURLs                = "redirect.valid"
 )
 
 // ConfigurationData encapsulates the Viper configuration object which stores the configuration data in-memory.
@@ -511,6 +512,19 @@ func (c *ConfigurationData) GetOpenshiftTenantMasterURL() string {
 	return c.v.GetString(varOpenshiftTenantMasterURL)
 }
 
+// GetValidRedirectURLs returns the RegEx of valid redirect URLs for auth requests
+// If the ALMIGHTY_REDIRECT_VALID env var is not set then in Dev Mode all redirects allowed - *
+// In prod mode the default regex will be returned
+func (c *ConfigurationData) GetValidRedirectURLs() string {
+	if c.v.IsSet(varValidRedirectURLs) {
+		return c.v.GetString(varValidRedirectURLs)
+	}
+	if c.IsPostgresDeveloperModeEnabled() {
+		return devModeValidRedirectURLs
+	}
+	return DefaultValidRedirectURL
+}
+
 const (
 	// Auth-related defaults
 
@@ -576,6 +590,12 @@ ZwIDAQAB
 
 	defaultOpenshiftTenantMasterURL = "https://tsrv.devshift.net:8443"
 	defaultCheStarterURL            = "che-server"
+
+	// DefaultValidRedirectURL is a regex to be used to whitelist redirect URL for auth
+	// If the ALMIGHTY_REDIRECT_VALID env var is not set then in Dev Mode all redirects allowed - *
+	// In prod mode the following regex will be used by default:
+	DefaultValidRedirectURL  = "^(https|http)://([^/]+[.])?(?i:openshift[.]io)(/.*)?$" // *.openshift.io/*
+	devModeValidRedirectURLs = ".*"
 )
 
 // ActualToken is actual OAuth access token of github

--- a/configuration/configuration_whitebox_test.go
+++ b/configuration/configuration_whitebox_test.go
@@ -102,3 +102,23 @@ func TestKeycloakRealmInDevModeCanBeOverridden(t *testing.T) {
 
 	assert.Equal(t, "somecustomrealm", config.GetKeycloakRealm())
 }
+
+func TestValidRedirectURLsInDevModeCanBeOverridden(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+
+	key := "ALMIGHTY_REDIRECT_VALID"
+	realEnvValue := os.Getenv(key)
+
+	os.Unsetenv(key)
+	defer func() {
+		os.Setenv(key, realEnvValue)
+		resetConfiguration()
+	}()
+
+	assert.Equal(t, devModeValidRedirectURLs, config.GetValidRedirectURLs())
+
+	os.Setenv(key, "https://someDomain.org/redirect")
+	resetConfiguration()
+
+	assert.Equal(t, "https://someDomain.org/redirect", config.GetValidRedirectURLs())
+}

--- a/controller/login.go
+++ b/controller/login.go
@@ -32,6 +32,7 @@ type loginConfiguration interface {
 	GetKeycloakTestUserSecret() string
 	GetKeycloakTestUser2Name() string
 	GetKeycloakTestUser2Secret() string
+	GetValidRedirectURLs() string
 }
 
 // LoginController implements the login resource.
@@ -72,7 +73,7 @@ func (c *LoginController) Authorize(ctx *app.AuthorizeLoginContext) error {
 		}, "Unable to get Keycloak broker endpoint URL")
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("unable to get Keycloak broker endpoint URL. "+err.Error()))
 	}
-	return c.auth.Perform(ctx, authEndpoint, tokenEndpoint, brokerEndpoint)
+	return c.auth.Perform(ctx, authEndpoint, tokenEndpoint, brokerEndpoint, c.configuration.GetValidRedirectURLs())
 }
 
 // Refresh obtain a new access token using the refresh token.
@@ -129,7 +130,7 @@ func (c *LoginController) Link(ctx *app.LinkLoginContext) error {
 	}
 	clientID := c.configuration.GetKeycloakClientID()
 
-	return c.auth.Link(ctx, brokerEndpoint, clientID)
+	return c.auth.Link(ctx, brokerEndpoint, clientID, c.configuration.GetValidRedirectURLs())
 }
 
 // Linksession links identity provider(s) to the user's account
@@ -143,7 +144,7 @@ func (c *LoginController) Linksession(ctx *app.LinksessionLoginContext) error {
 	}
 	clientID := c.configuration.GetKeycloakClientID()
 
-	return c.auth.LinkSession(ctx, brokerEndpoint, clientID)
+	return c.auth.LinkSession(ctx, brokerEndpoint, clientID, c.configuration.GetValidRedirectURLs())
 }
 
 // Linkcallback redirects to original referel when Identity Provider account are linked to the user account

--- a/controller/login_test.go
+++ b/controller/login_test.go
@@ -82,7 +82,7 @@ func (rest *TestLoginREST) TestAuthorizeLoginOK() {
 	resource.Require(t, resource.UnitTest)
 	svc, ctrl := rest.UnSecuredController()
 
-	test.AuthorizeLoginTemporaryRedirect(t, svc.Context, svc, ctrl, nil)
+	test.AuthorizeLoginTemporaryRedirect(t, svc.Context, svc, ctrl, nil, nil)
 }
 
 func (rest *TestLoginREST) TestTestUserTokenObtainedFromKeycloakOK() {

--- a/controller/login_test.go
+++ b/controller/login_test.go
@@ -168,7 +168,7 @@ func validateToken(t *testing.T, token *app.AuthToken, controler *LoginControlle
 
 type TestLoginService struct{}
 
-func (t TestLoginService) Perform(ctx *app.AuthorizeLoginContext, authEndpoint string, tokenEndpoint string, brokerEndpoint string) error {
+func (t TestLoginService) Perform(ctx *app.AuthorizeLoginContext, authEndpoint string, tokenEndpoint string, brokerEndpoint string, validRedirectURL string) error {
 	return ctx.TemporaryRedirect()
 }
 
@@ -176,11 +176,11 @@ func (t TestLoginService) CreateOrUpdateKeycloakUser(accessToken string, ctx con
 	return nil, nil, nil
 }
 
-func (t TestLoginService) Link(ctx *app.LinkLoginContext, brokerEndpoint string, clientID string) error {
+func (t TestLoginService) Link(ctx *app.LinkLoginContext, brokerEndpoint string, clientID string, validRedirectURL string) error {
 	return ctx.TemporaryRedirect()
 }
 
-func (t TestLoginService) LinkSession(ctx *app.LinksessionLoginContext, brokerEndpoint string, clientID string) error {
+func (t TestLoginService) LinkSession(ctx *app.LinksessionLoginContext, brokerEndpoint string, clientID string, validRedirectURL string) error {
 	return ctx.TemporaryRedirect()
 }
 

--- a/design/auth.go
+++ b/design/auth.go
@@ -15,11 +15,14 @@ var _ = a.Resource("login", func() {
 		)
 		a.Params(func() {
 			a.Param("link", d.Boolean, "If true then link all available Identity Providers to the user account after successful login")
+			a.Param("redirect", d.String, "URL to be redirected to after successful login. If not set then will redirect to the referrer instead.")
+
 		})
 		a.Description("Authorize with the ALM")
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.TemporaryRedirect)
 		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.BadRequest, JSONAPIErrors)
 	})
 
 	a.Action("generate", func() {

--- a/login/service.go
+++ b/login/service.go
@@ -395,11 +395,7 @@ func (keycloak *KeycloakOAuthProvider) saveReferrer(ctx linkInterface, state uui
 	}
 	err = application.Transactional(keycloak.db, func(appl application.Application) error {
 		_, err := appl.OauthStates().Create(ctx, &ref)
-		if err != nil {
-			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInternal(err.Error()))
-			return ctx.InternalServerError(jerrors)
-		}
-		return nil
+		return err
 	})
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{


### PR DESCRIPTION
- New optional redirect param for /api/login/authorize
- If no redirect param set then use referer header
- If no redirect param and referer is empty then return 400 Bad Request
- Validate referrers/redirect URLs if they are whitelisted

Fixes https://github.com/almighty/almighty-core/issues/1073 and https://github.com/almighty/almighty-core/issues/892
