### PR TITLE
Remove not needed check

### DIFF
--- a/workitem/workitemtype_repository.go
+++ b/workitem/workitemtype_repository.go
@@ -113,12 +113,6 @@ func (r *GormWorkItemTypeRepository) Create(ctx context.Context, spaceID uuid.UU
 		id = &tmpID
 	}
 
-	existing, _ := r.LoadTypeFromDB(ctx, *id)
-	if existing != nil {
-		log.Error(ctx, map[string]interface{}{"wit_id": *id}, "unable to create new work item type")
-		return nil, errors.NewBadParameterError("name", *id)
-	}
-
 	allFields := map[string]FieldDefinition{}
 	path := LtreeSafeID(*id)
 	if extendedTypeID != nil {


### PR DESCRIPTION
In the WIT repo's `Create()` function we checked if we can load a given work item type which is not needed IMHO. 
