### PR TITLE
Don't dereference before checking for NotNil

### DIFF
--- a/controller/space_test.go
+++ b/controller/space_test.go
@@ -395,20 +395,20 @@ func (rest *TestSpaceREST) TestShowSpaceNotModifiedUsingIfNoneMatchHeader() {
 	assert.Equal(t, *created.Data.Attributes.Version, *fetched.Data.Attributes.Version)
 
 	// verify list-WI URL exists in Relationships.Links
-	require.NotNil(t, *fetched.Data.Relationships.Workitems)
-	require.NotNil(t, *fetched.Data.Relationships.Workitems.Links)
-	require.NotNil(t, *fetched.Data.Relationships.Workitems.Links.Related)
+	require.NotNil(t, fetched.Data.Relationships.Workitems)
+	require.NotNil(t, fetched.Data.Relationships.Workitems.Links)
+	require.NotNil(t, fetched.Data.Relationships.Workitems.Links.Related)
 	subStringWI := fmt.Sprintf("/%s/workitems", created.Data.ID.String())
 	assert.Contains(t, *fetched.Data.Relationships.Workitems.Links.Related, subStringWI)
 
 	// verify list-WIT URL exists in Relationships.Links
-	require.NotNil(t, *fetched.Data.Links)
+	require.NotNil(t, fetched.Data.Links)
 	require.NotNil(t, fetched.Data.Links.Workitemtypes)
 	subStringWIL := fmt.Sprintf("/%s/workitemtypes", created.Data.ID.String())
 	assert.Contains(t, *fetched.Data.Links.Workitemtypes, subStringWIL)
 
 	// verify list-WILT URL exists in Relationships.Links
-	require.NotNil(t, *fetched.Data.Links)
+	require.NotNil(t, fetched.Data.Links)
 	require.NotNil(t, fetched.Data.Links.Workitemlinktypes)
 	subStringWILT := fmt.Sprintf("/%s/workitemlinktypes", created.Data.ID.String())
 	assert.Contains(t, *fetched.Data.Links.Workitemlinktypes, subStringWILT)


### PR DESCRIPTION
Correct me if I'm wrong but those tests look wrong to me, You dereference a point and check if the result is NotNil. The check should be done before dereferencing, no?

https://github.com/almighty/almighty-core/blame/master/controller/space_test.go#L398