### PR TITLE
Modify migrations for root iterations.

### DIFF
--- a/migration/sql-files/048-unique-iteration-name-create-new-iteration.sql
+++ b/migration/sql-files/048-unique-iteration-name-create-new-iteration.sql
@@ -1,5 +1,14 @@
 -- Update iterations having same name, append UUID to make it unique.
-update iterations set name = name || '-' || uuid_generate_v4()  where id IN( select id from iterations where name in (select name from iterations group by name having count(name) >1 ));
+UPDATE iterations
+SET name = name || '-' || uuid_generate_v4()
+WHERE id IN
+    (SELECT id
+     FROM iterations
+     WHERE name IN
+         (SELECT name
+          FROM iterations
+          GROUP BY name
+          HAVING count(name) >1));
 
 ------  For existing spaces in production, which dont have a root iteration, create one.
 --

--- a/migration/sql-files/048-unique-iteration-name-create-new-iteration.sql
+++ b/migration/sql-files/048-unique-iteration-name-create-new-iteration.sql
@@ -48,6 +48,7 @@ CREATE OR REPLACE FUNCTION GetUpdatedIterationPath(iteration_id uuid,space_id uu
      DECLARE
           rootiteration uuid;
      BEGIN
+     -- In production this probably not NULL; safety check.
      If path IS NULL
         THEN
             path = '';


### PR DESCRIPTION
Fixes #1135 

Verified with following case:-
1. Iterations having same name (append UUID to the name to make them unique)
2. Borrowed data dump from hector's commit #1134 

Modifications made in the PR are working fine for above two cases.

@aslakknutsen @alexeykazakov @hectorj2f 
I want to test this thing against Production-DB, is there any way I can get data dump for production ? 