### PR TITLE
Add capability to PATCH user contextInformation

### DIFF
--- a/controller/users.go
+++ b/controller/users.go
@@ -101,7 +101,12 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 
 		updatedContextInformation := ctx.Payload.Data.Attributes.ContextInformation
 		if updatedContextInformation != nil {
-			user.ContextInformation = workitem.Fields{}
+			// if user.ContextInformation , we get to PATCH the ContextInformation field,
+			// instead of over-writing it altogether. Note: The PATCH-ing is only for the
+			// 1st level of JSON.
+			if user.ContextInformation == nil {
+				user.ContextInformation = workitem.Fields{}
+			}
 			for fieldName, fieldValue := range updatedContextInformation {
 				// Save it as is, for short-term.
 				user.ContextInformation[fieldName] = fieldValue

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -205,6 +205,66 @@ func (s *TestUsersSuite) TestUpdateUserOKWithoutContextInfo() {
 	test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 }
 
+func (s *TestUsersSuite) TestPatchUserContextInformation() {
+
+	// given
+	user := s.createRandomUser("TestPatchUserContextInformation")
+	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String())
+	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
+	assert.Equal(s.T(), user.FullName, *result.Data.Attributes.FullName)
+	assert.Equal(s.T(), user.ImageURL, *result.Data.Attributes.ImageURL)
+	assert.Equal(s.T(), identity.ProviderType, *result.Data.Attributes.ProviderType)
+	assert.Equal(s.T(), identity.Username, *result.Data.Attributes.Username)
+	// when
+	secureService, secureController := s.SecuredController(identity)
+
+	contextInformation := map[string]interface{}{
+		"last_visited": "yesterday",
+		"count":        3,
+	}
+	//secureController, secureService := createSecureController(t, identity)
+	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, contextInformation)
+	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
+	// then
+	require.NotNil(s.T(), result)
+
+	// let's fetch it and validate the usual stuff.
+	_, result = test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String())
+	require.NotNil(s.T(), result)
+	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
+	updatedContextInformation := result.Data.Attributes.ContextInformation
+
+	// Before we PATCH, ensure that the 1st time update has worked well.
+	assert.Equal(s.T(), contextInformation["last_visited"], updatedContextInformation["last_visited"])
+	countValue, ok := updatedContextInformation["count"].(float64)
+	assert.True(s.T(), ok)
+	assert.Equal(s.T(), contextInformation["count"], int(countValue))
+
+	/** Usual stuff done, now lets PATCH only 1 contextInformation attribute **/
+	patchedContextInformation := map[string]interface{}{
+		"count": 5,
+	}
+
+	updateUsersPayload = createUpdateUsersPayload(nil, nil, nil, nil, nil, patchedContextInformation)
+	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
+	require.NotNil(s.T(), result)
+
+	// let's fetch it and validate the usual stuff.
+	_, result = test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String())
+	require.NotNil(s.T(), result)
+	updatedContextInformation = result.Data.Attributes.ContextInformation
+
+	// what was NOT passed, should remain intact.
+	assert.Equal(s.T(), contextInformation["last_visited"], updatedContextInformation["last_visited"])
+
+	// what WAS PASSED, should be updated.
+	countValue, ok = updatedContextInformation["count"].(float64)
+	assert.True(s.T(), ok)
+	assert.Equal(s.T(), patchedContextInformation["count"], int(countValue))
+
+}
+
 func (s *TestUsersSuite) TestUpdateUserUnauthorized() {
 	// given
 	user := s.createRandomUser("TestUpdateUserUnauthorized")


### PR DESCRIPTION
---- commit message ----

The User contextInformation is stored as a json blob in the backend. 
Prior to this PR, the client had to send the entire json blob to the API even for a tiny update.
This change ensures that only the changed attribute can be sent in the PATCH request, and the API would handle merging it with the existing contextInformation json blob

Fixes #1107 

--- end -----

Step 1:

```
./bin/alm-cli update users --key $ALM_TOKEN 
 --payload 
'
{
  "data": {
    "type": "identities",
    "attributes": {
      "contextInformation": {
        "a": "New Attribute , Yay!"
      },
      "bio": "something222"
    }
  }
}
'  -H localhost:8080 --pp
2017/04/03 10:11:38 [INFO] started id=QV9PrgVg PATCH=http://localhost:8080/api/users
2017/04/03 10:11:38 [INFO] completed id=QV9PrgVg status=200 time=14.818569ms
{
    "data": {
        "attributes": {
            "bio": "something222",
            "contextInformation": {
                "a": "New Attribute , Yay!"
            },
            "email": "updatedemaila2256b33-719a-4137-b9bc-c95550b9cd96@email.com",
            "fullName": "updatedFirstNameAgainNew900dcc26-0cab-4a46-b819-d9c8d5c248b4 updatedLastNameNewe876285e-a804-46e2-9569-dd743a8880c4",
            "imageURL": "https://www.gravatar.com/avatar/c4be9388d5808236876458ccee5d1e8a.jpg",
            "providerType": "kc",
            "url": "",
            "username": "testuser"
        },
        "id": "ad3d8a9d-3a33-40a6-afd2-1f50514388b8",
        "links": {
            "self": "http://localhost:8080/api/users/ad3d8a9d-3a33-40a6-afd2-1f50514388b8"
        },
        "type": "identities"
    }
}
```

Step 2:
Do not pass all `contextInformation` attributes, pass a new one only..


```
./bin/alm-cli update users --key $ALM_TOKEN  --payload 
'
{
  "data": {
    "type": "idenities",
    "attributes": {
      "contextInformation": {
        "b": "The Big Ben"
      },
      "bio": "something222"
    }
  }
}
'  -H localhost:8080 --pp
2017/04/03 10:11:53 [INFO] started id=3XN7N/N0 PATCH=http://localhost:8080/api/users
2017/04/03 10:11:53 [INFO] completed id=3XN7N/N0 status=200 time=17.903476ms
{
    "data": {
        "attributes": {
            "bio": "something222",
            "contextInformation": {
                "a": "New Attribute , Yay!"
                "b": "The Big Ben"
            },
            "email": "updatedemaila2256b33-719a-4137-b9bc-c95550b9cd96@email.com",
            "fullName": "updatedFirstNameAgainNew900dcc26-0cab-4a46-b819-d9c8d5c248b4 updatedLastNameNewe876285e-a804-46e2-9569-dd743a8880c4",
            "imageURL": "https://www.gravatar.com/avatar/c4be9388d5808236876458ccee5d1e8a.jpg",
            "providerType": "kc",
            "url": "",
            "username": "testuser"
        },
        "id": "ad3d8a9d-3a33-40a6-afd2-1f50514388b8",
        "links": {
            "self": "http://localhost:8080/api/users/ad3d8a9d-3a33-40a6-afd2-1f50514388b8"
        },
        "type": "identities"
    }
}
```


Step 3:
Do not pass all attributes, but pass an existing one:

```
./bin/alm-cli update users --key $ALM_TOKEN  --payload '

"data": {
  "type": "idenities",
  "attributes": {
    "contextInformation": {
      "b": "only this gets updated!"
    },
    "bio": "something222"
  }
}
}
'  -H localhost:8080 --pp
2017/04/03 10:47:39 [INFO] started id=juN/eMZ3 PATCH=http://localhost:8080/api/users
2017/04/03 10:47:39 [INFO] completed id=juN/eMZ3 status=200 time=15.069765ms
{
    "data": {
        "attributes": {
            "bio": "something222",
            "contextInformation": {
                "a": "New Attribute , Yay!",
                "b": "only this gets updated!"
            },
            "email": "updatedemaila2256b33-719a-4137-b9bc-c95550b9cd96@email.com",
            "fullName": "updatedFirstNameAgainNew900dcc26-0cab-4a46-b819-d9c8d5c248b4 updatedLastNameNewe876285e-a804-46e2-9569-dd743a8880c4",
            "imageURL": "https://www.gravatar.com/avatar/c4be9388d5808236876458ccee5d1e8a.jpg",
            "providerType": "kc",
            "url": "",
            "username": "testuser"
        },
        "id": "ad3d8a9d-3a33-40a6-afd2-1f50514388b8",
        "links": {
            "self": "http://localhost:8080/api/users/ad3d8a9d-3a33-40a6-afd2-1f50514388b8"
        },
        "type": "identities"
    }
}
```