### PR TITLE
WIP Disable hardcoded auto-linking during login. Relay on ?link param instead

### DIFF
--- a/login/service.go
+++ b/login/service.go
@@ -147,12 +147,7 @@ func (keycloak *KeycloakOAuthProvider) Perform(ctx *app.AuthorizeLoginContext, a
 			return ctx.TemporaryRedirect()
 		}
 
-		// TODO
-		// ---- Autolinking enabled regardless of the "link" param. Remove when UI adds support of account linking
-		link := true
-		// ----
-
-		if !link && (ctx.Link == nil || !*ctx.Link) {
+		if ctx.Link == nil || !*ctx.Link {
 			referrerStr = referrerStr + "&linked=false"
 			ctx.ResponseData.Header().Set("Location", referrerStr)
 			return ctx.TemporaryRedirect()


### PR DESCRIPTION
UI is now is now sending link=true on all requests to authorize. So we don't need to hardcode it anymore.
