### PR TITLE
Fix the "list spaces" test 

### DIFF
--- a/space/space_test.go
+++ b/space/space_test.go
@@ -103,11 +103,14 @@ func (test *repoBBTest) TestDelete() {
 }
 
 func (test *repoBBTest) TestList() {
+	// given
 	_, orgCount, _ := test.list(nil, nil)
 	newSpace, err := expectSpace(test.create(testSpace), test.requireOk)
 
 	require.Nil(test.T(), err)
 	require.NotNil(test.T(), newSpace)
+
+	// when
 	updatedListOfSpaces, newCount, _ := test.list(nil, nil)
 
 	assert.True(test.T(), newCount > orgCount)
@@ -118,6 +121,7 @@ func (test *repoBBTest) TestList() {
 			foundNewSpaceInList = true
 		}
 	}
+	// then
 	assert.True(test.T(), foundNewSpaceInList)
 }
 

--- a/space/space_test.go
+++ b/space/space_test.go
@@ -1,6 +1,7 @@
 package space_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/almighty/almighty-core/errors"
@@ -113,7 +114,7 @@ func (test *repoBBTest) TestList() {
 	// when
 	updatedListOfSpaces, newCount, _ := test.list(nil, nil)
 
-	assert.True(test.T(), newCount > orgCount)
+	test.T().Log(fmt.Sprintf("Old count of spaces : %d , new count of spaces : %d", orgCount, newCount))
 
 	foundNewSpaceInList := false
 	for _, retrievedSpace := range updatedListOfSpaces {

--- a/space/space_test.go
+++ b/space/space_test.go
@@ -104,9 +104,21 @@ func (test *repoBBTest) TestDelete() {
 
 func (test *repoBBTest) TestList() {
 	_, orgCount, _ := test.list(nil, nil)
-	expectSpace(test.create(testSpace), test.requireOk)
-	_, newCount, _ := test.list(nil, nil)
-	assert.Equal(test.T(), orgCount+1, newCount)
+	newSpace, err := expectSpace(test.create(testSpace), test.requireOk)
+
+	require.Nil(test.T(), err)
+	require.NotNil(test.T(), newSpace)
+	updatedListOfSpaces, newCount, _ := test.list(nil, nil)
+
+	assert.True(test.T(), newCount > orgCount)
+
+	foundNewSpaceInList := false
+	for _, retrievedSpace := range updatedListOfSpaces {
+		if retrievedSpace.ID == newSpace.ID {
+			foundNewSpaceInList = true
+		}
+	}
+	assert.True(test.T(), foundNewSpaceInList)
 }
 
 func (test *repoBBTest) TestListDoNotReturnPointerToSameObject() {


### PR DESCRIPTION
Check for presence of the space in the list instead of merely the length of the list.

Before this change, this is what the error looked like:

```
--- FAIL: TestList (0.01s)
	space_test.go:110: Old count of spaces : 2 , new count of spaces : 5
	assertions.go:241: 
                        
	Error Trace:	space_test.go:111
		
	Error:		Not equal: 0x3 (expected)
			        != 0x5 (actual)
```

https://ci.centos.org/job/devtools-almighty-core/3020/console