### PR TITLE
Add a new ENV variable to specify the logging level

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -34,7 +34,7 @@ cachecontrol.areas: max-age=2
 cachecontrol.users: max-age=2
 cachecontrol.comments: max-age=2
 cachecontrol.filters: max-age=86400 # 1 day
-# data returned from '/api/user' must not be cached by intermediate proxies, 
+# data returned from '/api/user' must not be cached by intermediate proxies,
 # but can only be kept in the client's local cache.
 cachecontrol.user: private,max-age=2
 
@@ -44,6 +44,7 @@ cachecontrol.user: private,max-age=2
 
 # Enable development related features, e.g. token generation endpoint
 developer.mode.enabled: false
+log.level: info
 
 # Whether you want to create the common work item types such as bug, feature, ...
 populate.commontypes: true

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -83,6 +83,7 @@ const (
 	varOpenshiftTenantMasterURL         = "openshift.tenant.masterurl"
 	varCheStarterURL                    = "chestarterurl"
 	varValidRedirectURLs                = "redirect.valid"
+	varLogLevel                         = "log.level"
 )
 
 // ConfigurationData encapsulates the Viper configuration object which stores the configuration data in-memory.
@@ -162,6 +163,8 @@ func (c *ConfigurationData) setConfigDefaults() {
 
 	// Enable development related features, e.g. token generation endpoint
 	c.v.SetDefault(varDeveloperModeEnabled, false)
+
+	c.v.SetDefault(varLogLevel, "info")
 
 	c.v.SetDefault(varPopulateCommonTypes, true)
 
@@ -557,6 +560,11 @@ func (c *ConfigurationData) GetCheStarterURL() string {
 // GetOpenshiftTenantMasterURL returns the URL for the openshift cluster where the tenant services are running
 func (c *ConfigurationData) GetOpenshiftTenantMasterURL() string {
 	return c.v.GetString(varOpenshiftTenantMasterURL)
+}
+
+// GetLogLevel returns the loggging level (as set via config file or environment variable)
+func (c *ConfigurationData) GetLogLevel() string {
+	return c.v.GetString(varLogLevel)
 }
 
 // GetValidRedirectURLs returns the RegEx of valid redirect URLs for auth requests

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -164,7 +164,7 @@ func (c *ConfigurationData) setConfigDefaults() {
 	// Enable development related features, e.g. token generation endpoint
 	c.v.SetDefault(varDeveloperModeEnabled, false)
 
-	c.v.SetDefault(varLogLevel, "info")
+	c.v.SetDefault(varLogLevel, defaultLogLevel)
 
 	c.v.SetDefault(varPopulateCommonTypes, true)
 
@@ -638,6 +638,8 @@ gDDTv2JaguNwlgbHLFWU08D03j2F5Yj4TO8LexRJwCYrKp1icQrvC+WGhRAlttbx
 51MKRiCnqhFJ8LYtCbPt5Xm5+FR2fHFCMyCqQsScu+dwsx+mb4JGAsdVEaUdcmOF
 ZwIDAQAB
 -----END PUBLIC KEY-----`
+
+	defaultLogLevel = "info"
 
 	defaultKeycloakClientID = "fabric8-online-platform"
 	defaultKeycloakSecret   = "7a3d5a00-7f80-40cf-8781-b5b6f2dfd1bd"

--- a/configuration/configuration_whitebox_test.go
+++ b/configuration/configuration_whitebox_test.go
@@ -104,6 +104,26 @@ func TestKeycloakRealmInDevModeCanBeOverridden(t *testing.T) {
 	assert.Equal(t, "somecustomrealm", config.GetKeycloakRealm())
 }
 
+func TestGetLogLevelOK(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+
+	key := "ALMIGHTY_LOG_LEVEL"
+	realEnvValue := os.Getenv(key)
+
+	os.Unsetenv(key)
+	defer func() {
+		os.Setenv(key, realEnvValue)
+		resetConfiguration()
+	}()
+
+	assert.Equal(t, defaultLogLevel, config.GetLogLevel())
+
+	os.Setenv(key, "warning")
+	resetConfiguration()
+
+	assert.Equal(t, "warning", config.GetLogLevel())
+}
+
 func TestValidRedirectURLsInDevModeCanBeOverridden(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 

--- a/log/log.go
+++ b/log/log.go
@@ -19,17 +19,22 @@ var (
 
 // InitializeLogger creates a default logger whose ouput format, log level differs
 // depending of whether the developer mode flag is enable/disabled.
-func InitializeLogger(developerModeFlag bool) {
+func InitializeLogger(developerModeFlag bool, lvl string) {
 	logger = log.New()
+
+	logLevel, err := log.ParseLevel(lvl)
+	if err != nil {
+		log.Debugf("unable to parse log level configuration Error: %q", err)
+		logLevel = log.ErrorLevel // reset to ERROR
+	}
+	log.SetLevel(logLevel)
+	logger.Level = logLevel
 
 	if developerModeFlag {
 		customFormatter := new(log.TextFormatter)
 		customFormatter.FullTimestamp = true
 		customFormatter.TimestampFormat = "2006-01-02 15:04:05"
 		log.SetFormatter(customFormatter)
-
-		log.SetLevel(log.DebugLevel)
-		logger.Level = log.DebugLevel
 		logger.Formatter = customFormatter
 	} else {
 		customFormatter := new(log.JSONFormatter)
@@ -37,9 +42,6 @@ func InitializeLogger(developerModeFlag bool) {
 
 		log.SetFormatter(customFormatter)
 		customFormatter.DisableTimestamp = false
-
-		log.SetLevel(log.InfoLevel)
-		logger.Level = log.InfoLevel
 		logger.Formatter = customFormatter
 	}
 

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -13,7 +13,7 @@ func LogAndAssertJSON(t *testing.T, log func(), assertions func(fields logrus.Fi
 	var buffer bytes.Buffer
 	var fields logrus.Fields
 
-	InitializeLogger(false)
+	InitializeLogger(false, "debug")
 	logger.Out = &buffer
 	logger.Level = logrus.DebugLevel
 	log()

--- a/main.go
+++ b/main.go
@@ -78,8 +78,8 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Initialized developer mode flag for the logger
-	log.InitializeLogger(configuration.IsPostgresDeveloperModeEnabled())
+	// Initialized developer mode flag and log level for the logger
+	log.InitializeLogger(configuration.IsPostgresDeveloperModeEnabled(), configuration.GetLogLevel())
 
 	printUserInfo()
 


### PR DESCRIPTION
related to: https://github.com/almighty/almighty-core/issues/1166

Default log level would be set to `ERROR`. If we use `config.yaml` then it is set to `INFO`. 

By using an ENV variable `ALMIGHTY_LOG_LEVEL=debug|info|panic|error|warning|fatal`, you're specifying the log level.

FYI: @ldimaggi 
