### PR TITLE
use, if available a location for tenant services

### DIFF
--- a/openshift/core.app.yaml
+++ b/openshift/core.app.yaml
@@ -80,6 +80,11 @@ objects:
               configMapKeyRef:
                 name: core
                 key: postgres.connection.maxopen
+          - name: ALMIGHTY_TENANT_SERVICEURL
+            valueFrom:
+              secretKeyRef:
+                name: core
+                key: tenantsvc.url
           - name: ALMIGHTY_CHESTARTERURL
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
if its set, then use the tenant init service locally