### PR TITLE
unique gorm create hook name

### DIFF
--- a/gormsupport/cleaner/db_clean.go
+++ b/gormsupport/cleaner/db_clean.go
@@ -69,7 +69,7 @@ func DeleteCreatedEntities(db *gorm.DB) func() {
 			log.Info(nil, map[string]interface{}{
 				"table":    entry.table,
 				"key":      entry.key,
-				"hookName": hookName,
+				"hook_name": hookName,
 			}, "Deleting entities from %s with key %s", entry.table, entry.key)
 			tx.Table(entry.table).Where(entry.keyname+" = ?", entry.key).Delete("")
 		}

--- a/gormsupport/cleaner/db_clean.go
+++ b/gormsupport/cleaner/db_clean.go
@@ -67,8 +67,8 @@ func DeleteCreatedEntities(db *gorm.DB) func() {
 		for i := len(entires) - 1; i >= 0; i-- {
 			entry := entires[i]
 			log.Info(nil, map[string]interface{}{
-				"table":    entry.table,
-				"key":      entry.key,
+				"table":     entry.table,
+				"key":       entry.key,
 				"hook_name": hookName,
 			}, "Deleting entities from %s with key %s", entry.table, entry.key)
 			tx.Table(entry.table).Where(entry.keyname+" = ?", entry.key).Delete("")

--- a/gormsupport/cleaner/db_clean.go
+++ b/gormsupport/cleaner/db_clean.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/almighty/almighty-core/log"
 	"github.com/almighty/almighty-core/workitem"
+	uuid "github.com/satori/go.uuid"
 
 	"fmt"
 
@@ -47,6 +48,10 @@ func DeleteCreatedEntities(db *gorm.DB) func() {
 		key     interface{}
 	}
 	var entires []entity
+	hookRegistered := db.Callback().Create().Get(hookName) != nil
+	if hookRegistered {
+		hookName += "-" + uuid.NewV4().String()
+	}
 	db.Callback().Create().After("gorm:create").Register(hookName, func(scope *gorm.Scope) {
 		logrus.Debug(fmt.Sprintf("Inserted entities from %s with %s=%v", scope.TableName(), scope.PrimaryKey(), scope.PrimaryKeyValue()))
 		entires = append(entires, entity{table: scope.TableName(), keyname: scope.PrimaryKey(), key: scope.PrimaryKeyValue()})
@@ -62,8 +67,9 @@ func DeleteCreatedEntities(db *gorm.DB) func() {
 		for i := len(entires) - 1; i >= 0; i-- {
 			entry := entires[i]
 			log.Info(nil, map[string]interface{}{
-				"table": entry.table,
-				"key":   entry.key,
+				"table":    entry.table,
+				"key":      entry.key,
+				"hookName": hookName,
 			}, "Deleting entities from %s with key %s", entry.table, entry.key)
 			tx.Table(entry.table).Where(entry.keyname+" = ?", entry.key).Delete("")
 		}


### PR DESCRIPTION
This change checks if a GORM `Create` hook has already been registered under the name `"mighti:record"`. If that is the case, it will register the same hook under a different unique name. 

When you want to use `cleaner.DeleteCreatedEntries` outside of the and `*_test.go` file you need this.

For example, I want to create a temporary space and some work item types as well as work item link types, when somebody creates a space template. This is for validation purposes that the space template can be created.
Once I've created all those entries I want to get rid of them and just store the space template but no longer keep the temporary objects around. `cleaner.DeleteCreatedEntries` comes in handy here but without this change it won't work when invoked from within tests because the tests already called the function in order to clean up after them.

Consider this pseudo-code example

```go
func foo() {
  // with and without this change, the following defered call will delete d,c,b, and a which is fine.
  defer cleaner.DeleteCreatedEntries()
  a := create()
  b := create()
  bar()

func bar() {
  // without this change, the following defered call will cause objects d,c,b, and a to be deleted.
  // with this change only d and c are deleted.
  defer cleaner.DeleteCreatedEntries()
  c := create()
  d := create()
}

foo()
```
