### PR TITLE
Fix redirect URL whitelist exception for prod-prevew

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -613,7 +613,7 @@ ZwIDAQAB
 	devModeValidRedirectURLs = ".*"
 	// Allow redirects to localhost when running in prod-preveiw
 	localhostRedirectURLs      = "(" + DefaultValidRedirectURLs + "|^(https|http)://([^/]+[.])?(localhost|127[.]0[.]0[.]1)(:\\d+)?(/.*)?$)" // *.openshift.io/* or localhost/* or 127.0.0.1/*
-	localhostRedirectException = "^(https|http)://([^/]+[.])?(?i:prod-preview[.]openshift[.]io)(/.*)?$"                                     // *.prod-preview.openshift.io/*
+	localhostRedirectException = "^(https|http)://([^/]+[.])?(?i:prod-preview[.]openshift[.]io)(:\\d+)?(/.*)?$"                             // *.prod-preview.openshift.io/*
 )
 
 // ActualToken is actual OAuth access token of github

--- a/configuration/configuration_whitebox_test.go
+++ b/configuration/configuration_whitebox_test.go
@@ -133,8 +133,10 @@ func TestRedirectURLsForLocalhostRequestAreExcepted(t *testing.T) {
 	// Invalid otherwise
 	assert.True(t, validateRedirectURL(t, "https://api.prod-preview.openshift.io/api", "http://localhost:3000/home"))
 	assert.True(t, validateRedirectURL(t, "https://api.prod-preview.openshift.io/api", "https://127.0.0.1"))
+	assert.True(t, validateRedirectURL(t, "https://api.prod-preview.openshift.io:8080/api", "https://127.0.0.1"))
 	assert.True(t, validateRedirectURL(t, "https://api.prod-preview.openshift.io/api", "https://prod-preview.openshift.io/home"))
 	assert.True(t, validateRedirectURL(t, "https://api.openshift.io/api", "https://openshift.io/home"))
+	assert.True(t, validateRedirectURL(t, "https://api.openshift.io:8080/api", "https://openshift.io/home"))
 	assert.False(t, validateRedirectURL(t, "https://api.openshift.io/api", "http://localhost:3000/api"))
 	assert.False(t, validateRedirectURL(t, "https://api.prod-preview.openshift.io/api", "http://domain.com"))
 	assert.False(t, validateRedirectURL(t, "https://api.openshift.io/api", "http://domain.com"))


### PR DESCRIPTION
localhost was whitelisted for requests to: api.prod-preview.osio.io/api 
but didn't work for requests to: api.prod-preview.osio.io:8080/api
Now it works for any port for prod-preview.osio.io.

Not sure if we really need it or customizing whitelist on cluster level by setting env var is enough/right approach.