### PR TITLE
include "hasChildren" field in a work item's "children" relationship

### DIFF
--- a/controller/work_item_children_blackbox_test.go
+++ b/controller/work_item_children_blackbox_test.go
@@ -182,6 +182,7 @@ func (s *workItemChildSuite) SetupTest() {
 	createPayload := CreateWorkItemLink(s.bug1ID, bug2ID, bugBlockerLinkTypeID)
 	_, workItemLink := test.CreateWorkItemLinkCreated(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, createPayload)
 	require.NotNil(s.T(), workItemLink)
+	// Check that the bug1 now hasChildren
 	_, workItemAfterLinked := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), *bug1.Data.ID, nil, nil)
 	checkChildrenRelationship(s.T(), workItemAfterLinked.Data, &hasChildren)
 

--- a/controller/work_item_children_blackbox_test.go
+++ b/controller/work_item_children_blackbox_test.go
@@ -263,7 +263,9 @@ func TestSuiteWorkItemChildren(t *testing.T) {
 	suite.Run(t, &workItemChildSuite{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
 }
 
-func (s *workItemChildSuite) TestWorkItemChildrenRelationship() {
+func (s *workItemChildSuite) TestChildren() {
+	// given
+	workItemID1 := strconv.FormatUint(s.bug1ID, 10)
 	hasChildren := true
 	hasNoChildren := false
 
@@ -275,13 +277,7 @@ func (s *workItemChildSuite) TestWorkItemChildrenRelationship() {
 		_, workItem := test.ShowWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), *s.bug3.Data.ID, nil, nil)
 		checkChildrenRelationship(t, workItem.Data, &hasNoChildren)
 	})
-}
-
-func (s *workItemChildSuite) TestListChildren() {
-	// given
-	workItemID1 := strconv.FormatUint(s.bug1ID, 10)
-
-	s.T().Run("ok", func(t *testing.T) {
+	s.T().Run("list ok", func(t *testing.T) {
 		// when
 		res, workItemList := test.ListChildrenWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, nil)
 		// then

--- a/controller/work_item_children_blackbox_test.go
+++ b/controller/work_item_children_blackbox_test.go
@@ -272,55 +272,46 @@ func (s *workItemChildSuite) TestWorkItemChildrenRelationship() {
 	})
 }
 
-func (s *workItemChildSuite) TestListChildrenOK() {
+func (s *workItemChildSuite) TestListChildren() {
 	// given
 	workItemID1 := strconv.FormatUint(s.bug1ID, 10)
-	// when
-	res, workItemList := test.ListChildrenWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, nil)
-	// then
-	assertWorkItemList(s.T(), workItemList)
-	assertResponseHeaders(s.T(), res)
-}
 
-func (s *workItemChildSuite) TestListChildrenOKUsingExpiredIfModifiedSinceHeader() {
-	// given
-	workItemID1 := strconv.FormatUint(s.bug1ID, 10)
-	// when
-	ifModifiedSince := app.ToHTTPTime(s.bug1.Data.Attributes[workitem.SystemUpdatedAt].(time.Time).Add(-1 * time.Hour))
-	res, workItemList := test.ListChildrenWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, &ifModifiedSince, nil)
-	// then
-	assertWorkItemList(s.T(), workItemList)
-	assertResponseHeaders(s.T(), res)
-}
-
-func (s *workItemChildSuite) TestListChildrenOKUsingExpiredIfNoneMatchHeader() {
-	// given
-	workItemID1 := strconv.FormatUint(s.bug1ID, 10)
-	// when
-	ifNoneMatch := "foo"
-	res, workItemList := test.ListChildrenWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, &ifNoneMatch)
-	// then
-	assertWorkItemList(s.T(), workItemList)
-	assertResponseHeaders(s.T(), res)
-}
-
-func (s *workItemChildSuite) TestListChildrenNotModifiedUsingIfModifiedSinceHeader() {
-	// given
-	workItemID1 := strconv.FormatUint(s.bug1ID, 10)
-	// when
-	ifModifiedSince := app.ToHTTPTime(s.bug3.Data.Attributes[workitem.SystemUpdatedAt].(time.Time))
-	res := test.ListChildrenWorkitemNotModified(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, &ifModifiedSince, nil)
-	// then
-	assertResponseHeaders(s.T(), res)
-}
-
-func (s *workItemChildSuite) TestListChildrenNotModifiedUsingIfNoneMatchHeader() {
-	// given
-	workItemID1 := strconv.FormatUint(s.bug1ID, 10)
-	_, workItemList := test.ListChildrenWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, nil)
-	// when
-	ifNoneMatch := generateWorkitemsTag(workItemList)
-	res := test.ListChildrenWorkitemNotModified(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, &ifNoneMatch)
-	// then
-	assertResponseHeaders(s.T(), res)
+	s.T().Run("ok", func(t *testing.T) {
+		// when
+		res, workItemList := test.ListChildrenWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, nil)
+		// then
+		assertWorkItemList(t, workItemList)
+		assertResponseHeaders(t, res)
+	})
+	s.T().Run("using expired if modified since header", func(t *testing.T) {
+		// when
+		ifModifiedSince := app.ToHTTPTime(s.bug1.Data.Attributes[workitem.SystemUpdatedAt].(time.Time).Add(-1 * time.Hour))
+		res, workItemList := test.ListChildrenWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, &ifModifiedSince, nil)
+		// then
+		assertWorkItemList(t, workItemList)
+		assertResponseHeaders(t, res)
+	})
+	s.T().Run("using expired if none match header", func(t *testing.T) {
+		// when
+		ifNoneMatch := "foo"
+		res, workItemList := test.ListChildrenWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, &ifNoneMatch)
+		// then
+		assertWorkItemList(t, workItemList)
+		assertResponseHeaders(t, res)
+	})
+	s.T().Run("not modified using if modified since header", func(t *testing.T) {
+		// when
+		ifModifiedSince := app.ToHTTPTime(s.bug3.Data.Attributes[workitem.SystemUpdatedAt].(time.Time))
+		res := test.ListChildrenWorkitemNotModified(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, &ifModifiedSince, nil)
+		// then
+		assertResponseHeaders(t, res)
+	})
+	s.T().Run("not modified using if none match header", func(t *testing.T) {
+		_, workItemList := test.ListChildrenWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, nil)
+		// when
+		ifNoneMatch := generateWorkitemsTag(workItemList)
+		res := test.ListChildrenWorkitemNotModified(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, &ifNoneMatch)
+		// then
+		assertResponseHeaders(t, res)
+	})
 }

--- a/controller/work_item_children_blackbox_test.go
+++ b/controller/work_item_children_blackbox_test.go
@@ -220,6 +220,10 @@ func assertWorkItemList(t *testing.T, workItemList *app.WorkItemList) {
 	assert.Equal(t, 2, len(workItemList.Data))
 	count := 0
 	for _, v := range workItemList.Data {
+		require.NotNil(t, v.Relationships.Children.Links, "no 'links' found in 'children' relationship")
+		require.NotNil(t, v.Relationships.Children.Meta, "no 'meta' found in 'children' relationship")
+		_, hasChildrenFound := v.Relationships.Children.Meta["hasChildren"]
+		require.True(t, hasChildrenFound, "no 'hasChildren' found in 'meta' object of 'children' relationship")
 		switch v.Attributes[workitem.SystemTitle] {
 		case "bug2":
 			count = count + 1

--- a/controller/work_item_children_blackbox_test.go
+++ b/controller/work_item_children_blackbox_test.go
@@ -118,7 +118,7 @@ func (s *workItemChildSuite) SetupSuite() {
 func (s *workItemChildSuite) SetupTest() {
 	s.clean = cleaner.DeleteCreatedEntities(s.DB)
 	var err error
-	//hasChildren := true
+	hasChildren := true
 	hasNoChildren := false
 
 	// Create a test user identity
@@ -182,6 +182,8 @@ func (s *workItemChildSuite) SetupTest() {
 	createPayload := CreateWorkItemLink(s.bug1ID, bug2ID, bugBlockerLinkTypeID)
 	_, workItemLink := test.CreateWorkItemLinkCreated(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, createPayload)
 	require.NotNil(s.T(), workItemLink)
+	_, workItemAfterLinked := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), *bug1.Data.ID, nil, nil)
+	checkChildrenRelationship(s.T(), workItemAfterLinked.Data, &hasChildren)
 
 	createPayload2 := CreateWorkItemLink(s.bug1ID, bug3ID, bugBlockerLinkTypeID)
 	_, workItemLink2 := test.CreateWorkItemLinkCreated(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, createPayload2)
@@ -224,13 +226,13 @@ func createParentChildWorkItemLinkType(name string, sourceTypeID, targetTypeID, 
 // checkChildrenRelationship runs a variety of checks on a given work item
 // regarding the children relationships
 func checkChildrenRelationship(t *testing.T, wi *app.WorkItem, expectedHasChildren *bool) {
-	require.NotNil(t, wi.Relationships.Children, "no 'children' relationship found")
-	require.NotNil(t, wi.Relationships.Children.Links, "no 'links' found in 'children' relationship")
-	require.NotNil(t, wi.Relationships.Children.Meta, "no 'meta' found in 'children' relationship")
+	require.NotNil(t, wi.Relationships.Children, "no 'children' relationship found in work item %s", *wi.ID)
+	require.NotNil(t, wi.Relationships.Children.Links, "no 'links' found in 'children' relationship in work item %s", *wi.ID)
+	require.NotNil(t, wi.Relationships.Children.Meta, "no 'meta' found in 'children' relationship in work item %s", *wi.ID)
 	hasChildren, hasChildrenFound := wi.Relationships.Children.Meta["hasChildren"]
-	require.True(t, hasChildrenFound, "no 'hasChildren' found in 'meta' object of 'children' relationship")
+	require.True(t, hasChildrenFound, "no 'hasChildren' found in 'meta' object of 'children' relationship in work item %s", *wi.ID)
 	if expectedHasChildren != nil {
-		require.Equal(t, *expectedHasChildren, hasChildren)
+		require.Equal(t, *expectedHasChildren, hasChildren, "work item %s is supposed to have children? %v", *wi.ID, *expectedHasChildren)
 	}
 }
 

--- a/controller/work_item_children_blackbox_test.go
+++ b/controller/work_item_children_blackbox_test.go
@@ -241,55 +241,46 @@ func TestSuiteWorkItemChildren(t *testing.T) {
 	suite.Run(t, &workItemChildSuite{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
 }
 
-func (s *workItemChildSuite) TestListChildrenOK() {
+func (s *workItemChildSuite) TestListChildren() {
 	// given
 	workItemID1 := strconv.FormatUint(s.bug1ID, 10)
-	// when
-	res, workItemList := test.ListChildrenWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, nil)
-	// then
-	assertWorkItemList(s.T(), workItemList)
-	assertResponseHeaders(s.T(), res)
-}
 
-func (s *workItemChildSuite) TestListChildrenOKUsingExpiredIfModifiedSinceHeader() {
-	// given
-	workItemID1 := strconv.FormatUint(s.bug1ID, 10)
-	// when
-	ifModifiedSince := app.ToHTTPTime(s.bug1.Data.Attributes[workitem.SystemUpdatedAt].(time.Time).Add(-1 * time.Hour))
-	res, workItemList := test.ListChildrenWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, &ifModifiedSince, nil)
-	// then
-	assertWorkItemList(s.T(), workItemList)
-	assertResponseHeaders(s.T(), res)
-}
-
-func (s *workItemChildSuite) TestListChildrenOKUsingExpiredIfNoneMatchHeader() {
-	// given
-	workItemID1 := strconv.FormatUint(s.bug1ID, 10)
-	// when
-	ifNoneMatch := "foo"
-	res, workItemList := test.ListChildrenWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, &ifNoneMatch)
-	// then
-	assertWorkItemList(s.T(), workItemList)
-	assertResponseHeaders(s.T(), res)
-}
-
-func (s *workItemChildSuite) TestListChildrenNotModifiedUsingIfModifiedSinceHeader() {
-	// given
-	workItemID1 := strconv.FormatUint(s.bug1ID, 10)
-	// when
-	ifModifiedSince := app.ToHTTPTime(s.bug3.Data.Attributes[workitem.SystemUpdatedAt].(time.Time))
-	res := test.ListChildrenWorkitemNotModified(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, &ifModifiedSince, nil)
-	// then
-	assertResponseHeaders(s.T(), res)
-}
-
-func (s *workItemChildSuite) TestListChildrenNotModifiedUsingIfNoneMatchHeader() {
-	// given
-	workItemID1 := strconv.FormatUint(s.bug1ID, 10)
-	_, workItemList := test.ListChildrenWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, nil)
-	// when
-	ifNoneMatch := generateWorkitemsTag(workItemList)
-	res := test.ListChildrenWorkitemNotModified(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, &ifNoneMatch)
-	// then
-	assertResponseHeaders(s.T(), res)
+	s.T().Run("ok", func(t *testing.T) {
+		// when
+		res, workItemList := test.ListChildrenWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, nil)
+		// then
+		assertWorkItemList(t, workItemList)
+		assertResponseHeaders(t, res)
+	})
+	s.T().Run("using expired if modified since header", func(t *testing.T) {
+		// when
+		ifModifiedSince := app.ToHTTPTime(s.bug1.Data.Attributes[workitem.SystemUpdatedAt].(time.Time).Add(-1 * time.Hour))
+		res, workItemList := test.ListChildrenWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, &ifModifiedSince, nil)
+		// then
+		assertWorkItemList(t, workItemList)
+		assertResponseHeaders(t, res)
+	})
+	s.T().Run("using expired if none match header", func(t *testing.T) {
+		// when
+		ifNoneMatch := "foo"
+		res, workItemList := test.ListChildrenWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, &ifNoneMatch)
+		// then
+		assertWorkItemList(t, workItemList)
+		assertResponseHeaders(t, res)
+	})
+	s.T().Run("not modified using if modified since header", func(t *testing.T) {
+		// when
+		ifModifiedSince := app.ToHTTPTime(s.bug3.Data.Attributes[workitem.SystemUpdatedAt].(time.Time))
+		res := test.ListChildrenWorkitemNotModified(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, &ifModifiedSince, nil)
+		// then
+		assertResponseHeaders(t, res)
+	})
+	s.T().Run("not modified using if none match header", func(t *testing.T) {
+		_, workItemList := test.ListChildrenWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, nil)
+		// when
+		ifNoneMatch := generateWorkitemsTag(workItemList)
+		res := test.ListChildrenWorkitemNotModified(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, &ifNoneMatch)
+		// then
+		assertResponseHeaders(t, res)
+	})
 }

--- a/controller/work_item_children_blackbox_test.go
+++ b/controller/work_item_children_blackbox_test.go
@@ -241,46 +241,55 @@ func TestSuiteWorkItemChildren(t *testing.T) {
 	suite.Run(t, &workItemChildSuite{DBTestSuite: gormtestsupport.NewDBTestSuite("../config.yaml")})
 }
 
-func (s *workItemChildSuite) TestListChildren() {
+func (s *workItemChildSuite) TestListChildrenOK() {
 	// given
 	workItemID1 := strconv.FormatUint(s.bug1ID, 10)
+	// when
+	res, workItemList := test.ListChildrenWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, nil)
+	// then
+	assertWorkItemList(s.T(), workItemList)
+	assertResponseHeaders(s.T(), res)
+}
 
-	s.T().Run("ok", func(t *testing.T) {
-		// when
-		res, workItemList := test.ListChildrenWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, nil)
-		// then
-		assertWorkItemList(t, workItemList)
-		assertResponseHeaders(t, res)
-	})
-	s.T().Run("using expired if modified since header", func(t *testing.T) {
-		// when
-		ifModifiedSince := app.ToHTTPTime(s.bug1.Data.Attributes[workitem.SystemUpdatedAt].(time.Time).Add(-1 * time.Hour))
-		res, workItemList := test.ListChildrenWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, &ifModifiedSince, nil)
-		// then
-		assertWorkItemList(t, workItemList)
-		assertResponseHeaders(t, res)
-	})
-	s.T().Run("using expired if none match header", func(t *testing.T) {
-		// when
-		ifNoneMatch := "foo"
-		res, workItemList := test.ListChildrenWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, &ifNoneMatch)
-		// then
-		assertWorkItemList(t, workItemList)
-		assertResponseHeaders(t, res)
-	})
-	s.T().Run("not modified using if modified since header", func(t *testing.T) {
-		// when
-		ifModifiedSince := app.ToHTTPTime(s.bug3.Data.Attributes[workitem.SystemUpdatedAt].(time.Time))
-		res := test.ListChildrenWorkitemNotModified(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, &ifModifiedSince, nil)
-		// then
-		assertResponseHeaders(t, res)
-	})
-	s.T().Run("not modified using if none match header", func(t *testing.T) {
-		_, workItemList := test.ListChildrenWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, nil)
-		// when
-		ifNoneMatch := generateWorkitemsTag(workItemList)
-		res := test.ListChildrenWorkitemNotModified(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, &ifNoneMatch)
-		// then
-		assertResponseHeaders(t, res)
-	})
+func (s *workItemChildSuite) TestListChildrenOKUsingExpiredIfModifiedSinceHeader() {
+	// given
+	workItemID1 := strconv.FormatUint(s.bug1ID, 10)
+	// when
+	ifModifiedSince := app.ToHTTPTime(s.bug1.Data.Attributes[workitem.SystemUpdatedAt].(time.Time).Add(-1 * time.Hour))
+	res, workItemList := test.ListChildrenWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, &ifModifiedSince, nil)
+	// then
+	assertWorkItemList(s.T(), workItemList)
+	assertResponseHeaders(s.T(), res)
+}
+
+func (s *workItemChildSuite) TestListChildrenOKUsingExpiredIfNoneMatchHeader() {
+	// given
+	workItemID1 := strconv.FormatUint(s.bug1ID, 10)
+	// when
+	ifNoneMatch := "foo"
+	res, workItemList := test.ListChildrenWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, &ifNoneMatch)
+	// then
+	assertWorkItemList(s.T(), workItemList)
+	assertResponseHeaders(s.T(), res)
+}
+
+func (s *workItemChildSuite) TestListChildrenNotModifiedUsingIfModifiedSinceHeader() {
+	// given
+	workItemID1 := strconv.FormatUint(s.bug1ID, 10)
+	// when
+	ifModifiedSince := app.ToHTTPTime(s.bug3.Data.Attributes[workitem.SystemUpdatedAt].(time.Time))
+	res := test.ListChildrenWorkitemNotModified(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, &ifModifiedSince, nil)
+	// then
+	assertResponseHeaders(s.T(), res)
+}
+
+func (s *workItemChildSuite) TestListChildrenNotModifiedUsingIfNoneMatchHeader() {
+	// given
+	workItemID1 := strconv.FormatUint(s.bug1ID, 10)
+	_, workItemList := test.ListChildrenWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, nil)
+	// when
+	ifNoneMatch := generateWorkitemsTag(workItemList)
+	res := test.ListChildrenWorkitemNotModified(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, &ifNoneMatch)
+	// then
+	assertResponseHeaders(s.T(), res)
 }

--- a/controller/work_item_children_blackbox_test.go
+++ b/controller/work_item_children_blackbox_test.go
@@ -264,14 +264,16 @@ func TestSuiteWorkItemChildren(t *testing.T) {
 }
 
 func (s *workItemChildSuite) TestWorkItemChildrenRelationship() {
-	// given
-	workItemID1 := strconv.FormatUint(s.bug1ID, 10)
 	hasChildren := true
-	//hasNoChildren := false
+	hasNoChildren := false
 
-	s.T().Run("show action", func(t *testing.T) {
-		_, workItem := test.ShowWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, nil)
+	s.T().Run("show action has children", func(t *testing.T) {
+		_, workItem := test.ShowWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), *s.bug1.Data.ID, nil, nil)
 		checkChildrenRelationship(t, workItem.Data, &hasChildren)
+	})
+	s.T().Run("show action has no children", func(t *testing.T) {
+		_, workItem := test.ShowWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), *s.bug3.Data.ID, nil, nil)
+		checkChildrenRelationship(t, workItem.Data, &hasNoChildren)
 	})
 }
 

--- a/controller/work_item_comments.go
+++ b/controller/work_item_comments.go
@@ -119,8 +119,8 @@ func (c *WorkItemCommentsController) Relations(ctx *app.RelationsWorkItemComment
 	})
 }
 
-// WorkItemIncludeCommentsAndTotal adds relationship about comments to workitem (include totalCount)
-func WorkItemIncludeCommentsAndTotal(ctx context.Context, db application.DB, parentID string) WorkItemConvertFunc {
+// workItemIncludeCommentsAndTotal adds relationship about comments to workitem (include totalCount)
+func workItemIncludeCommentsAndTotal(ctx context.Context, db application.DB, parentID string) WorkItemConvertFunc {
 	// TODO: Wrap ctx in a Timeout context?
 	count := make(chan int)
 	go func() {
@@ -143,8 +143,8 @@ func WorkItemIncludeCommentsAndTotal(ctx context.Context, db application.DB, par
 	}
 }
 
-// WorkItemIncludeComments adds relationship about comments to workitem (include totalCount)
-func WorkItemIncludeComments(request *goa.RequestData, wi *workitem.WorkItem, wi2 *app.WorkItem) {
+// workItemIncludeComments adds relationship about comments to workitem (include totalCount)
+func workItemIncludeComments(request *goa.RequestData, wi *workitem.WorkItem, wi2 *app.WorkItem) {
 	wi2.Relationships.Comments = CreateCommentsRelation(request, wi)
 }
 

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -621,6 +621,8 @@ func workItemIncludeHasChildren(appl application.Application, ctx context.Contex
 				"wi_id": wi.ID,
 				"err":   err,
 			}, "unable to find out if work item has children: %s", wi.ID)
+			// enforce to have no children
+			hasChildren = false
 		}
 		if wi2.Relationships.Children == nil {
 			wi2.Relationships.Children = &app.RelationGeneric{}

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -116,7 +116,7 @@ func (c *WorkitemController) List(ctx *app.ListWorkitemContext) error {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "Error listing work items"))
 		}
 		return ctx.ConditionalEntities(workitems, c.config.GetCacheControlWorkItems, func() error {
-			hasChildren := WorkItemIncludeHasChildren(appl, ctx)
+			hasChildren := WorkItemIncludeHasChildren(tx, ctx)
 			response := app.WorkItemList{
 				Links: &app.PagingLinks{},
 				Meta:  &app.WorkItemListResponseMeta{TotalCount: count},

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -109,8 +109,8 @@ func (c *WorkitemController) List(ctx *app.ListWorkitemContext) error {
 	}
 
 	offset, limit := computePagingLimts(ctx.PageOffset, ctx.PageLimit)
-	return application.Transactional(c.db, func(appl application.Application) error {
-		workitems, tc, err := appl.WorkItems().List(ctx.Context, spaceID, exp, &offset, &limit)
+	return application.Transactional(c.db, func(tx application.Application) error {
+		workitems, tc, err := tx.WorkItems().List(ctx.Context, spaceID, exp, &offset, &limit)
 		count := int(tc)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "Error listing work items"))

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -615,14 +615,19 @@ func ConvertWorkItem(request *goa.RequestData, wi workitem.WorkItem, additional 
 func workItemIncludeHasChildren(appl application.Application, ctx context.Context) WorkItemConvertFunc {
 	// TODO: Wrap ctx in a Timeout context?
 	return func(request *goa.RequestData, wi *workitem.WorkItem, wi2 *app.WorkItem) {
-		hasChildren, err := appl.WorkItemLinks().WorkItemHasChildren(ctx, wi.ID)
-		if err != nil {
-			log.Error(ctx, map[string]interface{}{
-				"wi_id": wi.ID,
-				"err":   err,
-			}, "unable to find out if work item has children: %s", wi.ID)
-			// enforce to have no children
-			hasChildren = false
+		var hasChildren bool
+		var err error
+		repo := appl.WorkItemLinks()
+		if repo != nil {
+			hasChildren, err = appl.WorkItemLinks().WorkItemHasChildren(ctx, wi.ID)
+			if err != nil {
+				log.Error(ctx, map[string]interface{}{
+					"wi_id": wi.ID,
+					"err":   err,
+				}, "unable to find out if work item has children: %s", wi.ID)
+				// enforce to have no children
+				hasChildren = false
+			}
 		}
 		if wi2.Relationships.Children == nil {
 			wi2.Relationships.Children = &app.RelationGeneric{}

--- a/workitem/link/link_repository.go
+++ b/workitem/link/link_repository.go
@@ -37,6 +37,7 @@ type WorkItemLinkRepository interface {
 	Delete(ctx context.Context, ID uuid.UUID, suppressorID uuid.UUID) error
 	Save(ctx context.Context, linkCat WorkItemLink, modifierID uuid.UUID) (*WorkItemLink, error)
 	ListWorkItemChildren(ctx context.Context, parent string) ([]workitem.WorkItem, error)
+	WorkItemHasChildren(ctx context.Context, parent string) (bool, error)
 }
 
 // NewWorkItemLinkRepository creates a work item link repository based on gorm
@@ -315,4 +316,27 @@ func (r *GormWorkItemLinkRepository) ListWorkItemChildren(ctx context.Context, p
 	}
 
 	return res, nil
+}
+
+// WorkItemHasChildren returns true if the given parent work item has children;
+// otherwise false is returned
+func (r *GormWorkItemLinkRepository) WorkItemHasChildren(ctx context.Context, parent string) (bool, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "workitem", "has", "children"}, time.Now())
+	row := r.db.DB().QueryRow(fmt.Sprintf(`
+	SELECT EXISTS (
+		SELECT %[1]s WHERE id in (
+			SELECT target_id FROM %[2]s
+			WHERE source_id = ? AND link_type_id IN (
+				SELECT id FROM %[3]s WHERE forward_name = 'parent of'
+			)
+		)
+	)
+	`, workitem.WorkItemStorage{}.TableName(), WorkItemLink{}.TableName(), WorkItemLinkType{}.TableName()))
+
+	var hasChildren bool
+	if err := row.Scan(&hasChildren); err != nil {
+		return false, errs.Wrapf(err, "failed to check if work item %s has children", parent)
+	}
+
+	return hasChildren, nil
 }


### PR DESCRIPTION
In order for the planner to render an expander symbol, it needs to know if a work item has any children. I've create a `SELECT EXISTS...` query for this because we don't need to fetch or count all children for this task.

These work item actions will include the `hasChildren` meta information:
 * list (tested),
 * show (tested),
 * update,
 * reorder
 * list children (tested), and
* create (tested)