### PR TITLE
Create permission polices for old spaces

### DIFF
--- a/auth/policy.go
+++ b/auth/policy.go
@@ -10,6 +10,7 @@ import (
 
 // AuthzPolicyManager represents a space collaborators policy manager
 type AuthzPolicyManager interface {
+	AuthzResourceManager
 	GetPolicy(ctx context.Context, request *goa.RequestData, policyID string) (*KeycloakPolicy, *string, error)
 	UpdatePolicy(ctx context.Context, request *goa.RequestData, policy KeycloakPolicy, pat string) error
 	VerifyUser(ctx context.Context, request *goa.RequestData, resourceName string) (bool, error)
@@ -19,12 +20,13 @@ type AuthzPolicyManager interface {
 
 // KeycloakPolicyManager implements AuthzPolicyManager interface
 type KeycloakPolicyManager struct {
-	configuration KeycloakConfiguration
+	configuration   KeycloakConfiguration
+	resourceManager AuthzResourceManager
 }
 
 // NewKeycloakPolicyManager constructs KeycloakPolicyManager
-func NewKeycloakPolicyManager(config KeycloakConfiguration) *KeycloakPolicyManager {
-	return &KeycloakPolicyManager{config}
+func NewKeycloakPolicyManager(config KeycloakConfiguration, resourceManager AuthzResourceManager) *KeycloakPolicyManager {
+	return &KeycloakPolicyManager{config, resourceManager}
 }
 
 // VerifyUser returns true if the user among the resource collaborators
@@ -88,4 +90,14 @@ func (m *KeycloakPolicyManager) UpdatePolicy(ctx context.Context, request *goa.R
 	}
 
 	return UpdatePolicy(ctx, clientsEndpoint, clientID, policy, pat)
+}
+
+// CreateResource creates a keyclaok resource and associated permission and policy
+func (m *KeycloakPolicyManager) CreateResource(ctx context.Context, request *goa.RequestData, name string, rType string, uri *string, scopes *[]string, userID string, policyName string) (*Resource, error) {
+	return m.resourceManager.CreateResource(ctx, request, name, rType, uri, scopes, userID, policyName)
+}
+
+// DeleteResource deletes the keycloak resource and associated permission and policy
+func (m *KeycloakPolicyManager) DeleteResource(ctx context.Context, request *goa.RequestData, resource Resource) error {
+	return m.resourceManager.DeleteResource(ctx, request, resource)
 }

--- a/auth/policy_blackbox_test.go
+++ b/auth/policy_blackbox_test.go
@@ -26,7 +26,7 @@ type TestPolicySuite struct {
 }
 
 func (s *TestPolicySuite) SetupSuite() {
-	s.policyManager = auth.NewKeycloakPolicyManager(configuration)
+	s.policyManager = auth.NewKeycloakPolicyManager(configuration, auth.NewKeycloakResourceManager(configuration))
 }
 
 func (s *TestPolicySuite) TearDownSuite() {

--- a/controller/collaborators_test.go
+++ b/controller/collaborators_test.go
@@ -60,6 +60,14 @@ func (m *DummyPolicyManager) RemoveUserFromPolicy(p *auth.KeycloakPolicy, userID
 	return p.RemoveUserFromPolicy(userID)
 }
 
+func (m *DummyPolicyManager) CreateResource(ctx context.Context, request *goa.RequestData, name string, rType string, uri *string, scopes *[]string, userID string, policyName string) (*auth.Resource, error) {
+	return &auth.Resource{ResourceID: uuid.NewV4().String(), PermissionID: uuid.NewV4().String(), PolicyID: uuid.NewV4().String()}, nil
+}
+
+func (m *DummyPolicyManager) DeleteResource(ctx context.Context, request *goa.RequestData, resource auth.Resource) error {
+	return nil
+}
+
 type TestCollaboratorsREST struct {
 	gormtestsupport.DBTestSuite
 

--- a/main.go
+++ b/main.go
@@ -302,7 +302,7 @@ func main() {
 	app.MountSpaceCodebasesController(service, spaceCodebaseCtrl)
 
 	// Mount "collaborators" controller
-	collaboratorsCtrl := controller.NewCollaboratorsController(service, appDB, configuration, auth.NewKeycloakPolicyManager(configuration))
+	collaboratorsCtrl := controller.NewCollaboratorsController(service, appDB, configuration, auth.NewKeycloakPolicyManager(configuration, auth.NewKeycloakResourceManager(configuration)))
 	app.MountCollaboratorsController(service, collaboratorsCtrl)
 
 	if !configuration.IsPostgresDeveloperModeEnabled() {


### PR DESCRIPTION
Currently we have many spaces in prod-preview that were created before we started creating Keycloak authz resources during space creation. So such old spaces don't have associated resources in Keycloak. Attempts to obtain or update the list of the space collaborators will fail. We basically can't authorize access to such resources via Keycloak.

This PR provides a possible solution. If no associated resource for the space found when trying to access the list of space owners then a new resource for this space will be created.
