### PR TITLE
Logout User

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -65,6 +65,7 @@ const (
 	varKeycloakEndpointEntitlement      = "keycloak.endpoint.entitlement"
 	varKeycloakEndpointBroker           = "keycloak.endpoint.broker"
 	varKeycloakEndpointAccount          = "keycloak.endpoint.account"
+	varKeycloakEndpointLogout           = "keycloak.endpoint.logout"
 	varTokenPublicKey                   = "token.publickey"
 	varTokenPrivateKey                  = "token.privatekey"
 	varCacheControlWorkItems            = "cachecontrol.workitems"
@@ -470,6 +471,15 @@ func (c *ConfigurationData) GetKeycloakEndpointBroker(req *goa.RequestData) (str
 // GetKeycloakAccountEndpoint returns the API URL for Read and Update on Keycloak User Accounts.
 func (c *ConfigurationData) GetKeycloakAccountEndpoint(req *goa.RequestData) (string, error) {
 	return c.getKeycloakEndpoint(req, varKeycloakEndpointAccount, "auth/realms/"+c.GetKeycloakRealm()+"/account")
+}
+
+// GetKeycloakEndpointLogout returns the keycloak logout endpoint set via config file or environment variable.
+// If nothing set then in Dev environment the defualt endopoint will be returned.
+// In producion the endpoint will be calculated from the request by replacing the last domain/host name in the full host name.
+// Example: api.service.domain.org -> sso.service.domain.org
+// or api.domain.org -> sso.domain.org
+func (c *ConfigurationData) GetKeycloakEndpointLogout(req *goa.RequestData) (string, error) {
+	return c.getKeycloakOpenIDConnectEndpoint(req, varKeycloakEndpointLogout, "logout")
 }
 
 // GetKeycloakDevModeURL returns Keycloak URL used by default in Dev mode

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -65,6 +65,10 @@ func TestGetKeycloakEndpointSetByUrlEnvVaribaleOK(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, "http://xyz.io/auth/realms/"+config.GetKeycloakRealm()+"/protocol/openid-connect/auth", url)
 
+	url, err = config.GetKeycloakEndpointLogout(reqLong)
+	require.Nil(t, err)
+	require.Equal(t, "http://xyz.io/auth/realms/"+config.GetKeycloakRealm()+"/protocol/openid-connect/logout", url)
+
 	url, err = config.GetKeycloakEndpointToken(reqLong)
 	require.Nil(t, err)
 	require.Equal(t, "http://xyz.io/auth/realms/"+config.GetKeycloakRealm()+"/protocol/openid-connect/token", url)
@@ -128,6 +132,17 @@ func TestGetKeycloakEndpointAuthDevModeOK(t *testing.T) {
 func TestGetKeycloakEndpointAuthSetByEnvVaribaleOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	checkGetKeycloakEndpointSetByEnvVaribaleOK(t, "ALMIGHTY_KEYCLOAK_ENDPOINT_AUTH", config.GetKeycloakEndpointAuth)
+}
+
+func TestGetKeycloakEndpointLogoutDevModeOK(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	t.Parallel()
+	checkGetKeycloakEndpointOK(t, config.GetKeycloakDevModeURL()+"/auth/realms/"+config.GetKeycloakRealm()+"/protocol/openid-connect/logout", config.GetKeycloakEndpointLogout)
+}
+
+func TestGetKeycloakEndpointLogoutSetByEnvVaribaleOK(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	checkGetKeycloakEndpointSetByEnvVaribaleOK(t, "ALMIGHTY_KEYCLOAK_ENDPOINT_LOGOUT", config.GetKeycloakEndpointLogout)
 }
 
 func TestGetKeycloakEndpointTokenOK(t *testing.T) {

--- a/controller/logout.go
+++ b/controller/logout.go
@@ -1,0 +1,43 @@
+package controller
+
+import (
+	"github.com/almighty/almighty-core/app"
+	"github.com/almighty/almighty-core/errors"
+	"github.com/almighty/almighty-core/jsonapi"
+	"github.com/almighty/almighty-core/log"
+	"github.com/almighty/almighty-core/login"
+	"github.com/goadesign/goa"
+)
+
+type logoutConfiguration interface {
+	GetKeycloakEndpointLogout(*goa.RequestData) (string, error)
+	GetValidRedirectURLs(*goa.RequestData) (string, error)
+}
+
+// LogoutController implements the logout resource.
+type LogoutController struct {
+	*goa.Controller
+	logoutService login.LogoutService
+	configuration logoutConfiguration
+}
+
+// NewLogoutController creates a logout controller.
+func NewLogoutController(service *goa.Service, logoutService *login.KeycloakLogoutService, configuration logoutConfiguration) *LogoutController {
+	return &LogoutController{Controller: service.NewController("LogoutController"), logoutService: logoutService, configuration: configuration}
+}
+
+// Logout runs the logout action.
+func (c *LogoutController) Logout(ctx *app.LogoutLogoutContext) error {
+	logoutEndpoint, err := c.configuration.GetKeycloakEndpointLogout(ctx.RequestData)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"err": err,
+		}, "Unable to get Keycloak logout endpoint URL")
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("unable to get Keycloak logout endpoint URL. "+err.Error()))
+	}
+	whitelist, err := c.configuration.GetValidRedirectURLs(ctx.RequestData)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(err.Error()))
+	}
+	return c.logoutService.Logout(ctx, logoutEndpoint, whitelist)
+}

--- a/controller/logout_test.go
+++ b/controller/logout_test.go
@@ -1,0 +1,59 @@
+package controller
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/almighty/almighty-core/app/test"
+	config "github.com/almighty/almighty-core/configuration"
+	"github.com/almighty/almighty-core/login"
+	"github.com/almighty/almighty-core/resource"
+	testsupport "github.com/almighty/almighty-core/test"
+	almtoken "github.com/almighty/almighty-core/token"
+	"github.com/goadesign/goa"
+	"github.com/stretchr/testify/suite"
+)
+
+type TestLogoutREST struct {
+	suite.Suite
+	configuration *config.ConfigurationData
+}
+
+func TestRunLogoutREST(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	configuration, err := config.GetConfigurationData()
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+	suite.Run(t, &TestLogoutREST{configuration: configuration})
+}
+
+func (rest *TestLogoutREST) SetupTest() {
+}
+
+func (rest *TestLogoutREST) TearDownTest() {
+}
+
+func (rest *TestLogoutREST) UnSecuredController() (*goa.Service, *LogoutController) {
+	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
+
+	svc := testsupport.ServiceAsUser("Logout-Service", almtoken.NewManagerWithPrivateKey(priv), testsupport.TestIdentity)
+	return svc, &LogoutController{Controller: svc.NewController("logout"), logoutService: &login.KeycloakLogoutService{}, configuration: rest.configuration}
+}
+
+func (rest *TestLogoutREST) TestLogoutRedirects() {
+	t := rest.T()
+	resource.Require(t, resource.UnitTest)
+	svc, ctrl := rest.UnSecuredController()
+
+	redirect := "http://domain.com"
+	test.LogoutLogoutTemporaryRedirect(t, svc.Context, svc, ctrl, &redirect)
+}
+
+func (rest *TestLogoutREST) TestLogoutWithoutReffererAndRedirectParamsBadRequest() {
+	t := rest.T()
+	resource.Require(t, resource.UnitTest)
+	svc, ctrl := rest.UnSecuredController()
+
+	test.LogoutLogoutBadRequest(t, svc.Context, svc, ctrl, nil)
+}

--- a/controller/logout_test.go
+++ b/controller/logout_test.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/almighty/almighty-core/app/test"
@@ -23,7 +22,7 @@ func TestRunLogoutREST(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	configuration, err := config.GetConfigurationData()
 	if err != nil {
-		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+		t.Fatalf("Failed to setup the configuration: %s", err.Error())
 	}
 	suite.Run(t, &TestLogoutREST{configuration: configuration})
 }

--- a/design/auth.go
+++ b/design/auth.go
@@ -102,6 +102,24 @@ var _ = a.Resource("login", func() {
 	})
 })
 
+var _ = a.Resource("logout", func() {
+
+	a.BasePath("/logout")
+
+	a.Action("logout", func() {
+		a.Routing(
+			a.GET(""),
+		)
+		a.Params(func() {
+			a.Param("redirect", d.String, "URL to be redirected to after successful logout. If not set then will redirect to the referrer instead.")
+		})
+		a.Description("Logout user")
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.TemporaryRedirect)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+	})
+})
+
 var refreshToken = a.Type("RefreshToken", func() {
 	a.Attribute("refresh_token", d.String, "Refresh token")
 })

--- a/login/logout.go
+++ b/login/logout.go
@@ -1,0 +1,79 @@
+package login
+
+import (
+	"net/url"
+	"regexp"
+
+	"github.com/almighty/almighty-core/app"
+	"github.com/almighty/almighty-core/jsonapi"
+	"github.com/almighty/almighty-core/log"
+	"github.com/goadesign/goa"
+)
+
+// KeycloakLogoutService represents a keyclaok logout service
+type KeycloakLogoutService struct {
+}
+
+// LogoutService represents logout service interface
+type LogoutService interface {
+	Logout(ctx *app.LogoutLogoutContext, logoutEndpoint string, validRedirectURL string) error
+}
+
+// Logout logs out user
+func (s *KeycloakLogoutService) Logout(ctx *app.LogoutLogoutContext, logoutEndpoint string, validRedirectURL string) error {
+	redirect := ctx.Redirect
+	referrer := ctx.RequestData.Header.Get("Referer")
+	if redirect == nil {
+		if referrer == "" {
+			log.Error(ctx, map[string]interface{}{}, "Failed to logout. Referer Header and redirect param are both empty.")
+			return jsonapi.JSONErrorResponse(ctx, goa.ErrBadRequest("Referer Header and redirect param are both empty. At least one should be specified."))
+		}
+		redirect = &referrer
+	}
+	// store referrer in a state reference to redirect later
+	log.Info(ctx, map[string]interface{}{
+		"referrer": referrer,
+		"redirect": redirect,
+	}, "Got Request to logout!")
+
+	redirectURL, err := url.Parse(*redirect)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"redirect-url": redirectURL,
+			"err":          err,
+		}, "Failed to logout. Unable to parse redirect url.")
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrBadRequest(err.Error()))
+	}
+
+	redirectURLStr := redirectURL.String()
+	matched, err := regexp.MatchString(validRedirectURL, redirectURLStr)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"redirect-url":       redirectURLStr,
+			"valid-redirect-url": validRedirectURL,
+			"err":                err,
+		}, "Can't match redirect URL and whitelist regex")
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
+	}
+	if !matched {
+		log.Error(ctx, map[string]interface{}{
+			"redirect-url":       redirectURLStr,
+			"valid-redirect-url": validRedirectURL,
+		}, "Redirect URL is not valid")
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrBadRequest("not valid redirect URL"))
+	}
+	logoutURL, err := url.Parse(logoutEndpoint)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"logout-endpoint": logoutEndpoint,
+			"err":             err,
+		}, "Failed to logout. Unable to parse logout url.")
+		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
+	}
+	parameters := logoutURL.Query()
+	parameters.Add("redirect_uri", redirectURLStr)
+	logoutURL.RawQuery = parameters.Encode()
+
+	ctx.ResponseData.Header().Set("Location", logoutURL.String())
+	return ctx.TemporaryRedirect()
+}

--- a/login/logout.go
+++ b/login/logout.go
@@ -25,8 +25,8 @@ func (s *KeycloakLogoutService) Logout(ctx *app.LogoutLogoutContext, logoutEndpo
 	referrer := ctx.RequestData.Header.Get("Referer")
 	if redirect == nil {
 		if referrer == "" {
-			log.Error(ctx, map[string]interface{}{}, "Failed to logout. Referer Header and redirect param are both empty.")
-			return jsonapi.JSONErrorResponse(ctx, goa.ErrBadRequest("Referer Header and redirect param are both empty. At least one should be specified."))
+			log.Error(ctx, nil, "Failed to logout. Referer Header and redirect param are both empty.")
+			return jsonapi.JSONErrorResponse(ctx, goa.ErrBadRequest("referer Header and redirect param are both empty (at least one should be specified)"))
 		}
 		redirect = &referrer
 	}

--- a/login/logout.go
+++ b/login/logout.go
@@ -30,7 +30,6 @@ func (s *KeycloakLogoutService) Logout(ctx *app.LogoutLogoutContext, logoutEndpo
 		}
 		redirect = &referrer
 	}
-	// store referrer in a state reference to redirect later
 	log.Info(ctx, map[string]interface{}{
 		"referrer": referrer,
 		"redirect": redirect,

--- a/login/logout_blackbox_test.go
+++ b/login/logout_blackbox_test.go
@@ -1,0 +1,82 @@
+package login_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/almighty/almighty-core/app"
+	config "github.com/almighty/almighty-core/configuration"
+	"github.com/almighty/almighty-core/login"
+	"github.com/almighty/almighty-core/resource"
+	"github.com/goadesign/goa"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	_ "github.com/lib/pq"
+)
+
+func TestLogout(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	configuration, err := config.GetConfigurationData()
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+	suite.Run(t, &TestLogoutSuite{configuration: configuration, logoutService: &login.KeycloakLogoutService{}})
+}
+
+type TestLogoutSuite struct {
+	suite.Suite
+	configuration *config.ConfigurationData
+	logoutService *login.KeycloakLogoutService
+}
+
+func (s *TestLogoutSuite) SetupSuite() {
+}
+
+func (s *TestLogoutSuite) TearDownSuite() {
+}
+
+func (s *TestLogoutSuite) TestLogoutRedirectsToKeycloakWithRedirectParam() {
+	s.checkRedirects("", "https://url.example.org/path", "https%3A%2F%2Furl.example.org%2Fpath")
+}
+
+func (s *TestLogoutSuite) TestLogoutRedirectsToKeycloakWithReferrer() {
+	s.checkRedirects("http://openshift.io/home", "https://url.example.org/path", "http%3A%2F%2Fopenshift.io%2Fhome")
+}
+
+func (s *TestLogoutSuite) checkRedirects(redirectParam string, referrerURL string, expectedRedirectParam string) {
+	rw := httptest.NewRecorder()
+	u := &url.URL{
+		Path: "/api/logout",
+	}
+	req, err := http.NewRequest("GET", u.String(), nil)
+	require.Nil(s.T(), err)
+	req.Header.Add("referer", referrerURL)
+
+	prms := url.Values{}
+	if redirectParam != "" {
+		prms.Add("redirect", redirectParam)
+	}
+	ctx := context.Background()
+	goaCtx := goa.NewContext(goa.WithAction(ctx, "LogoutTest"), rw, req, prms)
+	logoutCtx, err := app.NewLogoutLogoutContext(goaCtx, req, goa.New("LogoutService"))
+	require.Nil(s.T(), err)
+
+	r := &goa.RequestData{
+		Request: &http.Request{Host: "api.domain.io"},
+	}
+	logoutEndpoint, err := s.configuration.GetKeycloakEndpointLogout(r)
+	require.Nil(s.T(), err)
+	validURLs, err := s.configuration.GetValidRedirectURLs(r)
+	require.Nil(s.T(), err)
+
+	err = s.logoutService.Logout(logoutCtx, logoutEndpoint, validURLs)
+
+	assert.Equal(s.T(), 307, rw.Code)
+	assert.Equal(s.T(), fmt.Sprintf("%s?redirect_uri=%s", logoutEndpoint, expectedRedirectParam), rw.Header().Get("Location"))
+}

--- a/main.go
+++ b/main.go
@@ -191,6 +191,9 @@ func main() {
 	loginCtrl := controller.NewLoginController(service, loginService, tokenManager, configuration)
 	app.MountLoginController(service, loginCtrl)
 
+	logoutCtrl := controller.NewLogoutController(service, &login.KeycloakLogoutService{}, configuration)
+	app.MountLogoutController(service, logoutCtrl)
+
 	// Mount "status" controller
 	statusCtrl := controller.NewStatusController(service, db)
 	app.MountStatusController(service, statusCtrl)


### PR DESCRIPTION
There is now a new endpoint which redirects to Keycloak to log out user:

**GET /api/logout**
Optional param: redirect=<encodedRedirectURL>, if not set then referrer will be used to redirect to after logout.

Fixes https://github.com/almighty/almighty-core/issues/987