### PR TITLE
Add conditional requests and cache-control headers on the 'work item links' endpoints (#1112)

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -69,6 +69,7 @@ const (
 	varCacheControlWorkItemType         = "cachecontrol.workitemtype"
 	varCacheControlWorkItemLinkType     = "cachecontrol.workitemlinktype"
 	varCacheControlWorkItems            = "cachecontrol.workitems"
+	varCacheControlWorkItemLinks        = "cachecontrol.workitemLinks"
 	varCacheControlAreas                = "cachecontrol.areas"
 	varCacheControlSpace                = "cachecontrol.space"
 	varCacheControlIteration            = "cachecontrol.iteration"
@@ -172,6 +173,7 @@ func (c *ConfigurationData) setConfigDefaults() {
 	c.v.SetDefault(varCacheControlWorkItemType, "max-age=86400")     // 1 day
 	c.v.SetDefault(varCacheControlWorkItemLinkType, "max-age=86400") // 1 day
 	c.v.SetDefault(varCacheControlWorkItems, "max-age=300")
+	c.v.SetDefault(varCacheControlWorkItemLinks, "max-age=300")
 	c.v.SetDefault(varCacheControlAreas, "max-age=300")
 	c.v.SetDefault(varCacheControlSpace, "max-age=300")
 	c.v.SetDefault(varCacheControlIteration, "max-age=300")
@@ -284,7 +286,13 @@ func (c *ConfigurationData) GetCacheControlWorkItems() string {
 	return c.v.GetString(varCacheControlWorkItems)
 }
 
-// GetCacheControlWorkItems returns the value to set in the "Cache-Control" HTTP response header
+// GetCacheControlWorkItemLinks returns the value to set in the "Cache-Control" HTTP response header
+// when returning a work item (or a list of).
+func (c *ConfigurationData) GetCacheControlWorkItemLinks() string {
+	return c.v.GetString(varCacheControlWorkItemLinks)
+}
+
+// GetCacheControlAreas returns the value to set in the "Cache-Control" HTTP response header
 // when returning a work item (or a list of).
 func (c *ConfigurationData) GetCacheControlAreas() string {
 	return c.v.GetString(varCacheControlAreas)

--- a/controller/work_item_children_blackbox_test.go
+++ b/controller/work_item_children_blackbox_test.go
@@ -71,7 +71,7 @@ func (s *workItemChildSuite) SetupSuite() {
 
 	svc := testsupport.ServiceAsUser("WorkItemLink-Service", almtoken.NewManagerWithPrivateKey(priv), s.testIdentity)
 	require.NotNil(s.T(), svc)
-	s.workItemLinkCtrl = NewWorkItemLinkController(svc, s.db)
+	s.workItemLinkCtrl = NewWorkItemLinkController(svc, s.db, s.Configuration)
 	require.NotNil(s.T(), s.workItemLinkCtrl)
 
 	svc = testsupport.ServiceAsUser("WorkItemLinkType-Service", almtoken.NewManagerWithPrivateKey(priv), s.testIdentity)
@@ -86,17 +86,17 @@ func (s *workItemChildSuite) SetupSuite() {
 
 	svc = testsupport.ServiceAsUser("WorkItemType-Service", almtoken.NewManagerWithPrivateKey(priv), s.testIdentity)
 	require.NotNil(s.T(), svc)
-	s.typeCtrl = NewWorkitemtypeController(svc, s.db, wiConfiguration)
+	s.typeCtrl = NewWorkitemtypeController(svc, s.db, s.Configuration)
 	require.NotNil(s.T(), s.typeCtrl)
 
 	svc = testsupport.ServiceAsUser("WorkItemLink-Service", almtoken.NewManagerWithPrivateKey(priv), s.testIdentity)
 	require.NotNil(s.T(), svc)
-	s.workItemLinkCtrl = NewWorkItemLinkController(svc, s.db)
+	s.workItemLinkCtrl = NewWorkItemLinkController(svc, s.db, s.Configuration)
 	require.NotNil(s.T(), s.workItemLinkCtrl)
 
 	svc = testsupport.ServiceAsUser("WorkItemRelationshipsLinks-Service", almtoken.NewManagerWithPrivateKey(priv), s.testIdentity)
 	require.NotNil(s.T(), svc)
-	s.workItemRelsLinksCtrl = NewWorkItemRelationshipsLinksController(svc, s.db)
+	s.workItemRelsLinksCtrl = NewWorkItemRelationshipsLinksController(svc, s.db, s.Configuration)
 	require.NotNil(s.T(), s.workItemRelsLinksCtrl)
 
 	svc = testsupport.ServiceAsUser("TestWorkItem-Service", almtoken.NewManagerWithPrivateKey(priv), testIdentity)
@@ -107,7 +107,7 @@ func (s *workItemChildSuite) SetupSuite() {
 
 	svc = testsupport.ServiceAsUser("Space-Service", almtoken.NewManagerWithPrivateKey(priv), testIdentity)
 	require.NotNil(s.T(), svc)
-	s.spaceCtrl = NewSpaceController(svc, s.db, wiConfiguration, &DummyResourceManager{})
+	s.spaceCtrl = NewSpaceController(svc, s.db, s.Configuration, &DummyResourceManager{})
 	require.NotNil(s.T(), s.spaceCtrl)
 
 }

--- a/controller/work_item_relationships_links.go
+++ b/controller/work_item_relationships_links.go
@@ -90,8 +90,7 @@ func (c *WorkItemRelationshipsLinksController) List(ctx *app.ListWorkItemRelatio
 		linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkHref, nil)
 		modelLinks, err := appl.WorkItemLinks().ListByWorkItemID(ctx.Context, ctx.WiID)
 		if err != nil {
-			jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(err)
-			return ctx.ResponseData.Service.Send(ctx.Context, httpStatusCode, jerrors)
+			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 		return ctx.ConditionalEntities(modelLinks, c.config.GetCacheControlWorkItemLinks, func() error {
 			return listWorkItemLink(modelLinks, linkCtx, ctx)

--- a/controller/work_item_relationships_links.go
+++ b/controller/work_item_relationships_links.go
@@ -16,17 +16,24 @@ import (
 // WorkItemRelationshipsLinksController implements the work-item-relationships-links resource.
 type WorkItemRelationshipsLinksController struct {
 	*goa.Controller
-	db application.DB
+	db     application.DB
+	config WorkItemRelationshipsLinksControllerConfig
+}
+
+// WorkItemRelationshipsLinksControllerConfig the config interface for the WorkItemRelationshipsLinksController
+type WorkItemRelationshipsLinksControllerConfig interface {
+	GetCacheControlWorkItemLinks() string
 }
 
 // NewWorkItemRelationshipsLinksController creates a work-item-relationships-links controller.
-func NewWorkItemRelationshipsLinksController(service *goa.Service, db application.DB) *WorkItemRelationshipsLinksController {
+func NewWorkItemRelationshipsLinksController(service *goa.Service, db application.DB, config WorkItemRelationshipsLinksControllerConfig) *WorkItemRelationshipsLinksController {
 	if db == nil {
 		panic("db must not be nil")
 	}
 	return &WorkItemRelationshipsLinksController{
 		Controller: service.NewController("WorkItemRelationshipsLinksController"),
 		db:         db,
+		config:     config,
 	}
 }
 
@@ -81,7 +88,14 @@ func (c *WorkItemRelationshipsLinksController) Create(ctx *app.CreateWorkItemRel
 func (c *WorkItemRelationshipsLinksController) List(ctx *app.ListWorkItemRelationshipsLinksContext) error {
 	return application.Transactional(c.db, func(appl application.Application) error {
 		linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkHref, nil)
-		return listWorkItemLink(linkCtx, ctx, &ctx.WiID)
+		modelLinks, err := appl.WorkItemLinks().ListByWorkItemID(ctx.Context, ctx.WiID)
+		if err != nil {
+			jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(err)
+			return ctx.ResponseData.Service.Send(ctx.Context, httpStatusCode, jerrors)
+		}
+		return ctx.ConditionalEntities(modelLinks, c.config.GetCacheControlWorkItemLinks, func() error {
+			return listWorkItemLink(modelLinks, linkCtx, ctx)
+		})
 	})
 }
 

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -762,7 +762,7 @@ func (s *WorkItem2Suite) SetupTest() {
 	s.wi2Ctrl = NewWorkitemController(s.svc, gormapplication.NewGormDB(s.DB), s.Configuration)
 	s.linkCatCtrl = NewWorkItemLinkCategoryController(s.svc, gormapplication.NewGormDB(s.DB))
 	s.linkTypeCtrl = NewWorkItemLinkTypeController(s.svc, gormapplication.NewGormDB(s.DB))
-	s.linkCtrl = NewWorkItemLinkController(s.svc, gormapplication.NewGormDB(s.DB))
+	s.linkCtrl = NewWorkItemLinkController(s.svc, gormapplication.NewGormDB(s.DB), s.Configuration)
 	s.spaceCtrl = NewSpaceController(s.svc, gormapplication.NewGormDB(s.DB), s.Configuration, &DummyResourceManager{})
 
 	payload := minimumRequiredCreateWithType(workitem.SystemBug)
@@ -1620,7 +1620,7 @@ func (s *WorkItem2Suite) xTestWI2DeleteLinksOnWIDeletionOK() {
 	test.DeleteWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, wi1.Data.Relationships.Space.Data.ID.String(), *wi1.Data.ID)
 
 	// Check that the link was deleted by deleting wi1
-	test.ShowWorkItemLinkNotFound(s.T(), s.svc.Context, s.svc, s.linkCtrl, *workItemLink.Data.ID)
+	test.ShowWorkItemLinkNotFound(s.T(), s.svc.Context, s.svc, s.linkCtrl, *workItemLink.Data.ID, nil, nil)
 
 	// Check that we can query for wi2 without problems
 	test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, wi2.Data.Relationships.Space.Data.ID.String(), *wi2.Data.ID, nil, nil)

--- a/design/work_item_link.go
+++ b/design/work_item_link.go
@@ -51,9 +51,16 @@ See also http://jsonapi.org/format/#document-resource-object`)
 var workItemLinkAttributes = a.Type("WorkItemLinkAttributes", func() {
 	a.Description(`JSONAPI store for all the "attributes" of a work item link.
 See also see http://jsonapi.org/format/#document-resource-object-attributes`)
+	a.Attribute("created-at", d.DateTime, "When the space was created", func() {
+		a.Example("2016-11-29T23:18:14Z")
+	})
+	a.Attribute("updated-at", d.DateTime, "When the space was updated", func() {
+		a.Example("2016-11-29T23:18:14Z")
+	})
 	a.Attribute("version", d.Integer, "Version for optimistic concurrency control (optional during creating)", func() {
 		a.Example(0)
 	})
+
 	// IMPORTANT: We cannot require any field here because these "attributes" will be used
 	// during the creation as well as the update of a work item link type.
 	// During creation, the "name" field is required but not during update.
@@ -149,9 +156,9 @@ func listWorkItemLinks() {
 	a.Routing(
 		a.GET(""),
 	)
-	a.Response(d.OK, func() {
-		a.Media(workItemLinkList)
-	})
+	a.UseTrait("conditional")
+	a.Response(d.OK, workItemLinkList)
+	a.Response(d.NotModified)
 	a.Response(d.BadRequest, JSONAPIErrors)
 	a.Response(d.InternalServerError, JSONAPIErrors)
 }
@@ -164,9 +171,9 @@ func showWorkItemLink() {
 	a.Params(func() {
 		a.Param("linkId", d.UUID, "ID of the work item link to show")
 	})
-	a.Response(d.OK, func() {
-		a.Media(workItemLink)
-	})
+	a.UseTrait("conditional")
+	a.Response(d.OK, workItemLink)
+	a.Response(d.NotModified)
 	a.Response(d.BadRequest, JSONAPIErrors)
 	a.Response(d.InternalServerError, JSONAPIErrors)
 	a.Response(d.NotFound, JSONAPIErrors)

--- a/goasupport/conditional_request/generator.go
+++ b/goasupport/conditional_request/generator.go
@@ -80,6 +80,7 @@ func init() {
 	structPackages = map[string]string{
 		"WorkItem":         "workitemdsl",
 		"WorkItemType":     "workitemdsl",
+		"WorkItemLink":     "workitemlinkdsl",
 		"WorkItemLinkType": "workitemlinkdsl",
 		"Space":            "spacedsl",
 		"Iteration":        "iterationdsl",

--- a/main.go
+++ b/main.go
@@ -212,7 +212,7 @@ func main() {
 	app.MountWorkItemLinkTypeController(service, workItemLinkTypeCtrl)
 
 	// Mount "work item link" controller
-	workItemLinkCtrl := controller.NewWorkItemLinkController(service, appDB)
+	workItemLinkCtrl := controller.NewWorkItemLinkController(service, appDB, configuration)
 	app.MountWorkItemLinkController(service, workItemLinkCtrl)
 
 	// Mount "work item comments" controller
@@ -220,7 +220,7 @@ func main() {
 	app.MountWorkItemCommentsController(service, workItemCommentsCtrl)
 
 	// Mount "work item relationships links" controller
-	workItemRelationshipsLinksCtrl := controller.NewWorkItemRelationshipsLinksController(service, appDB)
+	workItemRelationshipsLinksCtrl := controller.NewWorkItemRelationshipsLinksController(service, appDB, configuration)
 	app.MountWorkItemRelationshipsLinksController(service, workItemRelationshipsLinksCtrl)
 
 	// Mount "comments" controller


### PR DESCRIPTION
Also added `created-at` and `updated-at` elements in the JSON responses.
Also removed the `wiConfiguration` package variable as it's a duplicate of
the `Configuration` variable inherited from the `gormtestsupport.DBTestSuite`

Fixes #1112

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
