### PR TITLE
Only space collaborators should be able to edit Work Items

### DIFF
--- a/auth/authz.go
+++ b/auth/authz.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/log"
 	"github.com/almighty/almighty-core/rest"
@@ -64,6 +63,16 @@ type KeycloakPolicy struct {
 type PolicyConfigData struct {
 	//"users":"[\"<ID>\",\"<ID>\"]"
 	UserIDs string `json:"users"`
+}
+
+// Token represents a Keycloak token respons
+type Token struct {
+	AccessToken      *string `json:"access_token,omitempty"`
+	ExpiresIn        *int    `json:"expires_in,omitempty"`
+	NotBeforePolicy  *int    `json:"not-before-policy,omitempty"`
+	RefreshExpiresIn *int    `json:"refresh_expires_in,omitempty"`
+	RefreshToken     *string `json:"refresh_token,omitempty"`
+	TokenType        *string `json:"token_type,omitempty"`
 }
 
 // AddUserToPolicy adds the user ID to the policy
@@ -746,14 +755,14 @@ func GetProtectedAPIToken(openidConnectTokenURL string, clientID string, clientS
 }
 
 // ReadToken extracts json with token data from the response
-func ReadToken(res *http.Response) (*app.TokenData, error) {
+func ReadToken(res *http.Response) (*Token, error) {
 	// Read the json out of the response body
 	buf := new(bytes.Buffer)
 	io.Copy(buf, res.Body)
 	res.Body.Close()
 	jsonString := strings.TrimSpace(buf.String())
 
-	var token app.TokenData
+	var token Token
 	err := json.Unmarshal([]byte(jsonString), &token)
 	if err != nil {
 		return nil, errors.NewInternalError(fmt.Sprintf("error when unmarshal json with access token %s ", jsonString) + err.Error())

--- a/auth/authz.go
+++ b/auth/authz.go
@@ -65,7 +65,7 @@ type PolicyConfigData struct {
 	UserIDs string `json:"users"`
 }
 
-// Token represents a Keycloak token respons
+// Token represents a Keycloak token response
 type Token struct {
 	AccessToken      *string `json:"access_token,omitempty"`
 	ExpiresIn        *int    `json:"expires_in,omitempty"`

--- a/auth/authz_blackbox_test.go
+++ b/auth/authz_blackbox_test.go
@@ -208,8 +208,9 @@ func (s *TestAuthSuite) TestGetEntitlement() {
 	entitlementResource := auth.EntitlementResource{
 		Permissions: []auth.ResourceSet{{Name: resourceName}},
 	}
-	ent, err := auth.GetEntitlement(ctx, entitlementEndpoint, entitlementResource, *testUserToken.Token.AccessToken)
+	ent, err := auth.GetEntitlement(ctx, entitlementEndpoint, &entitlementResource, *testUserToken.Token.AccessToken)
 	require.Nil(s.T(), err)
+	require.NotNil(s.T(), ent)
 	require.NotEqual(s.T(), "", ent)
 
 	ok, err := auth.VerifyResourceUser(ctx, *testUserToken.Token.AccessToken, resourceName, entitlementEndpoint)
@@ -224,13 +225,23 @@ func (s *TestAuthSuite) TestGetEntitlement() {
 	err = auth.UpdatePolicy(ctx, clientsEndpoint, clientId, *pl, pat)
 	require.Nil(s.T(), err)
 
-	ent, err = auth.GetEntitlement(ctx, entitlementEndpoint, entitlementResource, *testUserToken.Token.AccessToken)
+	ent, err = auth.GetEntitlement(ctx, entitlementEndpoint, &entitlementResource, *testUserToken.Token.AccessToken)
 	require.Nil(s.T(), err)
 	require.Nil(s.T(), ent)
 
 	ok, err = auth.VerifyResourceUser(ctx, *testUserToken.Token.AccessToken, resourceName, entitlementEndpoint)
 	require.False(s.T(), ok)
 	require.Nil(s.T(), err)
+
+	ent, err = auth.GetEntitlement(ctx, entitlementEndpoint, nil, *testUserToken.Token.AccessToken)
+	require.Nil(s.T(), err)
+	require.NotNil(s.T(), ent)
+	require.NotEqual(s.T(), "", ent)
+
+	ent, err = auth.GetEntitlement(ctx, entitlementEndpoint, nil, *ent)
+	require.Nil(s.T(), err)
+	require.NotNil(s.T(), ent)
+	require.NotEqual(s.T(), "", ent)
 }
 
 func (s *TestAuthSuite) TestGetClientIDOK() {

--- a/auth/policy.go
+++ b/auth/policy.go
@@ -3,16 +3,13 @@ package auth
 import (
 	"context"
 
-	"github.com/almighty/almighty-core/errors"
 	"github.com/goadesign/goa"
-	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 )
 
 // AuthzPolicyManager represents a space collaborators policy manager
 type AuthzPolicyManager interface {
 	GetPolicy(ctx context.Context, request *goa.RequestData, policyID string) (*KeycloakPolicy, *string, error)
 	UpdatePolicy(ctx context.Context, request *goa.RequestData, policy KeycloakPolicy, pat string) error
-	VerifyUser(ctx context.Context, request *goa.RequestData, resourceName string) (bool, error)
 	AddUserToPolicy(p *KeycloakPolicy, userID string) bool
 	RemoveUserFromPolicy(p *KeycloakPolicy, userID string) bool
 }
@@ -25,20 +22,6 @@ type KeycloakPolicyManager struct {
 // NewKeycloakPolicyManager constructs KeycloakPolicyManager
 func NewKeycloakPolicyManager(config KeycloakConfiguration) *KeycloakPolicyManager {
 	return &KeycloakPolicyManager{config}
-}
-
-// VerifyUser returns true if the user among the resource collaborators
-func (m *KeycloakPolicyManager) VerifyUser(ctx context.Context, request *goa.RequestData, resourceName string) (bool, error) {
-	entitlementEndpoint, err := m.configuration.GetKeycloakEndpointEntitlement(request)
-	if err != nil {
-		return false, err
-	}
-	token := goajwt.ContextJWT(ctx)
-	if token == nil {
-		return false, errors.NewUnauthorizedError("Missing token")
-	}
-
-	return VerifyResourceUser(ctx, token.Raw, resourceName, entitlementEndpoint)
 }
 
 // AddUserToPolicy adds the user ID to the policy

--- a/auth/resource.go
+++ b/auth/resource.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"context"
 
+	"fmt"
+
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/log"
 	"github.com/goadesign/goa"
@@ -11,7 +13,7 @@ import (
 
 // AuthzResourceManager represents a space resource manager
 type AuthzResourceManager interface {
-	CreateResource(ctx context.Context, request *goa.RequestData, name string, rType string, uri *string, scopes *[]string, userID string, policyName string) (*Resource, error)
+	CreateResource(ctx context.Context, request *goa.RequestData, name string, rType string, uri *string, scopes *[]string, userID string) (*Resource, error)
 	DeleteResource(ctx context.Context, request *goa.RequestData, resource Resource) error
 }
 
@@ -44,7 +46,7 @@ func NewKeycloakResourceManager(config KeycloakConfiguration) *KeycloakResourceM
 }
 
 // CreateResource creates a keyclaok resource and associated permission and policy
-func (m *KeycloakResourceManager) CreateResource(ctx context.Context, request *goa.RequestData, name string, rType string, uri *string, scopes *[]string, userID string, policyName string) (*Resource, error) {
+func (m *KeycloakResourceManager) CreateResource(ctx context.Context, request *goa.RequestData, name string, rType string, uri *string, scopes *[]string, userID string) (*Resource, error) {
 	pat, err := getPat(request, m.configuration)
 	if err != nil {
 		return nil, err
@@ -88,7 +90,7 @@ func (m *KeycloakResourceManager) CreateResource(ctx context.Context, request *g
 	}
 	userIDs := "[\"" + userID + "\"]"
 	policy := KeycloakPolicy{
-		Name:             policyName,
+		Name:             fmt.Sprintf("%s-%s", name, uuid.NewV4().String()),
 		Type:             PolicyTypeUser,
 		Logic:            PolicyLogicPossitive,
 		DecisionStrategy: PolicyDecisionStrategyUnanimous,
@@ -103,7 +105,7 @@ func (m *KeycloakResourceManager) CreateResource(ctx context.Context, request *g
 
 	// Create permission
 	permission := KeycloakPermission{
-		Name:             uuid.NewV4().String(),
+		Name:             fmt.Sprintf("%s-%s", name, uuid.NewV4().String()),
 		Type:             PermissionTypeResource,
 		Logic:            PolicyLogicPossitive,
 		DecisionStrategy: PolicyDecisionStrategyUnanimous,

--- a/controller/collaborators.go
+++ b/controller/collaborators.go
@@ -199,7 +199,7 @@ func (c *CollaboratorsController) checkSpaceOwner(ctx context.Context, spaceID u
 
 func (c *CollaboratorsController) updatePolicy(ctx collaboratorContext, req *goa.RequestData, spaceID string, identityIDs []*app.UpdateUserID, update func(policy *auth.KeycloakPolicy, identityID string) bool) error {
 	// Authorize current user
-	_, authorized, err := authz.Authorize(ctx, spaceID)
+	authorized, err := authz.Authorize(ctx, spaceID)
 	if err != nil {
 		return goa.ErrUnauthorized(err.Error())
 	}

--- a/controller/collaborators.go
+++ b/controller/collaborators.go
@@ -11,7 +11,7 @@ import (
 	"github.com/almighty/almighty-core/auth"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/log"
-	"github.com/almighty/almighty-core/space"
+	"github.com/almighty/almighty-core/space/authz"
 	"github.com/goadesign/goa"
 	"github.com/satori/go.uuid"
 )
@@ -199,7 +199,7 @@ func (c *CollaboratorsController) checkSpaceOwner(ctx context.Context, spaceID u
 
 func (c *CollaboratorsController) updatePolicy(ctx collaboratorContext, req *goa.RequestData, spaceID string, identityIDs []*app.UpdateUserID, update func(policy *auth.KeycloakPolicy, identityID string) bool) error {
 	// Authorize current user
-	_, authorized, err := space.Authorize(ctx, spaceID)
+	_, authorized, err := authz.Authorize(ctx, spaceID)
 	if err != nil {
 		return goa.ErrUnauthorized(err.Error())
 	}

--- a/controller/collaborators.go
+++ b/controller/collaborators.go
@@ -11,6 +11,7 @@ import (
 	"github.com/almighty/almighty-core/auth"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/log"
+	"github.com/almighty/almighty-core/space"
 	"github.com/goadesign/goa"
 	"github.com/satori/go.uuid"
 )
@@ -198,7 +199,7 @@ func (c *CollaboratorsController) checkSpaceOwner(ctx context.Context, spaceID u
 
 func (c *CollaboratorsController) updatePolicy(ctx collaboratorContext, req *goa.RequestData, spaceID string, identityIDs []*app.UpdateUserID, update func(policy *auth.KeycloakPolicy, identityID string) bool) error {
 	// Authorize current user
-	authorized, err := c.policyManager.VerifyUser(ctx, req, spaceID)
+	_, authorized, err := space.Authorize(ctx, spaceID)
 	if err != nil {
 		return goa.ErrUnauthorized(err.Error())
 	}

--- a/controller/collaborators_test.go
+++ b/controller/collaborators_test.go
@@ -40,19 +40,13 @@ type DummySpaceAuthzService struct {
 	rest *TestCollaboratorsREST
 }
 
-func (s *DummySpaceAuthzService) Authorize(ctx context.Context, endpoint string, spaceID string) (*string, bool, error) {
+func (s *DummySpaceAuthzService) Authorize(ctx context.Context, endpoint string, spaceID string) (bool, error) {
 	jwtToken := goajwt.ContextJWT(ctx)
 	if jwtToken == nil {
-		return nil, false, errors.NewUnauthorizedError("Missing token")
+		return false, errors.NewUnauthorizedError("Missing token")
 	}
 	id := jwtToken.Claims.(token.MapClaims)["sub"].(string)
-	var rpt *string
-	ok := strings.Contains(s.rest.policy.Config.UserIDs, id)
-	if ok {
-		t := ""
-		rpt = &t
-	}
-	return rpt, ok, nil
+	return strings.Contains(s.rest.policy.Config.UserIDs, id), nil
 }
 
 func (s *DummySpaceAuthzService) Configuration() authz.AuthzConfiguration {
@@ -369,19 +363,13 @@ type TestSpaceAuthzService struct {
 	owner account.Identity
 }
 
-func (s *TestSpaceAuthzService) Authorize(ctx context.Context, endpoint string, spaceID string) (*string, bool, error) {
+func (s *TestSpaceAuthzService) Authorize(ctx context.Context, endpoint string, spaceID string) (bool, error) {
 	jwtToken := goajwt.ContextJWT(ctx)
 	if jwtToken == nil {
-		return nil, false, errors.NewUnauthorizedError("Missing token")
+		return false, errors.NewUnauthorizedError("Missing token")
 	}
 	id := jwtToken.Claims.(token.MapClaims)["sub"].(string)
-	var rpt *string
-	ok := s.owner.ID.String() == id
-	if ok {
-		t := ""
-		rpt = &t
-	}
-	return rpt, ok, nil
+	return s.owner.ID.String() == id, nil
 }
 
 func (s *TestSpaceAuthzService) Configuration() authz.AuthzConfiguration {

--- a/controller/collaborators_test.go
+++ b/controller/collaborators_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
+	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/auth"
 	. "github.com/almighty/almighty-core/controller"
 	"github.com/almighty/almighty-core/errors"
@@ -16,6 +17,7 @@ import (
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/gormtestsupport"
 	"github.com/almighty/almighty-core/resource"
+	"github.com/almighty/almighty-core/space"
 	testsupport "github.com/almighty/almighty-core/test"
 	almtoken "github.com/almighty/almighty-core/token"
 	token "github.com/dgrijalva/jwt-go"
@@ -34,6 +36,29 @@ type DummyPolicyManager struct {
 	rest *TestCollaboratorsREST
 }
 
+type DummySpaceAuthzService struct {
+	rest *TestCollaboratorsREST
+}
+
+func (s *DummySpaceAuthzService) Authorize(ctx context.Context, endpoint string, spaceID string) (*string, bool, error) {
+	jwtToken := goajwt.ContextJWT(ctx)
+	if jwtToken == nil {
+		return nil, false, errors.NewUnauthorizedError("Missing token")
+	}
+	id := jwtToken.Claims.(token.MapClaims)["sub"].(string)
+	var rpt *string
+	ok := strings.Contains(s.rest.policy.Config.UserIDs, id)
+	if ok {
+		t := ""
+		rpt = &t
+	}
+	return rpt, ok, nil
+}
+
+func (s *DummySpaceAuthzService) Configuration() space.AuthzConfiguration {
+	return nil
+}
+
 func (m *DummyPolicyManager) GetPolicy(ctx context.Context, request *goa.RequestData, policyID string) (*auth.KeycloakPolicy, *string, error) {
 	pat := ""
 	return m.rest.policy, &pat, nil
@@ -41,15 +66,6 @@ func (m *DummyPolicyManager) GetPolicy(ctx context.Context, request *goa.Request
 
 func (m *DummyPolicyManager) UpdatePolicy(ctx context.Context, request *goa.RequestData, policy auth.KeycloakPolicy, pat string) error {
 	return nil
-}
-
-func (m *DummyPolicyManager) VerifyUser(ctx context.Context, request *goa.RequestData, resourceName string) (bool, error) {
-	jwtToken := goajwt.ContextJWT(ctx)
-	if jwtToken == nil {
-		return false, errors.NewUnauthorizedError("Missing token")
-	}
-	id := jwtToken.Claims.(token.MapClaims)["sub"].(string)
-	return strings.Contains(m.rest.policy.Config.UserIDs, id), nil
 }
 
 func (m *DummyPolicyManager) AddUserToPolicy(p *auth.KeycloakPolicy, userID string) bool {
@@ -103,7 +119,7 @@ func (rest *TestCollaboratorsREST) TearDownTest() {
 func (rest *TestCollaboratorsREST) SecuredController() (*goa.Service, *CollaboratorsController) {
 	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
 
-	svc := testsupport.ServiceAsUser("Collaborators-Service", almtoken.NewManagerWithPrivateKey(priv), rest.testIdentity1)
+	svc := testsupport.ServiceAsSpaceUser("Collaborators-Service", almtoken.NewManagerWithPrivateKey(priv), rest.testIdentity1, &DummySpaceAuthzService{rest})
 	return svc, NewCollaboratorsController(svc, rest.db, rest.Configuration, &DummyPolicyManager{rest: rest})
 }
 
@@ -225,7 +241,7 @@ func (rest *TestCollaboratorsREST) TestRemoveManyCollaboratorsUnauthorizedIfNoTo
 
 func (rest *TestCollaboratorsREST) TestRemoveCollaboratorsUnauthorizedIfCurrentUserIsNotCollaborator() {
 	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
-	svc := testsupport.ServiceAsUser("Collaborators-Service", almtoken.NewManagerWithPrivateKey(priv), rest.testIdentity2)
+	svc := testsupport.ServiceAsSpaceUser("Collaborators-Service", almtoken.NewManagerWithPrivateKey(priv), rest.testIdentity2, &DummySpaceAuthzService{rest})
 	ctrl := NewCollaboratorsController(svc, rest.db, rest.Configuration, &DummyPolicyManager{rest: rest})
 
 	rest.policy.AddUserToPolicy(rest.testIdentity1.ID.String())
@@ -236,7 +252,7 @@ func (rest *TestCollaboratorsREST) TestRemoveCollaboratorsUnauthorizedIfCurrentU
 
 func (rest *TestCollaboratorsREST) TestRemoveManyCollaboratorsUnauthorizedIfCurrentUserIsNotCollaborator() {
 	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
-	svc := testsupport.ServiceAsUser("Collaborators-Service", almtoken.NewManagerWithPrivateKey(priv), rest.testIdentity2)
+	svc := testsupport.ServiceAsSpaceUser("Collaborators-Service", almtoken.NewManagerWithPrivateKey(priv), rest.testIdentity2, &DummySpaceAuthzService{rest})
 	ctrl := NewCollaboratorsController(svc, rest.db, rest.Configuration, &DummyPolicyManager{rest: rest})
 
 	rest.policy.AddUserToPolicy(rest.testIdentity1.ID.String())
@@ -346,5 +362,50 @@ func (rest *TestCollaboratorsREST) createSpace() app.Space {
 	_, sp := test.CreateSpaceCreated(rest.T(), svc.Context, svc, spaceCtrl, spacePayload)
 	require.NotNil(rest.T(), sp)
 	require.NotNil(rest.T(), sp.Data)
+	return *sp.Data
+}
+
+type TestSpaceAuthzService struct {
+	owner account.Identity
+}
+
+func (s *TestSpaceAuthzService) Authorize(ctx context.Context, endpoint string, spaceID string) (*string, bool, error) {
+	jwtToken := goajwt.ContextJWT(ctx)
+	if jwtToken == nil {
+		return nil, false, errors.NewUnauthorizedError("Missing token")
+	}
+	id := jwtToken.Claims.(token.MapClaims)["sub"].(string)
+	var rpt *string
+	ok := s.owner.ID.String() == id
+	if ok {
+		t := ""
+		rpt = &t
+	}
+	return rpt, ok, nil
+}
+
+func (s *TestSpaceAuthzService) Configuration() space.AuthzConfiguration {
+	return nil
+}
+
+func CreateSecuredSpace(t *testing.T, db application.DB, config SpaceConfiguration, owner account.Identity) app.Space {
+	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
+	svc := testsupport.ServiceAsSpaceUser("Collaborators-Service", almtoken.NewManagerWithPrivateKey(priv), owner, &TestSpaceAuthzService{owner})
+	spaceCtrl := NewSpaceController(svc, db, config, &DummyResourceManager{})
+	require.NotNil(t, spaceCtrl)
+	name := "TestCollaborators-space-" + uuid.NewV4().String()
+	description := "description"
+	spacePayload := &app.CreateSpacePayload{
+		Data: &app.Space{
+			Type: "spaces",
+			Attributes: &app.SpaceAttributes{
+				Name:        &name,
+				Description: &description,
+			},
+		},
+	}
+	_, sp := test.CreateSpaceCreated(t, svc.Context, svc, spaceCtrl, spacePayload)
+	require.NotNil(t, sp)
+	require.NotNil(t, sp.Data)
 	return *sp.Data
 }

--- a/controller/collaborators_test.go
+++ b/controller/collaborators_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/gormtestsupport"
 	"github.com/almighty/almighty-core/resource"
-	"github.com/almighty/almighty-core/space"
+	"github.com/almighty/almighty-core/space/authz"
 	testsupport "github.com/almighty/almighty-core/test"
 	almtoken "github.com/almighty/almighty-core/token"
 	token "github.com/dgrijalva/jwt-go"
@@ -55,7 +55,7 @@ func (s *DummySpaceAuthzService) Authorize(ctx context.Context, endpoint string,
 	return rpt, ok, nil
 }
 
-func (s *DummySpaceAuthzService) Configuration() space.AuthzConfiguration {
+func (s *DummySpaceAuthzService) Configuration() authz.AuthzConfiguration {
 	return nil
 }
 
@@ -384,7 +384,7 @@ func (s *TestSpaceAuthzService) Authorize(ctx context.Context, endpoint string, 
 	return rpt, ok, nil
 }
 
-func (s *TestSpaceAuthzService) Configuration() space.AuthzConfiguration {
+func (s *TestSpaceAuthzService) Configuration() authz.AuthzConfiguration {
 	return nil
 }
 

--- a/controller/login_test.go
+++ b/controller/login_test.go
@@ -161,7 +161,7 @@ func validateToken(t *testing.T, token *app.AuthToken, controler *LoginControlle
 
 type TestLoginService struct{}
 
-func (t TestLoginService) Perform(ctx *app.AuthorizeLoginContext, oauth *oauth2.Config, authEndpoint string, tokenEndpoint string, brokerEndpoint string, validRedirectURL string) error {
+func (t TestLoginService) Perform(ctx *app.AuthorizeLoginContext, oauth *oauth2.Config, brokerEndpoint string, entitlementEndpoint string, validRedirectURL string) error {
 	return ctx.TemporaryRedirect()
 }
 

--- a/controller/login_test.go
+++ b/controller/login_test.go
@@ -61,20 +61,13 @@ func (rest *TestLoginREST) SecuredController() (*goa.Service, *LoginController) 
 }
 
 func newTestKeycloakOAuthProvider(db application.DB, configuration loginConfiguration) *login.KeycloakOAuthProvider {
-	oauth := &oauth2.Config{
-		ClientID:     configuration.GetKeycloakClientID(),
-		ClientSecret: configuration.GetKeycloakSecret(),
-		Scopes:       []string{"user:email"},
-		Endpoint:     oauth2.Endpoint{},
-	}
-
 	publicKey, err := token.ParsePublicKey([]byte(token.RSAPublicKey))
 	if err != nil {
 		panic(err)
 	}
 
 	tokenManager := token.NewManager(publicKey)
-	return login.NewKeycloakOAuthProvider(oauth, db.Identities(), db.Users(), tokenManager, db)
+	return login.NewKeycloakOAuthProvider(db.Identities(), db.Users(), tokenManager, db)
 }
 
 func (rest *TestLoginREST) TestAuthorizeLoginOK() {
@@ -168,7 +161,7 @@ func validateToken(t *testing.T, token *app.AuthToken, controler *LoginControlle
 
 type TestLoginService struct{}
 
-func (t TestLoginService) Perform(ctx *app.AuthorizeLoginContext, authEndpoint string, tokenEndpoint string, brokerEndpoint string, validRedirectURL string) error {
+func (t TestLoginService) Perform(ctx *app.AuthorizeLoginContext, oauth *oauth2.Config, authEndpoint string, tokenEndpoint string, brokerEndpoint string, validRedirectURL string) error {
 	return ctx.TemporaryRedirect()
 }
 

--- a/controller/space.go
+++ b/controller/space.go
@@ -28,7 +28,8 @@ const (
 
 var scopes = []string{"read:space", "admin:space"}
 
-type spaceConfiguration interface {
+// SpaceConfiguration represents space configuratoin
+type SpaceConfiguration interface {
 	GetKeycloakEndpointAuthzResourceset(*goa.RequestData) (string, error)
 	GetKeycloakEndpointToken(*goa.RequestData) (string, error)
 	GetKeycloakEndpointClients(*goa.RequestData) (string, error)
@@ -42,12 +43,12 @@ type spaceConfiguration interface {
 type SpaceController struct {
 	*goa.Controller
 	db              application.DB
-	config          spaceConfiguration
+	config          SpaceConfiguration
 	resourceManager auth.AuthzResourceManager
 }
 
 // NewSpaceController creates a space controller.
-func NewSpaceController(service *goa.Service, db application.DB, config spaceConfiguration, resourceManager auth.AuthzResourceManager) *SpaceController {
+func NewSpaceController(service *goa.Service, db application.DB, config SpaceConfiguration, resourceManager auth.AuthzResourceManager) *SpaceController {
 	return &SpaceController{Controller: service.NewController("SpaceController"), db: db, config: config, resourceManager: resourceManager}
 }
 
@@ -68,7 +69,7 @@ func (c *SpaceController) Create(ctx *app.CreateSpaceContext) error {
 	spaceID := uuid.NewV4()
 	// Create keycloak resource for this space
 	// TODO if transaction below fails we need to remove this Keycloak Resource to avoid poluting Keycloak with unused resources
-	resource, err := c.resourceManager.CreateResource(ctx, ctx.RequestData, spaceID.String(), spaceResourceType, &spaceName, &scopes, currentUser.String(), spaceName+"-"+uuid.NewV4().String())
+	resource, err := c.resourceManager.CreateResource(ctx, ctx.RequestData, spaceID.String(), spaceResourceType, &spaceName, &scopes, currentUser.String())
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}

--- a/controller/space_test.go
+++ b/controller/space_test.go
@@ -32,7 +32,7 @@ var spaceConfiguration *configuration.ConfigurationData
 type DummyResourceManager struct {
 }
 
-func (m *DummyResourceManager) CreateResource(ctx context.Context, request *goa.RequestData, name string, rType string, uri *string, scopes *[]string, userID string, policyName string) (*auth.Resource, error) {
+func (m *DummyResourceManager) CreateResource(ctx context.Context, request *goa.RequestData, name string, rType string, uri *string, scopes *[]string, userID string) (*auth.Resource, error) {
 	return &auth.Resource{ResourceID: uuid.NewV4().String(), PermissionID: uuid.NewV4().String(), PolicyID: uuid.NewV4().String()}, nil
 }
 

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -19,6 +19,7 @@ import (
 	query "github.com/almighty/almighty-core/query/simple"
 	"github.com/almighty/almighty-core/rendering"
 	"github.com/almighty/almighty-core/rest"
+	"github.com/almighty/almighty-core/space"
 	"github.com/almighty/almighty-core/workitem"
 
 	"github.com/goadesign/goa"
@@ -138,8 +139,14 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 	}
 	currentUserIdentityID, err := login.ContextIdentity(ctx)
 	if err != nil {
-		jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(err.Error()))
-		return ctx.Unauthorized(jerrors)
+		jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
+	}
+	_, authorized, err := space.Authorize(ctx, ctx.ID)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
+	}
+	if !authorized {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("user is not authorized to access the space"))
 	}
 	return application.Transactional(c.db, func(appl application.Application) error {
 		if ctx.Payload == nil || ctx.Payload.Data == nil || ctx.Payload.Data.ID == nil {
@@ -186,6 +193,13 @@ func (c *WorkitemController) Reorder(ctx *app.ReorderWorkitemContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
+	_, authorized, err := space.Authorize(ctx, ctx.ID)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
+	}
+	if !authorized {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("user is not authorized to access the space"))
+	}
 	return application.Transactional(c.db, func(appl application.Application) error {
 		var dataArray []*app.WorkItem
 		if ctx.Payload == nil || ctx.Payload.Data == nil || ctx.Payload.Position == nil {
@@ -228,8 +242,14 @@ func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
 
 	currentUserIdentityID, err := login.ContextIdentity(ctx)
 	if err != nil {
-		jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(err.Error()))
-		return ctx.Unauthorized(jerrors)
+		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
+	}
+	_, authorized, err := space.Authorize(ctx, ctx.ID)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
+	}
+	if !authorized {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("user is not authorized to access the space"))
 	}
 	var wit *uuid.UUID
 	if ctx.Payload.Data != nil && ctx.Payload.Data.Relationships != nil &&
@@ -335,8 +355,14 @@ func (c *WorkitemController) Delete(ctx *app.DeleteWorkitemContext) error {
 	}
 	currentUserIdentityID, err := login.ContextIdentity(ctx)
 	if err != nil {
-		jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(err.Error()))
-		return ctx.Unauthorized(jerrors)
+		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
+	}
+	_, authorized, err := space.Authorize(ctx, ctx.ID)
+	if err != nil {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
+	}
+	if !authorized {
+		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("user is not authorized to access the space"))
 	}
 	return application.Transactional(c.db, func(appl application.Application) error {
 		err := appl.WorkItems().Delete(ctx, spaceID, ctx.WiID, *currentUserIdentityID)

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -19,7 +19,7 @@ import (
 	query "github.com/almighty/almighty-core/query/simple"
 	"github.com/almighty/almighty-core/rendering"
 	"github.com/almighty/almighty-core/rest"
-	"github.com/almighty/almighty-core/space"
+	"github.com/almighty/almighty-core/space/authz"
 	"github.com/almighty/almighty-core/workitem"
 
 	"github.com/goadesign/goa"
@@ -141,7 +141,7 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 	if err != nil {
 		jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
-	_, authorized, err := space.Authorize(ctx, ctx.ID)
+	_, authorized, err := authz.Authorize(ctx, ctx.ID)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
@@ -193,7 +193,7 @@ func (c *WorkitemController) Reorder(ctx *app.ReorderWorkitemContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
-	_, authorized, err := space.Authorize(ctx, ctx.ID)
+	_, authorized, err := authz.Authorize(ctx, ctx.ID)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
@@ -244,7 +244,7 @@ func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
-	_, authorized, err := space.Authorize(ctx, ctx.ID)
+	_, authorized, err := authz.Authorize(ctx, ctx.ID)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
@@ -357,7 +357,7 @@ func (c *WorkitemController) Delete(ctx *app.DeleteWorkitemContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
-	_, authorized, err := space.Authorize(ctx, ctx.ID)
+	_, authorized, err := authz.Authorize(ctx, ctx.ID)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -141,7 +141,7 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 	if err != nil {
 		jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
-	_, authorized, err := authz.Authorize(ctx, ctx.ID)
+	authorized, err := authz.Authorize(ctx, ctx.ID)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
@@ -193,7 +193,7 @@ func (c *WorkitemController) Reorder(ctx *app.ReorderWorkitemContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
-	_, authorized, err := authz.Authorize(ctx, ctx.ID)
+	authorized, err := authz.Authorize(ctx, ctx.ID)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
@@ -244,7 +244,7 @@ func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
-	_, authorized, err := authz.Authorize(ctx, ctx.ID)
+	authorized, err := authz.Authorize(ctx, ctx.ID)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
@@ -357,7 +357,7 @@ func (c *WorkitemController) Delete(ctx *app.DeleteWorkitemContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
-	_, authorized, err := authz.Authorize(ctx, ctx.ID)
+	authorized, err := authz.Authorize(ctx, ctx.ID)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}

--- a/login/service_blackbox_test.go
+++ b/login/service_blackbox_test.go
@@ -124,14 +124,10 @@ func (s *serviceBlackBoxTest) TestKeycloakAuthorizationRedirect() {
 	r := &goa.RequestData{
 		Request: &http.Request{Host: "demo.api.almighty.io"},
 	}
-	authEndpoint, err := s.configuration.GetKeycloakEndpointAuth(r)
-	require.Nil(s.T(), err)
-	tokenEndpoint, err := s.configuration.GetKeycloakEndpointToken(r)
-	require.Nil(s.T(), err)
 	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 
-	err = s.loginService.Perform(authorizeCtx, s.oauth, authEndpoint, tokenEndpoint, brokerEndpoint, s.getValidRedirectURLs())
+	err = s.loginService.Perform(authorizeCtx, s.oauth, brokerEndpoint, "", s.getValidRedirectURLs())
 
 	assert.Equal(s.T(), 307, rw.Code)
 	assert.Contains(s.T(), rw.Header().Get("Location"), s.oauth.Endpoint.AuthURL)
@@ -173,14 +169,10 @@ func (s *serviceBlackBoxTest) TestKeycloakAuthorizationRedirectsToRedirectParam(
 	r := &goa.RequestData{
 		Request: &http.Request{Host: "api.domain.io"},
 	}
-	authEndpoint, err := s.configuration.GetKeycloakEndpointAuth(r)
-	require.Nil(s.T(), err)
-	tokenEndpoint, err := s.configuration.GetKeycloakEndpointToken(r)
-	require.Nil(s.T(), err)
 	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 
-	err = s.loginService.Perform(authorizeCtx, s.oauth, authEndpoint, tokenEndpoint, brokerEndpoint, s.getValidRedirectURLs())
+	err = s.loginService.Perform(authorizeCtx, s.oauth, brokerEndpoint, "", s.getValidRedirectURLs())
 
 	assert.Equal(s.T(), 307, rw.Code)
 	assert.Contains(s.T(), rw.Header().Get("Location"), s.oauth.Endpoint.AuthURL)
@@ -208,14 +200,10 @@ func (s *serviceBlackBoxTest) TestKeycloakAuthorizationWithNoRefererAndRedirectP
 	r := &goa.RequestData{
 		Request: &http.Request{Host: "api.domain.io"},
 	}
-	authEndpoint, err := s.configuration.GetKeycloakEndpointAuth(r)
-	require.Nil(s.T(), err)
-	tokenEndpoint, err := s.configuration.GetKeycloakEndpointToken(r)
-	require.Nil(s.T(), err)
 	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 
-	err = s.loginService.Perform(authorizeCtx, s.oauth, authEndpoint, tokenEndpoint, brokerEndpoint, s.getValidRedirectURLs())
+	err = s.loginService.Perform(authorizeCtx, s.oauth, brokerEndpoint, "", s.getValidRedirectURLs())
 	assert.Equal(s.T(), 400, rw.Code)
 }
 
@@ -243,14 +231,10 @@ func (s *serviceBlackBoxTest) TestKeycloakAuthorizationWithNoValidRefererFails()
 	r := &goa.RequestData{
 		Request: &http.Request{Host: "api.domain.io"},
 	}
-	authEndpoint, err := s.configuration.GetKeycloakEndpointAuth(r)
-	require.Nil(s.T(), err)
-	tokenEndpoint, err := s.configuration.GetKeycloakEndpointToken(r)
-	require.Nil(s.T(), err)
 	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 
-	err = s.loginService.Perform(authorizeCtx, s.oauth, authEndpoint, tokenEndpoint, brokerEndpoint, config.DefaultValidRedirectURLs)
+	err = s.loginService.Perform(authorizeCtx, s.oauth, brokerEndpoint, "", config.DefaultValidRedirectURLs)
 	assert.Equal(s.T(), 400, rw.Code)
 
 	// openshift.io redirects pass
@@ -264,7 +248,7 @@ func (s *serviceBlackBoxTest) TestKeycloakAuthorizationWithNoValidRefererFails()
 		panic("invalid test data " + err.Error()) // bug
 	}
 
-	err = s.loginService.Perform(authorizeCtx, s.oauth, authEndpoint, tokenEndpoint, brokerEndpoint, config.DefaultValidRedirectURLs)
+	err = s.loginService.Perform(authorizeCtx, s.oauth, brokerEndpoint, "", config.DefaultValidRedirectURLs)
 	assert.Equal(s.T(), 307, rw.Code)
 	assert.Contains(s.T(), rw.Header().Get("Location"), s.oauth.Endpoint.AuthURL)
 	assert.NotEqual(s.T(), rw.Header().Get("Location"), "")
@@ -280,7 +264,7 @@ func (s *serviceBlackBoxTest) TestKeycloakAuthorizationWithNoValidRefererFails()
 		panic("invalid test data " + err.Error()) // bug
 	}
 
-	err = s.loginService.Perform(authorizeCtx, s.oauth, authEndpoint, tokenEndpoint, brokerEndpoint, s.getValidRedirectURLs())
+	err = s.loginService.Perform(authorizeCtx, s.oauth, brokerEndpoint, "", s.getValidRedirectURLs())
 	assert.Equal(s.T(), 307, rw.Code)
 	assert.Contains(s.T(), rw.Header().Get("Location"), s.oauth.Endpoint.AuthURL)
 	assert.NotEqual(s.T(), rw.Header().Get("Location"), "")
@@ -418,14 +402,10 @@ func (s *serviceBlackBoxTest) TestInvalidState() {
 	r := &goa.RequestData{
 		Request: &http.Request{Host: "demo.api.almighty.io"},
 	}
-	authEndpoint, err := s.configuration.GetKeycloakEndpointAuth(r)
-	require.Nil(s.T(), err)
-	tokenEndpoint, err := s.configuration.GetKeycloakEndpointToken(r)
-	require.Nil(s.T(), err)
 	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 
-	err = s.loginService.Perform(authorizeCtx, s.oauth, authEndpoint, tokenEndpoint, brokerEndpoint, s.getValidRedirectURLs())
+	err = s.loginService.Perform(authorizeCtx, s.oauth, brokerEndpoint, "", s.getValidRedirectURLs())
 	assert.Equal(s.T(), 401, rw.Code)
 }
 
@@ -463,14 +443,10 @@ func (s *serviceBlackBoxTest) TestInvalidOAuthAuthorizationCode() {
 	r := &goa.RequestData{
 		Request: &http.Request{Host: "demo.api.almighty.io"},
 	}
-	authEndpoint, err := s.configuration.GetKeycloakEndpointAuth(r)
-	require.Nil(s.T(), err)
-	tokenEndpoint, err := s.configuration.GetKeycloakEndpointToken(r)
-	require.Nil(s.T(), err)
 	brokerEndpoint, err := s.configuration.GetKeycloakEndpointBroker(r)
 	require.Nil(s.T(), err)
 
-	err = s.loginService.Perform(authorizeCtx, s.oauth, authEndpoint, tokenEndpoint, brokerEndpoint, s.getValidRedirectURLs())
+	err = s.loginService.Perform(authorizeCtx, s.oauth, brokerEndpoint, "", s.getValidRedirectURLs())
 
 	assert.Equal(s.T(), 307, rw.Code) // redirect to keycloak login page.
 
@@ -505,7 +481,7 @@ func (s *serviceBlackBoxTest) TestInvalidOAuthAuthorizationCode() {
 	goaCtx = goa.NewContext(goa.WithAction(ctx, "LoginTest"), rw, req, prms)
 	authorizeCtx, err = app.NewAuthorizeLoginContext(goaCtx, req, goa.New("LoginService"))
 
-	err = s.loginService.Perform(authorizeCtx, s.oauth, authEndpoint, tokenEndpoint, brokerEndpoint, s.getValidRedirectURLs())
+	err = s.loginService.Perform(authorizeCtx, s.oauth, brokerEndpoint, "", s.getValidRedirectURLs())
 
 	locationString = rw.HeaderMap["Location"][0]
 	locationUrl, err = url.Parse(locationString)

--- a/login/service_whitebox_test.go
+++ b/login/service_whitebox_test.go
@@ -52,7 +52,6 @@ func setup() {
 	userRepository := account.NewUserRepository(nil)
 	identityRepository := account.NewIdentityRepository(nil)
 	loginService = &KeycloakOAuthProvider{
-		config:       oauth,
 		Identities:   identityRepository,
 		Users:        userRepository,
 		TokenManager: tokenManager,

--- a/login/token_context/token_context.go
+++ b/login/token_context/token_context.go
@@ -9,19 +9,25 @@ import (
 type contextTMKey int
 
 const (
+	_ = iota
 	//contextTokenManagerKey is a key that will be used to put and to get `tokenManager` from goa.context
-	contextTokenManagerKey contextTMKey = iota + 1
+	contextTokenManagerKey contextTMKey = iota
+	//autzSpaceServiceKey is a key that will be used to put and to get `AuthzService` from goa.context
+	autzSpaceServiceKey int = iota
 )
 
 // ReadTokenManagerFromContext returns an interface that encapsulates the
 // tokenManager extracted from context. This interface can be safely converted.
 // Must have been set by ContextWithTokenManager ONLY.
 func ReadTokenManagerFromContext(ctx context.Context) interface{} {
-	tm := ctx.Value(contextTokenManagerKey)
-	if tm != nil {
-		return tm
-	}
-	return nil
+	return ctx.Value(contextTokenManagerKey)
+}
+
+// ReadSpaceAuthzServiceFromContext returns an interface that encapsulates the
+// AuthzServiceManager extracted from context. This interface can be safely converted to space.AuthzServiceManager.
+// Must have been set by ContextWithSpaceAuthzService ONLY.
+func ReadSpaceAuthzServiceFromContext(ctx context.Context) interface{} {
+	return ctx.Value(autzSpaceServiceKey)
 }
 
 // ContextWithTokenManager injects tokenManager in the context for every incoming request
@@ -29,4 +35,11 @@ func ReadTokenManagerFromContext(ctx context.Context) interface{} {
 // Only other possible value is nil
 func ContextWithTokenManager(ctx context.Context, tm interface{}) context.Context {
 	return context.WithValue(ctx, contextTokenManagerKey, tm)
+}
+
+// ContextWithSpaceAuthzService injects AuthzServiceManager in the context for every incoming request
+// Accepts service.AuthzServiceManager in order to make sure that correct object is set in the context.
+// Only other possible value is nil
+func ContextWithSpaceAuthzService(ctx context.Context, s interface{}) context.Context {
+	return context.WithValue(ctx, autzSpaceServiceKey, s)
 }

--- a/login/token_context/token_context.go
+++ b/login/token_context/token_context.go
@@ -24,7 +24,7 @@ func ReadTokenManagerFromContext(ctx context.Context) interface{} {
 }
 
 // ReadSpaceAuthzServiceFromContext returns an interface that encapsulates the
-// AuthzServiceManager extracted from context. This interface can be safely converted to authz.AuthzServiceManager.
+// AuthzServiceManager extracted from context. This interface can be safely converted to space.AuthzServiceManager.
 // Must have been set by ContextWithSpaceAuthzService ONLY.
 func ReadSpaceAuthzServiceFromContext(ctx context.Context) interface{} {
 	return ctx.Value(autzSpaceServiceKey)

--- a/login/token_context/token_context.go
+++ b/login/token_context/token_context.go
@@ -24,7 +24,7 @@ func ReadTokenManagerFromContext(ctx context.Context) interface{} {
 }
 
 // ReadSpaceAuthzServiceFromContext returns an interface that encapsulates the
-// AuthzServiceManager extracted from context. This interface can be safely converted to space.AuthzServiceManager.
+// AuthzServiceManager extracted from context. This interface can be safely converted to authz.AuthzServiceManager.
 // Must have been set by ContextWithSpaceAuthzService ONLY.
 func ReadSpaceAuthzServiceFromContext(ctx context.Context) interface{} {
 	return ctx.Value(autzSpaceServiceKey)

--- a/space/authz.go
+++ b/space/authz.go
@@ -1,0 +1,116 @@
+package space
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/almighty/almighty-core/auth"
+	errs "github.com/almighty/almighty-core/errors"
+	"github.com/almighty/almighty-core/log"
+	tokencontext "github.com/almighty/almighty-core/login/token_context"
+	"github.com/goadesign/goa"
+	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+	contx "golang.org/x/net/context"
+)
+
+// AuthzService represents a space authorization service
+type AuthzService interface {
+	Authorize(ctx context.Context, entitlementEndpoint string, spaceID string) (*string, bool, error)
+	Configuration() AuthzConfiguration
+}
+
+// AuthzConfiguration represents a Keycloak entitlement endpoint configuration
+type AuthzConfiguration interface {
+	GetKeycloakEndpointEntitlement(*goa.RequestData) (string, error)
+}
+
+// AuthzServiceManager represents a space autharizarion service
+type AuthzServiceManager interface {
+	AuthzService() AuthzService
+	EntitlementEndpoint() string
+}
+
+// KeyclaokAuthzServiceManager is a keyaloak implementation of a space autharizarion service
+type KeyclaokAuthzServiceManager struct {
+	Service             AuthzService
+	entitlementEndpoint string
+}
+
+// AuthzService returns a space autharizarion service
+func (m *KeyclaokAuthzServiceManager) AuthzService() AuthzService {
+	return m.Service
+}
+
+// EntitlementEndpoint returns a keyclaok entitlement endpoint URL
+func (m *KeyclaokAuthzServiceManager) EntitlementEndpoint() string {
+	return m.entitlementEndpoint
+}
+
+// KeyclaokAuthzService implements AuthzService interface
+type KeyclaokAuthzService struct {
+	config AuthzConfiguration
+}
+
+// NewAuthzService constructs a new KeyclaokAuthzService
+func NewAuthzService(config AuthzConfiguration) *KeyclaokAuthzService {
+	return &KeyclaokAuthzService{config: config}
+}
+
+// Authorize returns true and the corresponding Requesting Party Token if the current user is among the space collaborators
+func (s *KeyclaokAuthzService) Authorize(ctx context.Context, entitlementEndpoint string, spaceID string) (*string, bool, error) {
+	token := goajwt.ContextJWT(ctx)
+	if token == nil {
+		return nil, false, errs.NewUnauthorizedError("missing token")
+	}
+
+	resource := auth.EntitlementResource{
+		Permissions: []auth.ResourceSet{{Name: spaceID}},
+	}
+	ent, err := auth.GetEntitlement(ctx, entitlementEndpoint, resource, token.Raw)
+	if err != nil {
+		return nil, false, err
+	}
+	return nil, ent != nil, nil
+}
+
+// Configuration returns authz service configuration
+func (s *KeyclaokAuthzService) Configuration() AuthzConfiguration {
+	return s.config
+}
+
+// InjectAuthzService is a middleware responsible for setting up AuthzService in the context for every request.
+func InjectAuthzService(service AuthzService) goa.Middleware {
+	return func(h goa.Handler) goa.Handler {
+		return func(ctx contx.Context, rw http.ResponseWriter, req *http.Request) error {
+			config := service.Configuration()
+			var endpoint string
+			if config != nil {
+				var err error
+				endpoint, err = config.GetKeycloakEndpointEntitlement(&goa.RequestData{Request: req})
+				if err != nil {
+					log.Error(ctx, map[string]interface{}{
+						"err": err,
+					}, "unable to get entitlement endpoint")
+					return err
+				}
+			}
+			ctxWithAuthzServ := tokencontext.ContextWithSpaceAuthzService(ctx, &KeyclaokAuthzServiceManager{Service: service, entitlementEndpoint: endpoint})
+			return h(ctxWithAuthzServ, rw, req)
+		}
+	}
+}
+
+// Authorize returns true and the corresponding Requesting Party Token if the current user is among the space collaborators
+func Authorize(ctx context.Context, spaceID string) (*string, bool, error) {
+	srv := tokencontext.ReadSpaceAuthzServiceFromContext(ctx)
+	if srv == nil {
+		log.Error(ctx, map[string]interface{}{
+			"authz-service": srv,
+		}, "Missing space authz service")
+
+		return nil, false, errors.New("missing space authz service")
+	}
+	h := srv.(AuthzServiceManager)
+	return h.AuthzService().Authorize(ctx, h.EntitlementEndpoint(), spaceID)
+}

--- a/space/authz.go
+++ b/space/authz.go
@@ -106,11 +106,11 @@ func Authorize(ctx context.Context, spaceID string) (*string, bool, error) {
 	srv := tokencontext.ReadSpaceAuthzServiceFromContext(ctx)
 	if srv == nil {
 		log.Error(ctx, map[string]interface{}{
-			"authz-service": srv,
+			"space-id": spaceID,
 		}, "Missing space authz service")
 
 		return nil, false, errors.New("missing space authz service")
 	}
-	h := srv.(AuthzServiceManager)
-	return h.AuthzService().Authorize(ctx, h.EntitlementEndpoint(), spaceID)
+	manager := srv.(AuthzServiceManager)
+	return manager.AuthzService().Authorize(ctx, manager.EntitlementEndpoint(), spaceID)
 }

--- a/space/authz/authz.go
+++ b/space/authz/authz.go
@@ -1,18 +1,36 @@
-package space
+// Package authz contains the code that authorizes space operations
+package authz
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
+	"strconv"
+	"time"
 
+	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/auth"
 	errs "github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/log"
 	tokencontext "github.com/almighty/almighty-core/login/token_context"
+	"github.com/almighty/almighty-core/space"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+	uuid "github.com/satori/go.uuid"
 	contx "golang.org/x/net/context"
 )
+
+type authorization struct {
+	Permissions []permissions `json:"permissions"`
+}
+
+type permissions struct {
+	ResourceSetName *string `json:"resource_set_name"`
+	ResourceSetID   *string `json:"resource_set_id"`
+}
 
 // AuthzService represents a space authorization service
 type AuthzService interface {
@@ -50,11 +68,17 @@ func (m *KeyclaokAuthzServiceManager) EntitlementEndpoint() string {
 // KeyclaokAuthzService implements AuthzService interface
 type KeyclaokAuthzService struct {
 	config AuthzConfiguration
+	db     application.DB
 }
 
 // NewAuthzService constructs a new KeyclaokAuthzService
-func NewAuthzService(config AuthzConfiguration) *KeyclaokAuthzService {
-	return &KeyclaokAuthzService{config: config}
+func NewAuthzService(config AuthzConfiguration, db application.DB) *KeyclaokAuthzService {
+	return &KeyclaokAuthzService{config: config, db: db}
+}
+
+// Configuration returns authz service configuration
+func (s *KeyclaokAuthzService) Configuration() AuthzConfiguration {
+	return s.config
 }
 
 // Authorize returns true and the corresponding Requesting Party Token if the current user is among the space collaborators
@@ -63,20 +87,71 @@ func (s *KeyclaokAuthzService) Authorize(ctx context.Context, entitlementEndpoin
 	if token == nil {
 		return nil, false, errs.NewUnauthorizedError("missing token")
 	}
+	authz := token.Claims.(jwt.MapClaims)["authorization"]
+	if authz == nil {
+		return s.checkEntitlementForSpace(ctx, *token, entitlementEndpoint, spaceID)
+	}
+	var authzJSON authorization
+	err := json.Unmarshal([]byte(authz.(string)), &authzJSON)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"space-id": spaceID,
+			"err":      err,
+		}, "unable to unmarshal json with permissions from the rpt token")
+		return nil, false, errs.NewInternalError(fmt.Sprintf("unable to unmarshal json with permissions from the rpt token: %s : %s", authz, err.Error()))
+	}
+	permissions := authzJSON.Permissions
+	if permissions == nil {
+		return s.checkEntitlementForSpace(ctx, *token, entitlementEndpoint, spaceID)
+	}
+	for _, permission := range permissions {
+		name := permission.ResourceSetName
+		if name != nil && spaceID == *name {
+			return &token.Raw, true, nil
+		}
+	}
+	return s.checkEntitlementForSpace(ctx, *token, entitlementEndpoint, spaceID)
+}
+
+func (s *KeyclaokAuthzService) checkEntitlementForSpace(ctx context.Context, token jwt.Token, entitlementEndpoint string, spaceID string) (*string, bool, error) {
+	spaceUUID, err := uuid.FromString(spaceID)
+	if err != nil {
+		return nil, false, errs.NewInternalError(err.Error())
+	}
+	var spaceResource *space.Resource
+	err = application.Transactional(s.db, func(appl application.Application) error {
+		spaceResource, err = appl.SpaceResources().LoadBySpace(ctx, &spaceUUID)
+		return err
+	})
+	if err != nil {
+		if _, notFound := err.(errs.NotFoundError); notFound {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	iat := token.Claims.(jwt.MapClaims)["iat"]
+	if iat == nil {
+		return nil, false, errs.NewInternalError("iat claim is not found in the token")
+	}
+	i, err := strconv.ParseInt(iat.(string), 10, 64)
+	if err != nil {
+		return nil, false, errs.NewInternalError(err.Error())
+	}
+	tm := time.Unix(i, 0)
+	if !tm.Before(spaceResource.UpdatedAt) {
+		// Token issued after the space permissions were updated last time
+		// No need to update the token
+		return nil, false, nil
+	}
 
 	resource := auth.EntitlementResource{
 		Permissions: []auth.ResourceSet{{Name: spaceID}},
 	}
-	ent, err := auth.GetEntitlement(ctx, entitlementEndpoint, resource, token.Raw)
+	ent, err := auth.GetEntitlement(ctx, entitlementEndpoint, &resource, token.Raw)
 	if err != nil {
 		return nil, false, err
 	}
 	return nil, ent != nil, nil
-}
-
-// Configuration returns authz service configuration
-func (s *KeyclaokAuthzService) Configuration() AuthzConfiguration {
-	return s.config
 }
 
 // InjectAuthzService is a middleware responsible for setting up AuthzService in the context for every request.

--- a/space/authz/authz_test.go
+++ b/space/authz/authz_test.go
@@ -76,7 +76,7 @@ func (s *TestAuthzSuite) checkPermissions(authzPayload authz.AuthorizationPayloa
 	authzService := authz.NewAuthzService(nil, &db{app{resource: resource}})
 	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
 	testIdentity := testsupport.TestIdentity
-	svc := testsupport.ServiceAsUserWithAuthz("SpaceAuthz-Service", almtoken.NewManagerWithPrivateKey(priv), testIdentity, authzPayload)
+	svc := testsupport.ServiceAsUserWithAuthz("SpaceAuthz-Service", almtoken.NewManagerWithPrivateKey(priv), priv, testIdentity, authzPayload)
 	resource.UpdatedAt = time.Now()
 
 	ok, err := authzService.Authorize(svc.Context, "", spaceID)

--- a/space/authz/authz_test.go
+++ b/space/authz/authz_test.go
@@ -58,7 +58,7 @@ func (s *TestAuthzSuite) TestFailsIfNoTokenInContext() {
 
 func (s *TestAuthzSuite) TestUserAmongSpaceCollaboratorsOK() {
 	spaceID := uuid.NewV4().String()
-	authzPayload := authz.AuthorizationPayload{Permissions: []authz.Permissions{authz.Permissions{ResourceSetName: &spaceID}}}
+	authzPayload := authz.AuthorizationPayload{Permissions: []authz.Permissions{{ResourceSetName: &spaceID}}}
 	ok := s.checkPermissions(authzPayload, spaceID)
 	require.True(s.T(), ok)
 }
@@ -66,7 +66,7 @@ func (s *TestAuthzSuite) TestUserAmongSpaceCollaboratorsOK() {
 func (s *TestAuthzSuite) TestUserIsNotAmongSpaceCollaboratorsFails() {
 	spaceID1 := uuid.NewV4().String()
 	spaceID2 := uuid.NewV4().String()
-	authzPayload := authz.AuthorizationPayload{Permissions: []authz.Permissions{authz.Permissions{ResourceSetName: &spaceID1}}}
+	authzPayload := authz.AuthorizationPayload{Permissions: []authz.Permissions{{ResourceSetName: &spaceID1}}}
 	ok := s.checkPermissions(authzPayload, spaceID2)
 	require.False(s.T(), ok)
 }

--- a/space/authz/authz_test.go
+++ b/space/authz/authz_test.go
@@ -1,0 +1,204 @@
+package authz_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/almighty/almighty-core/account"
+	"github.com/almighty/almighty-core/application"
+	"github.com/almighty/almighty-core/area"
+	"github.com/almighty/almighty-core/auth"
+	"github.com/almighty/almighty-core/codebase"
+	"github.com/almighty/almighty-core/comment"
+	"github.com/almighty/almighty-core/iteration"
+	"github.com/almighty/almighty-core/resource"
+	"github.com/almighty/almighty-core/space"
+	"github.com/almighty/almighty-core/space/authz"
+	testsupport "github.com/almighty/almighty-core/test"
+	almtoken "github.com/almighty/almighty-core/token"
+	"github.com/almighty/almighty-core/workitem"
+	"github.com/almighty/almighty-core/workitem/link"
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	netcontext "golang.org/x/net/context"
+)
+
+var (
+	scopes = []string{"read:test", "admin:test"}
+)
+
+func TestAuthz(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	suite.Run(t, new(TestAuthzSuite))
+}
+
+type TestAuthzSuite struct {
+	suite.Suite
+	authzService *authz.KeyclaokAuthzService
+}
+
+func (s *TestAuthzSuite) SetupSuite() {
+	var err error
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup the configuration: %s", err.Error()))
+	}
+	var resource *space.Resource
+	s.authzService = authz.NewAuthzService(nil, &db{app{resource: resource}})
+}
+
+func (s *TestAuthzSuite) TestFailsIfNoTokenInContext() {
+	ctx := context.Background()
+	spaceID := ""
+	_, err := s.authzService.Authorize(ctx, "", spaceID)
+	require.NotNil(s.T(), err)
+}
+
+func (s *TestAuthzSuite) TestUserAmongSpaceCollaboratorsOK() {
+	spaceID := uuid.NewV4().String()
+	authzPayload := authz.AuthorizationPayload{Permissions: []authz.Permissions{authz.Permissions{ResourceSetName: &spaceID}}}
+	ok := s.checkPermissions(authzPayload, spaceID)
+	require.True(s.T(), ok)
+}
+
+func (s *TestAuthzSuite) TestUserIsNotAmongSpaceCollaboratorsFails() {
+	spaceID1 := uuid.NewV4().String()
+	spaceID2 := uuid.NewV4().String()
+	authzPayload := authz.AuthorizationPayload{Permissions: []authz.Permissions{authz.Permissions{ResourceSetName: &spaceID1}}}
+	ok := s.checkPermissions(authzPayload, spaceID2)
+	require.False(s.T(), ok)
+}
+
+func (s *TestAuthzSuite) checkPermissions(authzPayload authz.AuthorizationPayload, spaceID string) bool {
+	resource := &space.Resource{}
+	authzService := authz.NewAuthzService(nil, &db{app{resource: resource}})
+	priv, _ := almtoken.ParsePrivateKey([]byte(almtoken.RSAPrivateKey))
+	testIdentity := testsupport.TestIdentity
+	svc := testsupport.ServiceAsUserWithAuthz("SpaceAuthz-Service", almtoken.NewManagerWithPrivateKey(priv), testIdentity, authzPayload)
+	resource.UpdatedAt = time.Now()
+
+	ok, err := authzService.Authorize(svc.Context, "", spaceID)
+	require.Nil(s.T(), err)
+	return ok
+}
+
+type app struct {
+	resource *space.Resource
+}
+
+type db struct {
+	app
+}
+
+type trx struct {
+	app
+}
+
+type resourceRepo struct {
+	resource *space.Resource
+}
+
+func (t *trx) Commit() error {
+	return nil
+}
+
+func (t *trx) Rollback() error {
+	return nil
+}
+
+func (d *db) BeginTransaction() (application.Transaction, error) {
+	return &trx{}, nil
+}
+
+func (a *app) WorkItems() workitem.WorkItemRepository {
+	return nil
+}
+
+func (a *app) WorkItemTypes() workitem.WorkItemTypeRepository {
+	return nil
+}
+
+func (a *app) Trackers() application.TrackerRepository {
+	return nil
+}
+
+func (a *app) TrackerQueries() application.TrackerQueryRepository {
+	return nil
+}
+
+func (a *app) SearchItems() application.SearchRepository {
+	return nil
+}
+
+func (a *app) Identities() account.IdentityRepository {
+	return nil
+}
+
+func (a *app) WorkItemLinkCategories() link.WorkItemLinkCategoryRepository {
+	return nil
+}
+
+func (a *app) WorkItemLinkTypes() link.WorkItemLinkTypeRepository {
+	return nil
+}
+
+func (a *app) WorkItemLinks() link.WorkItemLinkRepository {
+	return nil
+}
+
+func (a *app) Comments() comment.Repository {
+	return nil
+}
+
+func (a *app) Spaces() space.Repository {
+	return nil
+}
+
+func (a *app) SpaceResources() space.ResourceRepository {
+	return &resourceRepo{a.resource}
+}
+
+func (a *app) Iterations() iteration.Repository {
+	return nil
+}
+
+func (a *app) Users() account.UserRepository {
+	return nil
+}
+
+func (a *app) Areas() area.Repository {
+	return nil
+}
+
+func (a *app) OauthStates() auth.OauthStateReferenceRepository {
+	return nil
+}
+
+func (a *app) Codebases() codebase.Repository {
+	return nil
+}
+
+func (r *resourceRepo) Create(ctx netcontext.Context, s *space.Resource) (*space.Resource, error) {
+	return nil, nil
+}
+
+func (r *resourceRepo) Save(ctx netcontext.Context, s *space.Resource) (*space.Resource, error) {
+	return nil, nil
+}
+
+func (r *resourceRepo) Load(ctx netcontext.Context, ID uuid.UUID) (*space.Resource, error) {
+	return nil, nil
+}
+
+func (r *resourceRepo) Delete(ctx netcontext.Context, ID uuid.UUID) error {
+	return nil
+}
+
+func (r *resourceRepo) LoadBySpace(ctx netcontext.Context, spaceID *uuid.UUID) (*space.Resource, error) {
+	resource := &space.Resource{}
+	past := time.Now().Unix() - 1000
+	resource.UpdatedAt = time.Unix(past, 0)
+	return resource, nil
+}

--- a/test/login.go
+++ b/test/login.go
@@ -2,11 +2,15 @@ package test
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"github.com/almighty/almighty-core/account"
 	tokencontext "github.com/almighty/almighty-core/login/token_context"
 	"github.com/almighty/almighty-core/space/authz"
 	"github.com/almighty/almighty-core/token"
+
+	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
@@ -16,9 +20,8 @@ import (
 type dummySpaceAuthzService struct {
 }
 
-func (s *dummySpaceAuthzService) Authorize(ctx context.Context, entitlementEndpoint string, spaceID string) (*string, bool, error) {
-	token := ""
-	return &token, true, nil
+func (s *dummySpaceAuthzService) Authorize(ctx context.Context, entitlementEndpoint string, spaceID string) (bool, error) {
+	return true, nil
 }
 
 func (s *dummySpaceAuthzService) Configuration() authz.AuthzConfiguration {
@@ -28,31 +31,60 @@ func (s *dummySpaceAuthzService) Configuration() authz.AuthzConfiguration {
 // WithIdentity fills the context with token
 // Token is filled using input Identity object
 func WithIdentity(ctx context.Context, ident account.Identity) context.Context {
+	token := fillClaimsWithIdentity(ident)
+	return goajwt.WithJWT(ctx, token)
+}
+
+// WithAuthz fills the context with token
+// Token is filled using input Identity object and resource authorization information
+func WithAuthz(ctx context.Context, ident account.Identity, authz authz.AuthorizationPayload) context.Context {
+	token := fillClaimsWithIdentity(ident)
+	json, err := json.Marshal(&authz)
+	if err != nil {
+		panic(err.Error())
+	}
+	token.Claims.(jwt.MapClaims)["authorization"] = string(json)
+	return goajwt.WithJWT(ctx, token)
+}
+
+func fillClaimsWithIdentity(ident account.Identity) *jwt.Token {
 	token := jwt.New(jwt.SigningMethodRS256)
 	token.Claims.(jwt.MapClaims)["sub"] = ident.ID.String()
 	token.Claims.(jwt.MapClaims)["uuid"] = ident.ID.String()
 	token.Claims.(jwt.MapClaims)["fullName"] = ident.User.FullName
 	token.Claims.(jwt.MapClaims)["imageURL"] = ident.User.ImageURL
-	return goajwt.WithJWT(ctx, token)
+	token.Claims.(jwt.MapClaims)["iat"] = fmt.Sprintf("%d", time.Now().Unix())
+	return token
 }
 
-func service(serviceName string, tm token.Manager, u account.Identity) *goa.Service {
+func service(serviceName string, tm token.Manager, u account.Identity, authz *authz.AuthorizationPayload) *goa.Service {
 	svc := goa.New(serviceName)
-	svc.Context = WithIdentity(svc.Context, u)
+	if authz == nil {
+		svc.Context = WithIdentity(svc.Context, u)
+	} else {
+		svc.Context = WithAuthz(svc.Context, u, *authz)
+	}
 	svc.Context = tokencontext.ContextWithTokenManager(svc.Context, tm)
+	return svc
+}
+
+// ServiceAsUserWithAuthz creates a new service and fill the context with input Identity and resource authorization information
+func ServiceAsUserWithAuthz(serviceName string, tm token.Manager, u account.Identity, authorizationPayload authz.AuthorizationPayload) *goa.Service {
+	svc := service(serviceName, tm, u, &authorizationPayload)
+	svc.Context = tokencontext.ContextWithSpaceAuthzService(svc.Context, &authz.KeyclaokAuthzServiceManager{Service: &dummySpaceAuthzService{}})
 	return svc
 }
 
 // ServiceAsUser creates a new service and fill the context with input Identity
 func ServiceAsUser(serviceName string, tm token.Manager, u account.Identity) *goa.Service {
-	svc := service(serviceName, tm, u)
+	svc := service(serviceName, tm, u, nil)
 	svc.Context = tokencontext.ContextWithSpaceAuthzService(svc.Context, &authz.KeyclaokAuthzServiceManager{Service: &dummySpaceAuthzService{}})
 	return svc
 }
 
 // ServiceAsSpaceUser creates a new service and fill the context with input Identity and space authz service
 func ServiceAsSpaceUser(serviceName string, tm token.Manager, u account.Identity, authzSrv authz.AuthzService) *goa.Service {
-	svc := service(serviceName, tm, u)
+	svc := service(serviceName, tm, u, nil)
 	svc.Context = tokencontext.ContextWithSpaceAuthzService(svc.Context, &authz.KeyclaokAuthzServiceManager{Service: authzSrv})
 	return svc
 }

--- a/test/login.go
+++ b/test/login.go
@@ -1,16 +1,29 @@
 package test
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/account"
 	tokencontext "github.com/almighty/almighty-core/login/token_context"
 	"github.com/almighty/almighty-core/token"
 
+	"github.com/almighty/almighty-core/space"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 )
+
+type dummySpaceAuthzService struct {
+}
+
+func (s *dummySpaceAuthzService) Authorize(ctx context.Context, entitlementEndpoint string, spaceID string) (*string, bool, error) {
+	token := ""
+	return &token, true, nil
+}
+
+func (s *dummySpaceAuthzService) Configuration() space.AuthzConfiguration {
+	return nil
+}
 
 // WithIdentity fills the context with token
 // Token is filled using input Identity object
@@ -23,10 +36,23 @@ func WithIdentity(ctx context.Context, ident account.Identity) context.Context {
 	return goajwt.WithJWT(ctx, token)
 }
 
-// ServiceAsUser creates a new service and fill the context with input Identity
-func ServiceAsUser(serviceName string, tm token.Manager, u account.Identity) *goa.Service {
+func service(serviceName string, tm token.Manager, u account.Identity) *goa.Service {
 	svc := goa.New(serviceName)
 	svc.Context = WithIdentity(svc.Context, u)
 	svc.Context = tokencontext.ContextWithTokenManager(svc.Context, tm)
+	return svc
+}
+
+// ServiceAsUser creates a new service and fill the context with input Identity
+func ServiceAsUser(serviceName string, tm token.Manager, u account.Identity) *goa.Service {
+	svc := service(serviceName, tm, u)
+	svc.Context = tokencontext.ContextWithSpaceAuthzService(svc.Context, &space.KeyclaokAuthzServiceManager{Service: &dummySpaceAuthzService{}})
+	return svc
+}
+
+// ServiceAsSpaceUser creates a new service and fill the context with input Identity and space authz service
+func ServiceAsSpaceUser(serviceName string, tm token.Manager, u account.Identity, authz space.AuthzService) *goa.Service {
+	svc := service(serviceName, tm, u)
+	svc.Context = tokencontext.ContextWithSpaceAuthzService(svc.Context, &space.KeyclaokAuthzServiceManager{Service: authz})
 	return svc
 }

--- a/test/login.go
+++ b/test/login.go
@@ -2,8 +2,6 @@ package test
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
 	"github.com/almighty/almighty-core/account"
 	tokencontext "github.com/almighty/almighty-core/login/token_context"
@@ -37,13 +35,14 @@ func WithIdentity(ctx context.Context, ident account.Identity) context.Context {
 
 // WithAuthz fills the context with token
 // Token is filled using input Identity object and resource authorization information
-func WithAuthz(ctx context.Context, ident account.Identity, authz authz.AuthorizationPayload) context.Context {
+func WithAuthz(ctx context.Context, key interface{}, ident account.Identity, authz authz.AuthorizationPayload) context.Context {
 	token := fillClaimsWithIdentity(ident)
-	json, err := json.Marshal(&authz)
+	token.Claims.(jwt.MapClaims)["authorization"] = authz
+	t, err := token.SignedString(key)
 	if err != nil {
 		panic(err.Error())
 	}
-	token.Claims.(jwt.MapClaims)["authorization"] = string(json)
+	token.Raw = t
 	return goajwt.WithJWT(ctx, token)
 }
 
@@ -53,38 +52,38 @@ func fillClaimsWithIdentity(ident account.Identity) *jwt.Token {
 	token.Claims.(jwt.MapClaims)["uuid"] = ident.ID.String()
 	token.Claims.(jwt.MapClaims)["fullName"] = ident.User.FullName
 	token.Claims.(jwt.MapClaims)["imageURL"] = ident.User.ImageURL
-	token.Claims.(jwt.MapClaims)["iat"] = fmt.Sprintf("%d", time.Now().Unix())
+	token.Claims.(jwt.MapClaims)["iat"] = time.Now().Unix()
 	return token
 }
 
-func service(serviceName string, tm token.Manager, u account.Identity, authz *authz.AuthorizationPayload) *goa.Service {
+func service(serviceName string, tm token.Manager, key interface{}, u account.Identity, authz *authz.AuthorizationPayload) *goa.Service {
 	svc := goa.New(serviceName)
 	if authz == nil {
 		svc.Context = WithIdentity(svc.Context, u)
 	} else {
-		svc.Context = WithAuthz(svc.Context, u, *authz)
+		svc.Context = WithAuthz(svc.Context, key, u, *authz)
 	}
 	svc.Context = tokencontext.ContextWithTokenManager(svc.Context, tm)
 	return svc
 }
 
 // ServiceAsUserWithAuthz creates a new service and fill the context with input Identity and resource authorization information
-func ServiceAsUserWithAuthz(serviceName string, tm token.Manager, u account.Identity, authorizationPayload authz.AuthorizationPayload) *goa.Service {
-	svc := service(serviceName, tm, u, &authorizationPayload)
+func ServiceAsUserWithAuthz(serviceName string, tm token.Manager, key interface{}, u account.Identity, authorizationPayload authz.AuthorizationPayload) *goa.Service {
+	svc := service(serviceName, tm, key, u, &authorizationPayload)
 	svc.Context = tokencontext.ContextWithSpaceAuthzService(svc.Context, &authz.KeyclaokAuthzServiceManager{Service: &dummySpaceAuthzService{}})
 	return svc
 }
 
 // ServiceAsUser creates a new service and fill the context with input Identity
 func ServiceAsUser(serviceName string, tm token.Manager, u account.Identity) *goa.Service {
-	svc := service(serviceName, tm, u, nil)
+	svc := service(serviceName, tm, nil, u, nil)
 	svc.Context = tokencontext.ContextWithSpaceAuthzService(svc.Context, &authz.KeyclaokAuthzServiceManager{Service: &dummySpaceAuthzService{}})
 	return svc
 }
 
 // ServiceAsSpaceUser creates a new service and fill the context with input Identity and space authz service
 func ServiceAsSpaceUser(serviceName string, tm token.Manager, u account.Identity, authzSrv authz.AuthzService) *goa.Service {
-	svc := service(serviceName, tm, u, nil)
+	svc := service(serviceName, tm, nil, u, nil)
 	svc.Context = tokencontext.ContextWithSpaceAuthzService(svc.Context, &authz.KeyclaokAuthzServiceManager{Service: authzSrv})
 	return svc
 }

--- a/test/login.go
+++ b/test/login.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/almighty/almighty-core/account"
 	tokencontext "github.com/almighty/almighty-core/login/token_context"
+	"github.com/almighty/almighty-core/space/authz"
 	"github.com/almighty/almighty-core/token"
 
-	"github.com/almighty/almighty-core/space"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
@@ -21,7 +21,7 @@ func (s *dummySpaceAuthzService) Authorize(ctx context.Context, entitlementEndpo
 	return &token, true, nil
 }
 
-func (s *dummySpaceAuthzService) Configuration() space.AuthzConfiguration {
+func (s *dummySpaceAuthzService) Configuration() authz.AuthzConfiguration {
 	return nil
 }
 
@@ -46,13 +46,13 @@ func service(serviceName string, tm token.Manager, u account.Identity) *goa.Serv
 // ServiceAsUser creates a new service and fill the context with input Identity
 func ServiceAsUser(serviceName string, tm token.Manager, u account.Identity) *goa.Service {
 	svc := service(serviceName, tm, u)
-	svc.Context = tokencontext.ContextWithSpaceAuthzService(svc.Context, &space.KeyclaokAuthzServiceManager{Service: &dummySpaceAuthzService{}})
+	svc.Context = tokencontext.ContextWithSpaceAuthzService(svc.Context, &authz.KeyclaokAuthzServiceManager{Service: &dummySpaceAuthzService{}})
 	return svc
 }
 
 // ServiceAsSpaceUser creates a new service and fill the context with input Identity and space authz service
-func ServiceAsSpaceUser(serviceName string, tm token.Manager, u account.Identity, authz space.AuthzService) *goa.Service {
+func ServiceAsSpaceUser(serviceName string, tm token.Manager, u account.Identity, authzSrv authz.AuthzService) *goa.Service {
 	svc := service(serviceName, tm, u)
-	svc.Context = tokencontext.ContextWithSpaceAuthzService(svc.Context, &space.KeyclaokAuthzServiceManager{Service: authz})
+	svc.Context = tokencontext.ContextWithSpaceAuthzService(svc.Context, &authz.KeyclaokAuthzServiceManager{Service: authzSrv})
 	return svc
 }


### PR DESCRIPTION
There is a new Space Authorization Service injected in every request.
So, there following code can now be used to check if the current user is among space collaborators:
```
_, authorized, err := space.Authorize(ctx, spaceID)
if err != nil {
	return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
}
if !authorized {
	return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("user is not authorized to access the space"))
}
```
If this PR is approved and merged then PRs for other secured space resources (WI links, types, areas, etc) will follow.

Fixes https://github.com/almighty/almighty-core/issues/1152
