### PR TITLE
Don't swap access tokens for too big rpt tokens when refreshing

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -20,6 +20,7 @@ postgres.connection.maxopen: -1
 #------------------------
 
 http.address: 0.0.0.0:8080
+#header.maxlength: 10240 # bytes
 
 #------------------------
 # HTTP Cache-Control

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -68,6 +68,7 @@ const (
 	varKeycloakEndpointLogout           = "keycloak.endpoint.logout"
 	varTokenPublicKey                   = "token.publickey"
 	varTokenPrivateKey                  = "token.privatekey"
+	varHeaderMaxLength                  = "header.maxlength"
 	varCacheControlWorkItems            = "cachecontrol.workitems"
 	varCacheControlWorkItemTypes        = "cachecontrol.workitemtypes"
 	varCacheControlWorkItemLinks        = "cachecontrol.workitemLinks"
@@ -156,6 +157,7 @@ func (c *ConfigurationData) setConfigDefaults() {
 	// HTTP
 	//-----
 	c.v.SetDefault(varHTTPAddress, "0.0.0.0:8080")
+	c.v.SetDefault(varHeaderMaxLength, defaultHeaderMaxLength)
 
 	//-----
 	// Misc
@@ -275,6 +277,12 @@ func (c *ConfigurationData) GetPopulateCommonTypes() bool {
 // that the alm server binds to (e.g. "0.0.0.0:8080")
 func (c *ConfigurationData) GetHTTPAddress() string {
 	return c.v.GetString(varHTTPAddress)
+}
+
+// GetHeaderMaxLength returns the max length of HTTP headers allowed in the system
+// For example it can be used to limit the size of bearer tokens returned by the api service
+func (c *ConfigurationData) GetHeaderMaxLength() int64 {
+	return c.v.GetInt64(varHeaderMaxLength)
 }
 
 // IsPostgresDeveloperModeEnabled returns if development related features (as set via default, config file, or environment variable),
@@ -595,6 +603,8 @@ func (c *ConfigurationData) checkLocalhostRedirectException(req *goa.RequestData
 }
 
 const (
+	defaultHeaderMaxLength = 5000 // bytes
+
 	// Auth-related defaults
 
 	// RSAPrivateKey for signing JWT Tokens

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -3,10 +3,13 @@ package configuration_test
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
 	"net/http"
+
+	"time"
 
 	"github.com/almighty/almighty-core/configuration"
 	"github.com/almighty/almighty-core/resource"
@@ -213,7 +216,7 @@ func checkGetKeycloakEndpointOK(t *testing.T, expectedEndpoint string, getEndpoi
 }
 
 func TestGetTokenPrivateKeyFromConfigFile(t *testing.T) {
-
+	resource.Require(t, resource.UnitTest)
 	envKey := generateEnvKey(varTokenPrivateKey)
 	realEnvValue := os.Getenv(envKey) // could be "" as well.
 
@@ -235,7 +238,7 @@ func TestGetTokenPrivateKeyFromConfigFile(t *testing.T) {
 }
 
 func TestGetTokenPublicKeyFromConfigFile(t *testing.T) {
-
+	resource.Require(t, resource.UnitTest)
 	envKey := generateEnvKey(varTokenPublicKey)
 	realEnvValue := os.Getenv(envKey) // could be "" as well.
 
@@ -255,6 +258,31 @@ func TestGetTokenPublicKeyFromConfigFile(t *testing.T) {
 	parsedKey, err := jwt.ParseRSAPublicKeyFromPEM(viperValue)
 	require.Nil(t, err)
 	assert.NotNil(t, parsedKey)
+}
+
+func TestGetMaxHeaderSizeUsingDefaults(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	viperValue := config.GetHeaderMaxLength()
+	require.NotNil(t, viperValue)
+	assert.Equal(t, int64(5000), viperValue)
+}
+
+func TestGetMaxHeaderSizeSetByEnvVaribaleOK(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	envName := "ALMIGHTY_HEADER_MAXLENGTH"
+	envValue := time.Now().Unix()
+	env := os.Getenv(envName)
+	defer func() {
+		os.Setenv(envName, env)
+		resetConfiguration(defaultValuesConfigFilePath)
+	}()
+
+	os.Setenv(envName, strconv.FormatInt(envValue, 10))
+	resetConfiguration(defaultValuesConfigFilePath)
+
+	viperValue := config.GetHeaderMaxLength()
+	require.NotNil(t, viperValue)
+	assert.Equal(t, envValue, viperValue)
 }
 
 func generateEnvKey(yamlKey string) string {

--- a/controller/login.go
+++ b/controller/login.go
@@ -23,6 +23,12 @@ import (
 	"github.com/goadesign/goa"
 )
 
+const (
+	// Max lenght of an rpt token.
+	// The token longer than that can cause 400s responsed if used as a Bearer in http requests because of header size limit.
+	maxRPTLenght = 5000
+)
+
 type loginConfiguration interface {
 	GetKeycloakEndpointAuth(*goa.RequestData) (string, error)
 	GetKeycloakEndpointToken(*goa.RequestData) (string, error)
@@ -163,8 +169,9 @@ func (c *LoginController) Refresh(ctx *app.RefreshLoginContext) error {
 		}, "failed to obtain entitlement during login")
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrInternal(err.Error()))
 	}
-	if rpt != nil {
-		// Swap access token and rpt which contains all resources available to the user
+	if rpt != nil && len(*rpt) < maxRPTLenght {
+		// If the rpt token is not too long for using it as a Bearer in http requests because of header size limit
+		// the swap access token for the rpt token which contains all resources available to the user
 		token.AccessToken = rpt
 	}
 


### PR DESCRIPTION
This is a workaround of the OS limit of using long http headers.
If an RPT token is too big then we should issue a new access token when refreshing instead of a new RPT token.

We would need to merge it if we can't solve this problem on the OS side. The OS header limit problem is being currently investigated.