### PR TITLE
Remove deprecated token param from 307 response URL

### DIFF
--- a/login/service.go
+++ b/login/service.go
@@ -607,7 +607,6 @@ func encodeToken(referrer *url.URL, outhToken *oauth2.Token) error {
 	}
 
 	parameters := referrer.Query()
-	parameters.Add("token", outhToken.AccessToken) // Temporary keep the old "token" param. We will drop this param as soon as UI adopt the new json param.
 	parameters.Add("token_json", string(b))
 	referrer.RawQuery = parameters.Encode()
 


### PR DESCRIPTION
Removing deprecated token param from /api/login/authorize response. We are currently using token_json only. It will help us to reduce the length of the URL
See https://github.com/almighty/almighty-core/issues/1177
