### PR TITLE
BIOHAZARD WARNING - PMCD IMPLANT

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -10,10 +10,21 @@ RUN useradd --no-create-home -s /bin/bash ${ALMIGHTY_USER_NAME}
 COPY bin/alm ${ALMIGHTY_INSTALL_PREFIX}/bin/alm
 COPY config.yaml ${ALMIGHTY_INSTALL_PREFIX}/etc/config.yaml
 
+# Install little pcp pmcd server for metrics collection
+# would prefer only pmcd, and not the /bin/pm*tools etc.
+COPY pcp.repo /etc/yum.repos.d/pcp.repo
+RUN yum install -y pcp && yum clean all
+COPY ./alm+pmcd.sh /alm+pmcd.sh
+RUN chmod a+x      /alm+pmcd.sh
+RUN mkdir -p                       /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp
+RUN chown -R ${ALMIGHTY_USER_NAME} /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp
+EXPOSE 44321
+
+
 # From here onwards, any RUN, CMD, or ENTRYPOINT will be run under the following user
 USER ${ALMIGHTY_USER_NAME}
 
 WORKDIR ${ALMIGHTY_INSTALL_PREFIX}
-ENTRYPOINT [ "bin/alm" ]
+ENTRYPOINT [ "/alm+pmcd.sh" ]
 
 EXPOSE 8080

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -13,11 +13,10 @@ COPY config.yaml ${ALMIGHTY_INSTALL_PREFIX}/etc/config.yaml
 # Install little pcp pmcd server for metrics collection
 # would prefer only pmcd, and not the /bin/pm*tools etc.
 COPY pcp.repo /etc/yum.repos.d/pcp.repo
-RUN yum install -y pcp && yum clean all
+RUN yum install -y pcp && yum clean all && \
+    mkdir -p /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp && \
+    chown -R ${ALMIGHTY_USER_NAME} /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp
 COPY ./alm+pmcd.sh /alm+pmcd.sh
-RUN chmod a+x      /alm+pmcd.sh
-RUN mkdir -p                       /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp
-RUN chown -R ${ALMIGHTY_USER_NAME} /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp
 EXPOSE 44321
 
 

--- a/alm+pmcd.sh
+++ b/alm+pmcd.sh
@@ -1,0 +1,39 @@
+#! /bin/sh
+
+# Initialize a little unprivileged pcp pmcd metrics collector
+# process within this container; run this in a background subshell.
+# No special signal handling or cleanup required.
+(
+# Setup pmcd to run in unprivileged mode of operation
+. /etc/pcp.conf
+
+# Configure pmcd with a minimal set of DSO agents
+rm -f $PCP_PMCDCONF_PATH; # start empty
+echo "# Name  ID  IPC  IPC Params  File/Cmd" >> $PCP_PMCDCONF_PATH;
+echo "pmcd     2  dso  pmcd_init   $PCP_PMDAS_DIR/pmcd/pmda_pmcd.so"   >> $PCP_PMCDCONF_PATH;
+echo "proc     3  dso  proc_init   $PCP_PMDAS_DIR/proc/pmda_proc.so"   >> $PCP_PMCDCONF_PATH;
+echo "linux   60  dso  linux_init  $PCP_PMDAS_DIR/linux/pmda_linux.so" >> $PCP_PMCDCONF_PATH;
+rm -f $PCP_VAR_DIR/pmns/root_xfs $PCP_VAR_DIR/pmns/root_jbd2 $PCP_VAR_DIR/pmns/root_root $PCP_VAR_DIR/pmns/root
+touch $PCP_VAR_DIR/pmns/.NeedRebuild
+
+# allow unauthenticated access to proc.* metrics (default is false)
+export PROC_ACCESS=1
+export PMCD_ROOT_AGENT=0
+
+# NB: we can't use the rc.pmcd script.  It assumes that it's run as root.
+cd $PCP_VAR_DIR/pmns
+./Rebuild
+
+cd $PCP_LOG_DIR
+
+: "${PCP_HOSTNAME:=`hostname`}"
+# possibly: filter pod name?
+
+# We can log in plaintext to stdout also, even though ALM uses
+# JSON.  pmcd is not chatty and only speaks up during errors.
+exec /usr/libexec/pcp/bin/pmcd -l /dev/no-such-file -f -A -H $PCP_HOSTNAME
+) &
+sleep 5 # give time for pmcd's startup messages, so it doesn't intermix with ALM's
+
+
+exec bin/alm ${1+"$@"}

--- a/alm+pmcd.sh
+++ b/alm+pmcd.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -eu
+
 # Initialize a little unprivileged pcp pmcd metrics collector
 # process within this container; run this in a background subshell.
 # No special signal handling or cleanup required.

--- a/pcp.repo
+++ b/pcp.repo
@@ -1,0 +1,10 @@
+[fche-pcp]
+name=Copr repo for pcp owned by fche
+baseurl=https://copr-be.cloud.fedoraproject.org/results/fche/pcp/epel-7-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/fche/pcp/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1


### PR DESCRIPTION
Implant a performance-copilot server background process in the
almighty-core dockerfile, so that central performance monitoring
software can query process statistics.