### PR TITLE
Add company detail to user profile

### DIFF
--- a/account/user.go
+++ b/account/user.go
@@ -27,6 +27,7 @@ type User struct {
 	ImageURL           string          // The image URL for the User
 	Bio                string          // The bio of the User
 	URL                string          // The URL of the User
+	Company            string          // The (optional) Company of the User
 	Identities         []Identity      // has many Identities from different IDPs
 	ContextInformation workitem.Fields `sql:"type:jsonb"` // context information of the user activity
 }

--- a/controller/users.go
+++ b/controller/users.go
@@ -169,6 +169,12 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 			(*keycloakUserProfile.Attributes)[login.URLAttributeName] = []string{*updateURL}
 		}
 
+		updatedCompany := ctx.Payload.Data.Attributes.Company
+		if updatedCompany != nil {
+			user.Company = *updatedCompany
+			(*keycloakUserProfile.Attributes)[login.CompanyAttributeName] = []string{*updatedCompany}
+		}
+
 		// If none of the 'extra' attributes were present, we better make that section nil
 		// so that the Attributes section is omitted in the payload sent to KC
 
@@ -260,6 +266,7 @@ func ConvertUser(request *goa.RequestData, identity *account.Identity, user *acc
 	var bio string
 	var userURL string
 	var email string
+	var company string
 	var contextInformation workitem.Fields
 
 	if user != nil {
@@ -268,6 +275,7 @@ func ConvertUser(request *goa.RequestData, identity *account.Identity, user *acc
 		bio = user.Bio
 		userURL = user.URL
 		email = user.Email
+		company = user.Company
 		contextInformation = user.ContextInformation
 	}
 
@@ -292,6 +300,7 @@ func ConvertUser(request *goa.RequestData, identity *account.Identity, user *acc
 				URL:                &userURL,
 				ProviderType:       &providerType,
 				Email:              &email,
+				Company:            &company,
 				ContextInformation: workitem.Fields{},
 			},
 			Links: createUserLinks(request, uuid),

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -88,12 +88,15 @@ func (s *TestUsersSuite) TestUpdateUserOK() {
 	assert.Equal(s.T(), user.ImageURL, *result.Data.Attributes.ImageURL)
 	assert.Equal(s.T(), identity.ProviderType, *result.Data.Attributes.ProviderType)
 	assert.Equal(s.T(), identity.Username, *result.Data.Attributes.Username)
+	assert.Equal(s.T(), user.Company, *result.Data.Attributes.Company)
+
 	// when
 	newEmail := "updated-" + uuid.NewV4().String() + "@email.com"
 	newFullName := "TestUpdateUserOK"
 	newImageURL := "http://new.image.io/imageurl"
 	newBio := "new bio"
 	newProfileURL := "http://new.profile.url/url"
+	newCompany := "updateCompany " + uuid.NewV4().String()
 	secureService, secureController := s.SecuredController(identity)
 
 	contextInformation := map[string]interface{}{
@@ -103,7 +106,7 @@ func (s *TestUsersSuite) TestUpdateUserOK() {
 		"count":        3,
 	}
 	//secureController, secureService := createSecureController(t, identity)
-	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, contextInformation)
+	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, &newCompany, contextInformation)
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 
 	// then
@@ -158,7 +161,7 @@ func (s *TestUsersSuite) TestUpdateUserVariableSpacesInNameOK() {
 		"count":        3,
 	}
 	//secureController, secureService := createSecureController(t, identity)
-	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, contextInformation)
+	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, nil, contextInformation)
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 	// then
 	require.NotNil(s.T(), result)
@@ -210,7 +213,7 @@ func (s *TestUsersSuite) TestUpdateUserUnsetVariableInContextInfo() {
 		"count":        3,
 	}
 	//secureController, secureService := createSecureController(t, identity)
-	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, contextInformation)
+	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, nil, contextInformation)
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 	// then
 	require.NotNil(s.T(), result)
@@ -233,7 +236,7 @@ func (s *TestUsersSuite) TestUpdateUserUnsetVariableInContextInfo() {
 		"count":        3,
 	}
 
-	updateUsersPayload = createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, contextInformation)
+	updateUsersPayload = createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, nil, contextInformation)
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 	// then
 	require.NotNil(s.T(), result)
@@ -297,7 +300,7 @@ func (s *TestUsersSuite) TestPatchUserContextInformation() {
 		"count":        3,
 	}
 	//secureController, secureService := createSecureController(t, identity)
-	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, contextInformation)
+	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, contextInformation)
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 	// then
 	require.NotNil(s.T(), result)
@@ -319,7 +322,7 @@ func (s *TestUsersSuite) TestPatchUserContextInformation() {
 		"count": 5,
 	}
 
-	updateUsersPayload = createUpdateUsersPayload(nil, nil, nil, nil, nil, patchedContextInformation)
+	updateUsersPayload = createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, patchedContextInformation)
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 	require.NotNil(s.T(), result)
 
@@ -358,7 +361,7 @@ func (s *TestUsersSuite) TestUpdateUserUnauthorized() {
 		"space":        "3d6dab8d-f204-42e8-ab29-cdb1c93130ad",
 	}
 	//secureController, secureService := createSecureController(t, identity)
-	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, contextInformation)
+	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, nil, contextInformation)
 	// when/then
 	test.UpdateUsersUnauthorized(s.T(), context.Background(), nil, s.controller, updateUsersPayload)
 }
@@ -440,7 +443,7 @@ func assertUser(t *testing.T, actual *app.IdentityData, expectedUser account.Use
 	assert.Equal(t, expectedUser.Email, *actual.Attributes.Email)
 }
 
-func createUpdateUsersPayload(email, fullName, bio, imageURL, profileURL *string, contextInformation map[string]interface{}) *app.UpdateUsersPayload {
+func createUpdateUsersPayload(email, fullName, bio, imageURL, profileURL, company *string, contextInformation map[string]interface{}) *app.UpdateUsersPayload {
 	return &app.UpdateUsersPayload{
 		Data: &app.UpdateIdentityData{
 			Type: "identities",
@@ -450,6 +453,7 @@ func createUpdateUsersPayload(email, fullName, bio, imageURL, profileURL *string
 				Bio:                bio,
 				ImageURL:           imageURL,
 				URL:                profileURL,
+				Company:            company,
 				ContextInformation: contextInformation,
 			},
 		},

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -119,6 +119,8 @@ func (s *TestUsersSuite) TestUpdateUserOK() {
 	assert.Equal(s.T(), newImageURL, *result.Data.Attributes.ImageURL)
 	assert.Equal(s.T(), newBio, *result.Data.Attributes.Bio)
 	assert.Equal(s.T(), newProfileURL, *result.Data.Attributes.URL)
+	assert.Equal(s.T(), newCompany, *result.Data.Attributes.Company)
+
 	updatedContextInformation := result.Data.Attributes.ContextInformation
 	assert.Equal(s.T(), contextInformation["last_visited"], updatedContextInformation["last_visited"])
 

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -141,6 +141,8 @@ func (s *TestUsersSuite) TestUpdateUserVariableSpacesInNameOK() {
 	assert.Equal(s.T(), user.ImageURL, *result.Data.Attributes.ImageURL)
 	assert.Equal(s.T(), identity.ProviderType, *result.Data.Attributes.ProviderType)
 	assert.Equal(s.T(), identity.Username, *result.Data.Attributes.Username)
+	assert.Equal(s.T(), user.Company, *result.Data.Attributes.Company)
+
 	// when
 	newEmail := "updated-" + uuid.NewV4().String() + "@email.com"
 
@@ -154,6 +156,8 @@ func (s *TestUsersSuite) TestUpdateUserVariableSpacesInNameOK() {
 	newImageURL := "http://new.image.io/imageurl"
 	newBio := "new bio"
 	newProfileURL := "http://new.profile.url/url"
+	newCompany := "updateCompany " + uuid.NewV4().String()
+
 	secureService, secureController := s.SecuredController(identity)
 
 	contextInformation := map[string]interface{}{
@@ -163,7 +167,7 @@ func (s *TestUsersSuite) TestUpdateUserVariableSpacesInNameOK() {
 		"count":        3,
 	}
 	//secureController, secureService := createSecureController(t, identity)
-	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, nil, contextInformation)
+	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, &newCompany, contextInformation)
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 	// then
 	require.NotNil(s.T(), result)
@@ -175,6 +179,8 @@ func (s *TestUsersSuite) TestUpdateUserVariableSpacesInNameOK() {
 	assert.Equal(s.T(), newImageURL, *result.Data.Attributes.ImageURL)
 	assert.Equal(s.T(), newBio, *result.Data.Attributes.Bio)
 	assert.Equal(s.T(), newProfileURL, *result.Data.Attributes.URL)
+	assert.Equal(s.T(), newCompany, *result.Data.Attributes.Company)
+
 	updatedContextInformation := result.Data.Attributes.ContextInformation
 	assert.Equal(s.T(), contextInformation["last_visited"], updatedContextInformation["last_visited"])
 
@@ -200,6 +206,7 @@ func (s *TestUsersSuite) TestUpdateUserUnsetVariableInContextInfo() {
 	assert.Equal(s.T(), user.ImageURL, *result.Data.Attributes.ImageURL)
 	assert.Equal(s.T(), identity.ProviderType, *result.Data.Attributes.ProviderType)
 	assert.Equal(s.T(), identity.Username, *result.Data.Attributes.Username)
+
 	// when
 	newEmail := "updated-" + uuid.NewV4().String() + "@email.com"
 	newFullName := "TestUpdateUserUnsetVariableInContextInfo"
@@ -294,6 +301,8 @@ func (s *TestUsersSuite) TestPatchUserContextInformation() {
 	assert.Equal(s.T(), user.ImageURL, *result.Data.Attributes.ImageURL)
 	assert.Equal(s.T(), identity.ProviderType, *result.Data.Attributes.ProviderType)
 	assert.Equal(s.T(), identity.Username, *result.Data.Attributes.Username)
+	assert.Equal(s.T(), user.Company, *result.Data.Attributes.Company)
+
 	// when
 	secureService, secureController := s.SecuredController(identity)
 
@@ -380,6 +389,7 @@ func (s *TestUsersSuite) TestShowUserOK() {
 	assert.Equal(s.T(), user.ImageURL, *result.Data.Attributes.ImageURL)
 	assert.Equal(s.T(), identity.ProviderType, *result.Data.Attributes.ProviderType)
 	assert.Equal(s.T(), identity.Username, *result.Data.Attributes.Username)
+	assert.Equal(s.T(), user.Company, *result.Data.Attributes.Company)
 }
 
 func (s *TestUsersSuite) TestListUsersOK() {
@@ -408,6 +418,7 @@ func (s *TestUsersSuite) createRandomUser(fullname string) account.User {
 		FullName: fullname,
 		ImageURL: "someURLForUpdate",
 		ID:       uuid.NewV4(),
+		Company:  uuid.NewV4().String() + "company",
 	}
 	err := s.userRepo.Create(context.Background(), &user)
 	require.Nil(s.T(), err)
@@ -443,6 +454,8 @@ func assertUser(t *testing.T, actual *app.IdentityData, expectedUser account.Use
 	assert.Equal(t, expectedUser.FullName, *actual.Attributes.FullName)
 	assert.Equal(t, expectedUser.ImageURL, *actual.Attributes.ImageURL)
 	assert.Equal(t, expectedUser.Email, *actual.Attributes.Email)
+	assert.Equal(t, expectedUser.Company, *actual.Attributes.Company)
+
 }
 
 func createUpdateUsersPayload(email, fullName, bio, imageURL, profileURL, company *string, contextInformation map[string]interface{}) *app.UpdateUsersPayload {

--- a/design/account.go
+++ b/design/account.go
@@ -179,6 +179,7 @@ var identityDataAttributes = a.Type("IdentityDataAttributes", func() {
 	a.Attribute("email", d.String, "The email")
 	a.Attribute("bio", d.String, "The bio")
 	a.Attribute("url", d.String, "The url")
+	a.Attribute("company", d.String, "The company")
 	a.Attribute("providerType", d.String, "The IDP provided this identity")
 	a.Attribute("contextInformation", a.HashOf(d.String, d.Any), "User context information of any type as a json", func() {
 		a.Example(map[string]interface{}{"last_visited_url": "https://a.openshift.io", "space": "3d6dab8d-f204-42e8-ab29-cdb1c93130ad"})

--- a/login/profile.go
+++ b/login/profile.go
@@ -15,6 +15,7 @@ import (
 const ImageURLAttributeName = "ImageURL"
 const BioAttributeName = "Bio"
 const URLAttributeName = "URL"
+const CompanyAttributeName = "Company"
 
 // KeycloakUserProfile represents standard Keycloak User profile api request payload
 type KeycloakUserProfile struct {

--- a/login/profile.go
+++ b/login/profile.go
@@ -15,7 +15,7 @@ import (
 const ImageURLAttributeName = "ImageURL"
 const BioAttributeName = "Bio"
 const URLAttributeName = "URL"
-const CompanyAttributeName = "Company"
+const CompanyAttributeName = "company"
 
 // KeycloakUserProfile represents standard Keycloak User profile api request payload
 type KeycloakUserProfile struct {

--- a/login/service.go
+++ b/login/service.go
@@ -77,6 +77,7 @@ type keycloakTokenClaims struct {
 	GivenName     string `json:"given_name"`
 	FamilyName    string `json:"family_name"`
 	Email         string `json:"email"`
+	Company       string `json:"company"`
 	SessionState  string `json:"session_state"`
 	ClientSession string `json:"client_session"`
 	jwt.StandardClaims
@@ -711,6 +712,7 @@ func checkClaims(claims *keycloakTokenClaims) error {
 func fillUser(claims *keycloakTokenClaims, user *account.User) error {
 	user.FullName = claims.Name
 	user.Email = claims.Email
+	user.Company = claims.Company
 	image, err := generateGravatarURL(claims.Email)
 	if err != nil {
 		log.Warn(nil, map[string]interface{}{

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -267,6 +267,9 @@ func getMigrations() migrations {
 	// Version 49
 	m = append(m, steps{executeSQLFile("049-add-wi-to-root-area.sql")})
 
+	// Version 50
+	m = append(m, steps{executeSQLFile("050-add-company-to-user-profile.sql")})
+
 	// Version N
 	//
 	// In order to add an upgrade, simply append an array of MigrationFunc to the

--- a/migration/sql-files/050-add-company-to-user-profile.sql
+++ b/migration/sql-files/050-add-company-to-user-profile.sql
@@ -1,0 +1,1 @@
+ alter table users add  company text;

--- a/migration/sql-files/050-add-company-to-user-profile.sql
+++ b/migration/sql-files/050-add-company-to-user-profile.sql
@@ -1,1 +1,1 @@
- alter table users add  company text;
+ALTER TABLE users ADD COLUMN company TEXT;


### PR DESCRIPTION
fixes https://github.com/almighty/almighty-core/issues/1052
- [x] Add API usage examples in PR body.



Steps to test the changes:

1. Call user update API:

```
Shoubhiks-MacBook-Pro:almighty-core shoubhikbose$ ./bin/alm-cli update users --key $ALM_TOKEN  --payload '{ "data":{ "type":"identities" ,  "attributes":{"bio":"something","company":"redhat inc " }}}'  -H localhost:8080 --pp
2017/04/10 13:38:27 [INFO] started id=tsO8VBMA PATCH=http://localhost:8080/api/users


2017/04/10 13:38:30 [INFO] completed id=tsO8VBMA status=200 time=2.48466458s
{
    "data": {
        "attributes": {
            "bio": "something",
            "company": "redhat inc ",
            "email": "smith@matrix.net",
            "fullName": "Agent Smith",
            "imageURL": "https://www.gravatar.com/avatar/0ae61af08b4d0ea5db25d6db8afbe9b9.jpg",
            "providerType": "kc",
            "url": "",
            "username": "testuser"
        },
        "id": "ad3d8a9d-3a33-40a6-afd2-1f50514388b8",
        "links": {
            "self": "http://localhost:8080/api/users/ad3d8a9d-3a33-40a6-afd2-1f50514388b8"
        },
        "type": "identities"
    }
}
```

2. Check with keycloak api to see how it looks in keycloak..

```
{
  "id": "ad3d8a9d-3a33-40a6-afd2-1f50514388b8",
  "createdTimestamp": 1490075218820,
  "username": "testuser",
  "enabled": true,
  "totp": false,
  "emailVerified": false,
  "firstName": "Agent",
  "lastName": "Smith",
  "email": "smith@matrix.net",
  "attributes": {
    "Bio": [
      "something"
    ],
    "ImageURL": [
      "https://www.gravatar.com/avatar/aefdc75fa22c3c7bd1e6d7d93f843801.jpg"
    ],
    "Company": [
      "redhat inc "
    ],
    "URL": [
      "www.google.com"
    ]
  },
  "disableableCredentialTypes": [
    "password"
  ],
  "requiredActions": [
    
  ]
}
```