### PR TITLE
Add tenant service call from /api/user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ swagger/
 tool/cli/
 migration/sqlbindata.go
 migration/sqlbindata_test.go
+account/tenant
 
 # Ignore artifacts directory
 bin/

--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,7 @@ clean-generated:
 	-rm -f ./bindata_assetfs.go
 	-rm -f ./migration/sqlbindata.go
 	-rm -f ./migration/sqlbindata_test.go
+	-rm -f ./account/tenant
 
 CLEAN_TARGETS += clean-vendor
 .PHONY: clean-vendor
@@ -221,6 +222,7 @@ app/controllers.go: $(DESIGNS) $(GOAGEN_BIN) $(VENDOR_DIR)
 	$(GOAGEN_BIN) gen -d ${PACKAGE_NAME}/${DESIGN_DIR} --pkg-path=${PACKAGE_NAME}/goasupport/helper_function --out app
 	$(GOAGEN_BIN) client -d ${PACKAGE_NAME}/${DESIGN_DIR}
 	$(GOAGEN_BIN) swagger -d ${PACKAGE_NAME}/${DESIGN_DIR}
+	$(GOAGEN_BIN) client -d github.com/fabric8io/fabric8-init-tenant/design --notool --pkg tenant -o account
 
 
 assets/js/client.js: $(DESIGNS) $(GOAGEN_BIN) $(VENDOR_DIR)

--- a/account/init_tenant.go
+++ b/account/init_tenant.go
@@ -1,0 +1,45 @@
+package account
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+
+	"net/url"
+
+	"github.com/almighty/almighty-core/account/tenant"
+	"github.com/almighty/almighty-core/goasupport"
+	goaclient "github.com/goadesign/goa/client"
+)
+
+type tenantConfig interface {
+	GetTenantServiceURL() string
+}
+
+// NewInitTenant creates a new tenant service in oso
+func NewInitTenant(config tenantConfig) func(context.Context) error {
+	return func(ctx context.Context) error {
+		return InitTenant(ctx, config)
+	}
+}
+
+// InitTenant creates a new tenant service in oso
+func InitTenant(ctx context.Context, config tenantConfig) error {
+
+	u, err := url.Parse(config.GetTenantServiceURL())
+	if err != nil {
+		return err
+	}
+
+	c := tenant.New(goaclient.HTTPClientDoer(http.DefaultClient))
+	c.Host = u.Host
+	c.Scheme = u.Scheme
+	c.SetJWTSigner(goasupport.NewForwardSigner(ctx))
+
+	// Ignore response for now
+	_, err = c.SetupTenant(ctx, tenant.SetupTenantPath())
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -85,6 +85,7 @@ const (
 	varCheStarterURL                    = "chestarterurl"
 	varValidRedirectURLs                = "redirect.valid"
 	varLogLevel                         = "log.level"
+	varTenantServiceURL                 = "tenant.serviceurl"
 )
 
 // ConfigurationData encapsulates the Viper configuration object which stores the configuration data in-memory.
@@ -602,6 +603,11 @@ func (c *ConfigurationData) checkLocalhostRedirectException(req *goa.RequestData
 	return DefaultValidRedirectURLs, nil
 }
 
+// GetTenantServiceURL returns the URL for the Tenant service used by login to initialize OSO tenant space
+func (c *ConfigurationData) GetTenantServiceURL() string {
+	return c.v.GetString(varTenantServiceURL)
+}
+
 const (
 	defaultHeaderMaxLength = 5000 // bytes
 
@@ -680,6 +686,7 @@ ZwIDAQAB
 	// Allow redirects to localhost when running in prod-preveiw
 	localhostRedirectURLs      = "(" + DefaultValidRedirectURLs + "|^(https|http)://([^/]+[.])?(localhost|127[.]0[.]0[.]1)(:\\d+)?(/.*)?$)" // *.openshift.io/* or localhost/* or 127.0.0.1/*
 	localhostRedirectException = "^(https|http)://([^/]+[.])?(?i:prod-preview[.]openshift[.]io)(:\\d+)?(/.*)?$"                             // *.prod-preview.openshift.io/*
+
 )
 
 // ActualToken is actual OAuth access token of github

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 2a169f03a0cb6842708fa61ee7be28abc174b2a1f6cdc0ad528a71f441f01eaf
-updated: 2017-03-11T22:29:26.961341809+01:00
+hash: 3e9f1b6af7274e8d50e57500f92f1374c63cce5e765993d8649e03350936560c
+updated: 2017-04-17T23:07:16.622277679+02:00
 imports:
 - name: bitbucket.org/pkg/inflect
   version: 8961c3750a47b8c0b3e118d52513b97adf85a7e8
@@ -26,12 +26,16 @@ imports:
 - name: github.com/dnaeon/go-vcr
   version: 9d71b8a6df86e00127f96bc8dabc09856ab8afdb
   subpackages:
-  - recorder
   - cassette
+  - recorder
 - name: github.com/elazarl/go-bindata-assetfs
   version: 9a6736ed45b44bf3835afeebb3034b57ed329f3e
   subpackages:
   - go-bindata-assetfs
+- name: github.com/fabric8io/fabric8-init-tenant
+  version: e492aecc52e027cfc9958e8d6085ca6fac039964
+  subpackages:
+  - design
 - name: github.com/fatih/structs
   version: dc3312cb1a4513a366c4c9e622ad55c32df12ed3
 - name: github.com/fsnotify/fsnotify
@@ -46,18 +50,19 @@ imports:
   - cors
   - design
   - design/apidsl
+  - dslengine
   - goagen
   - goagen/codegen
   - goagen/gen_app
   - goagen/gen_controller
   - goagen/utils
   - goatest
-  - middleware
-  - middleware/security/jwt
   - logging/logrus
+  - middleware
   - middleware/gzip
+  - middleware/security/jwt
   - uuid
-  - dslengine
+  - version
 - name: github.com/golang/lint
   version: c7bacac2b21ca01afa1dee0acf64df3ce047c28f
   subpackages:
@@ -79,10 +84,10 @@ imports:
   subpackages:
   - hcl/ast
   - hcl/parser
-  - hcl/token
-  - json/parser
   - hcl/scanner
   - hcl/strconv
+  - hcl/token
+  - json/parser
   - json/scanner
   - json/token
 - name: github.com/howeyc/fsnotify
@@ -108,13 +113,13 @@ imports:
 - name: github.com/lsegal/gucumber
   version: 71608e2f6e76fd4da5b09a376aeec7a5c0b5edbc
 - name: github.com/magiconair/properties
-  version: c265cfa48dda6474e208715ca93e987829f572f8
+  version: f917359f079a3759162704eaa8caeec3d01d9f91
 - name: github.com/manveru/faker
   version: 717f7cf83fb78669bfab612749c2e8ff63d5be11
 - name: github.com/mattn/go-colorable
   version: d228849504861217f796da67fae4f6e347643f15
 - name: github.com/mattn/go-isatty
-  version: 3a115632dcd687f9c8cd01679c83a06a0e21c1f3
+  version: fc9e8d8ef48496124e79ae0df75490096eccf6fe
 - name: github.com/microcosm-cc/bluemonday
   version: e79763773ab6222ca1d5a7cbd9d62d83c1f77081
 - name: github.com/mitchellh/mapstructure
@@ -165,8 +170,8 @@ imports:
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
-  - suite
   - require
+  - suite
 - name: github.com/trivago/tgo
   version: 4a656addb20609ba4cb4d20219a2f6c27aeb142c
   subpackages:
@@ -179,9 +184,9 @@ imports:
   version: b1a2d6e8c8b5fc8f601ead62536f02a8e1b6217d
   subpackages:
   - context
-  - websocket
   - html
   - html/atom
+  - websocket
 - name: golang.org/x/oauth2
   version: da3ce8d62a7f77aadfda06cb82bd604d6469c645
   subpackages:
@@ -202,13 +207,13 @@ imports:
 - name: google.golang.org/appengine
   version: ca59ef35f409df61fa4a5f8290ff289b37eccfb8
   subpackages:
-  - urlfetch
   - internal
-  - internal/urlfetch
   - internal/base
   - internal/datastore
   - internal/log
   - internal/remote_api
+  - internal/urlfetch
+  - urlfetch
 - name: gopkg.in/asaskevich/govalidator.v4
   version: 7664702784775e51966f0885f5cd27435916517b
 - name: gopkg.in/yaml.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,6 +2,9 @@ package: github.com/almighty/almighty-core
 homepage: https://github.com/almighty/almighty-core
 license: Apache-2.0
 import:
+- package: github.com/fabric8io/fabric8-init-tenant
+  subpackages:
+  - design
 - package: github.com/dgrijalva/jwt-go
   version: ^3.0.0
 - package: github.com/goadesign/goa

--- a/goasupport/forward_signer.go
+++ b/goasupport/forward_signer.go
@@ -1,0 +1,25 @@
+package goasupport
+
+import (
+	"context"
+	"net/http"
+
+	goaclient "github.com/goadesign/goa/client"
+	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+)
+
+// ForwardSigner reuse Token from caller and forward to target Request
+type forwardSigner struct {
+	token string
+}
+
+// Sign set the Auth header
+func (f forwardSigner) Sign(request *http.Request) error {
+	request.Header.Set("Authorization", "Bearer "+f.token)
+	return nil
+}
+
+// NewForwardSigner return a new signer based on curret context
+func NewForwardSigner(ctx context.Context) goaclient.Signer {
+	return &forwardSigner{token: goajwt.ContextJWT(ctx).Raw}
+}

--- a/main.go
+++ b/main.go
@@ -237,6 +237,10 @@ func main() {
 
 	// Mount "user" controller
 	userCtrl := controller.NewUserController(service, appDB, tokenManager)
+	if configuration.GetTenantServiceURL() != "" {
+		log.Logger().Infof("Enabling Init Tenant service %v", configuration.GetTenantServiceURL())
+		userCtrl.InitTenant = account.NewInitTenant(configuration)
+	}
 	app.MountUserController(service, userCtrl)
 
 	// Mount "search" controller


### PR DESCRIPTION
Due to lack of 'in linking flow' location to call init tenant
it's currently being done as part of the /api/user call which
is the first call that is done from the UI after linking is done.

First call to tenant service will start the initialize process
while all other will return a Conflict error which is ignored.
