### PR TITLE
Make Search API space aware 

### DIFF
--- a/application/repositories.go
+++ b/application/repositories.go
@@ -29,5 +29,5 @@ type TrackerQueryRepository interface {
 
 // SearchRepository encapsulates searching of woritems,users,etc
 type SearchRepository interface {
-	SearchFullText(ctx context.Context, searchStr string, start *int, length *int, spaceID uuid.UUID) ([]workitem.WorkItem, uint64, error)
+	SearchFullText(ctx context.Context, searchStr string, start *int, length *int, spaceID *string) ([]workitem.WorkItem, uint64, error)
 }

--- a/application/repositories.go
+++ b/application/repositories.go
@@ -29,5 +29,5 @@ type TrackerQueryRepository interface {
 
 // SearchRepository encapsulates searching of woritems,users,etc
 type SearchRepository interface {
-	SearchFullText(ctx context.Context, searchStr string, start *int, length *int) ([]workitem.WorkItem, uint64, error)
+	SearchFullText(ctx context.Context, searchStr string, start *int, length *int, spaceID uuid.UUID) ([]workitem.WorkItem, uint64, error)
 }

--- a/controller/search.go
+++ b/controller/search.go
@@ -12,7 +12,6 @@ import (
 	"github.com/almighty/almighty-core/space"
 	"github.com/goadesign/goa"
 	errs "github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
 )
 
 type searchConfiguration interface {
@@ -41,13 +40,6 @@ func (c *SearchController) Show(ctx *app.ShowSearchContext) error {
 
 	offset, limit = computePagingLimts(ctx.PageOffset, ctx.PageLimit)
 
-	if ctx.SpaceID == nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("spaceID", nil).Expected("not nil"))
-	}
-	spaceID, conversionErr := uuid.FromString(*ctx.SpaceID)
-	if conversionErr != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("spaceID", nil).Expected("valid UUID"))
-	}
 	// ToDo : Keep URL registeration central somehow.
 	hostString := ctx.RequestData.Host
 	if hostString == "" {
@@ -60,7 +52,7 @@ func (c *SearchController) Show(ctx *app.ShowSearchContext) error {
 
 	return application.Transactional(c.db, func(appl application.Application) error {
 		//return transaction.Do(c.ts, func() error {
-		result, c, err := appl.SearchItems().SearchFullText(ctx.Context, ctx.Q, &offset, &limit, spaceID)
+		result, c, err := appl.SearchItems().SearchFullText(ctx.Context, ctx.Q, &offset, &limit, ctx.SpaceID)
 		count := int(c)
 		if err != nil {
 			cause := errs.Cause(err)

--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -368,15 +368,16 @@ func (s *searchBlackBoxTest) TestSearchWorkItemsSpaceContext() {
 	})
 
 	name2 := "Ultimate Space 2" + uuid.NewV4().String()
-	space2 := &space.Space{
-		Name: name2,
-	}
-	err2 := application.Transactional(s.db, func(app application.Application) error {
+	var space2 *space.Space
+	application.Transactional(s.db, func(app application.Application) error {
+		sp := space.Space{
+			Name: name2,
+		}
 		var err error
-		space2, err = app.Spaces().Create(context.Background(), space2)
-		return err
+		space2, err = app.Spaces().Create(context.Background(), &sp)
+		require.Nil(s.T(), err)
+		return nil
 	})
-	require.Nil(s.T(), err2)
 
 	// WI for space 1
 	for i := 0; i < 3; i++ {

--- a/design/search.go
+++ b/design/search.go
@@ -34,7 +34,7 @@ var _ = a.Resource("search", func() {
 				3) "simple keywords separated by space" :- Search in Work Items based on these keywords.`)
 			a.Param("page[offset]", d.String, "Paging start position") // #428
 			a.Param("page[limit]", d.Integer, "Paging size")
-			a.Param("spaceID", d.String, "Search within given Space ID")
+			a.Param("spaceID", d.String, "search within given Space ID if provided")
 			a.Required("q")
 		})
 		a.Response(d.OK, func() {

--- a/design/search.go
+++ b/design/search.go
@@ -34,6 +34,7 @@ var _ = a.Resource("search", func() {
 				3) "simple keywords separated by space" :- Search in Work Items based on these keywords.`)
 			a.Param("page[offset]", d.String, "Paging start position") // #428
 			a.Param("page[limit]", d.Integer, "Paging size")
+			a.Param("spaceID", d.String, "Search within given Space ID")
 			a.Required("q")
 		})
 		a.Response(d.OK, func() {

--- a/design/search.go
+++ b/design/search.go
@@ -34,7 +34,7 @@ var _ = a.Resource("search", func() {
 				3) "simple keywords separated by space" :- Search in Work Items based on these keywords.`)
 			a.Param("page[offset]", d.String, "Paging start position") // #428
 			a.Param("page[limit]", d.Integer, "Paging size")
-			a.Param("spaceID", d.String, "search within given Space ID if provided")
+			a.Param("spaceID", d.String, "The optional space ID of the space to be searched in")
 			a.Required("q")
 		})
 		a.Response(d.OK, func() {

--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -252,7 +252,7 @@ func generateSQLSearchInfo(keywords searchKeyword) (sqlParameter string) {
 
 // extracted this function from List() in order to close the rows object with "defer" for more readability
 // workaround for https://github.com/lib/pq/issues/81
-func (r *GormSearchRepository) search(ctx context.Context, sqlSearchQueryParameter string, workItemTypes []uuid.UUID, start *int, limit *int) ([]workitem.WorkItemStorage, uint64, error) {
+func (r *GormSearchRepository) search(ctx context.Context, sqlSearchQueryParameter string, workItemTypes []uuid.UUID, start *int, limit *int, spaceID uuid.UUID) ([]workitem.WorkItemStorage, uint64, error) {
 	db := r.db.Model(workitem.WorkItemStorage{}).Where("tsv @@ query")
 	if start != nil {
 		if *start < 0 {
@@ -277,6 +277,7 @@ func (r *GormSearchRepository) search(ctx context.Context, sqlSearchQueryParamet
 
 	db = db.Select("count(*) over () as cnt2 , *")
 	db = db.Joins(", to_tsquery('english', ?) as query, ts_rank(tsv, query) as rank", sqlSearchQueryParameter)
+	db = db.Where("space_id=?", spaceID)
 	db = db.Order(fmt.Sprintf("rank desc,%s.updated_at desc", workitem.WorkItemStorage{}.TableName()))
 
 	rows, err := db.Rows()
@@ -323,7 +324,7 @@ func (r *GormSearchRepository) search(ctx context.Context, sqlSearchQueryParamet
 }
 
 // SearchFullText Search returns work items for the given query
-func (r *GormSearchRepository) SearchFullText(ctx context.Context, rawSearchString string, start *int, limit *int) ([]workitem.WorkItem, uint64, error) {
+func (r *GormSearchRepository) SearchFullText(ctx context.Context, rawSearchString string, start *int, limit *int, spaceID uuid.UUID) ([]workitem.WorkItem, uint64, error) {
 	// parse
 	// generateSearchQuery
 	// ....
@@ -334,7 +335,7 @@ func (r *GormSearchRepository) SearchFullText(ctx context.Context, rawSearchStri
 
 	sqlSearchQueryParameter := generateSQLSearchInfo(parsedSearchDict)
 	var rows []workitem.WorkItemStorage
-	rows, count, err := r.search(ctx, sqlSearchQueryParameter, parsedSearchDict.workItemTypes, start, limit)
+	rows, count, err := r.search(ctx, sqlSearchQueryParameter, parsedSearchDict.workItemTypes, start, limit, spaceID)
 	if err != nil {
 		return nil, 0, errs.WithStack(err)
 	}

--- a/search/search_repository_blackbox_test.go
+++ b/search/search_repository_blackbox_test.go
@@ -63,7 +63,7 @@ func (s *searchRepositoryBlackboxTest) TestRestrictByType() {
 	params := url.Values{}
 	ctx := goa.NewContext(context.Background(), nil, req, params)
 
-	res, count, err := s.searchRepo.SearchFullText(ctx, "TestRestrictByType", nil, nil)
+	res, count, err := s.searchRepo.SearchFullText(ctx, "TestRestrictByType", nil, nil, nil)
 	require.Nil(s.T(), err)
 	require.True(s.T(), count == uint64(len(res))) // safety check for many, many instances of bogus search results.
 	for _, wi := range res {
@@ -100,37 +100,37 @@ func (s *searchRepositoryBlackboxTest) TestRestrictByType() {
 	require.Nil(s.T(), err)
 	require.NotNil(s.T(), wi2)
 
-	res, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType", nil, nil)
+	res, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType", nil, nil, nil)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), uint64(2), count)
 
-	res, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType type:"+sub1.ID.String(), nil, nil)
+	res, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType type:"+sub1.ID.String(), nil, nil, nil)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), uint64(1), count)
 	if count == 1 {
 		assert.Equal(s.T(), wi1.ID, res[0].ID)
 	}
 
-	res, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType type:"+sub2.ID.String(), nil, nil)
+	res, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType type:"+sub2.ID.String(), nil, nil, nil)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), uint64(1), count)
 	if count == 1 {
 		assert.Equal(s.T(), wi2.ID, res[0].ID)
 	}
 
-	_, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType type:"+base.ID.String(), nil, nil)
+	_, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType type:"+base.ID.String(), nil, nil, nil)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), uint64(2), count)
 
-	_, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType type:"+sub2.ID.String()+" type:"+sub1.ID.String(), nil, nil)
+	_, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType type:"+sub2.ID.String()+" type:"+sub1.ID.String(), nil, nil, nil)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), uint64(2), count)
 
-	_, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType type:"+base.ID.String()+" type:"+sub1.ID.String(), nil, nil)
+	_, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType type:"+base.ID.String()+" type:"+sub1.ID.String(), nil, nil, nil)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), uint64(2), count)
 
-	_, count, err = s.searchRepo.SearchFullText(ctx, "TRBTgorxi type:"+base.ID.String(), nil, nil)
+	_, count, err = s.searchRepo.SearchFullText(ctx, "TRBTgorxi type:"+base.ID.String(), nil, nil, nil)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), uint64(0), count)
 }

--- a/search/search_repository_whitebox_test.go
+++ b/search/search_repository_whitebox_test.go
@@ -187,7 +187,7 @@ func (s *searchRepositoryWhiteboxTest) TestSearchByText() {
 			s.T().Log("using search string: " + searchString)
 			sr := NewGormSearchRepository(tx)
 			var start, limit int = 0, 100
-			workItemList, _, err := sr.SearchFullText(ctx, searchString, &start, &limit)
+			workItemList, _, err := sr.SearchFullText(ctx, searchString, &start, &limit, nil)
 			if err != nil {
 				s.T().Fatal("Error getting search result ", err)
 			}
@@ -294,7 +294,7 @@ func (s *searchRepositoryWhiteboxTest) TestSearchByID() {
 
 		var start, limit int = 0, 100
 		searchString := "id:" + createdWorkItem.ID
-		workItemList, _, err := sr.SearchFullText(ctx, searchString, &start, &limit)
+		workItemList, _, err := sr.SearchFullText(ctx, searchString, &start, &limit, nil)
 		if err != nil {
 			s.T().Fatal("Error gettig search result ", err)
 		}


### PR DESCRIPTION
Fixes #1169 

Search API takes a `spaceID` as query param to contextualize the search results.
If not passed `spaceID` then searching will not be affected.
Tests added/updated.
