### PR TITLE
API to list WIs without any parents

### DIFF
--- a/controller/planner_backlog.go
+++ b/controller/planner_backlog.go
@@ -130,7 +130,7 @@ func getBacklogItems(ctx context.Context, db application.DB, spaceID uuid.UUID, 
 	err = application.Transactional(db, func(appl application.Application) error {
 		// Get the list of work items for the following criteria
 		var tc uint64
-		result, tc, err = appl.WorkItems().List(ctx, spaceID, backlogExp, offset, limit)
+		result, tc, err = appl.WorkItems().List(ctx, spaceID, backlogExp, nil, offset, limit)
 		count = int(tc)
 		if err != nil {
 			return errs.Wrap(err, "error listing backlog items")

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -111,7 +111,7 @@ func (c *WorkitemController) List(ctx *app.ListWorkitemContext) error {
 
 	offset, limit := computePagingLimts(ctx.PageOffset, ctx.PageLimit)
 	return application.Transactional(c.db, func(tx application.Application) error {
-		workitems, tc, err := tx.WorkItems().List(ctx.Context, spaceID, exp, &offset, &limit)
+		workitems, tc, err := tx.WorkItems().List(ctx.Context, spaceID, exp, ctx.FilterParentexists, &offset, &limit)
 		count := int(tc)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "Error listing work items"))

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -2261,10 +2261,21 @@ func convertWorkItemToConditionalResponseEntity(appWI app.WorkItemSingle) app.Co
 }
 
 func (s *workItemChildSuite) TestWorkItemListFilterByNoParents() {
-	_, result := test.ListWorkitemOK(s.T(), nil, nil, s.workItemCtrl, s.userSpaceID.String(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
-	assert.Len(s.T(), result.Data, 3)
+	s.T().Run("without parentexists filter", func(t *testing.T) {
+		_, result := test.ListWorkitemOK(t, nil, nil, s.workItemCtrl, s.userSpaceID.String(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		assert.Len(t, result.Data, 3)
+	})
 
-	pe := false
-	_, result2 := test.ListWorkitemOK(s.T(), nil, nil, s.workItemCtrl, s.userSpaceID.String(), nil, nil, nil, nil, &pe, nil, nil, nil, nil, nil, nil)
-	assert.Len(s.T(), result2.Data, 1)
+	s.T().Run("with parentexists value set to false", func(t *testing.T) {
+		pe := false
+		_, result2 := test.ListWorkitemOK(t, nil, nil, s.workItemCtrl, s.userSpaceID.String(), nil, nil, nil, nil, &pe, nil, nil, nil, nil, nil, nil)
+		assert.Len(t, result2.Data, 1)
+	})
+
+	s.T().Run("with parentexists value set to true", func(t *testing.T) {
+		pe := true
+		_, result2 := test.ListWorkitemOK(t, nil, nil, s.workItemCtrl, s.userSpaceID.String(), nil, nil, nil, nil, &pe, nil, nil, nil, nil, nil, nil)
+		assert.Len(t, result2.Data, 3)
+	})
+
 }

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -350,14 +350,14 @@ func (s *WorkItemSuite) TestListByFields() {
 	filter := "{\"system.title\":\"run integration test\"}"
 	offset := "0"
 	limit := 1
-	_, result := test.ListWorkitemOK(s.T(), nil, nil, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &filter, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result := test.ListWorkitemOK(s.T(), nil, nil, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &filter, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	// then
 	require.NotNil(s.T(), result)
 	require.Equal(s.T(), 1, len(result.Data))
 	// when
 	filter = fmt.Sprintf("{\"system.creator\":\"%s\"}", s.testIdentity.ID.String())
 	// then
-	_, result = test.ListWorkitemOK(s.T(), nil, nil, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &filter, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result = test.ListWorkitemOK(s.T(), nil, nil, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &filter, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	require.NotNil(s.T(), result)
 	require.Equal(s.T(), 1, len(result.Data))
 }
@@ -507,7 +507,7 @@ func createPagingTest(t *testing.T, ctx context.Context, controller *WorkitemCon
 		repo.ListReturns(makeWorkItems(count), uint64(totalCount), nil)
 		offset := strconv.Itoa(start)
 
-		_, response := test.ListWorkitemOK(t, ctx, nil, controller, spaceID, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+		_, response := test.ListWorkitemOK(t, ctx, nil, controller, spaceID, nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 		assertLink(t, "first", first, response.Links.First)
 		assertLink(t, "last", last, response.Links.Last)
 		assertLink(t, "prev", prev, response.Links.Prev)
@@ -1220,7 +1220,7 @@ func (s *WorkItem2Suite) TestWI2ListByAssigneeFilter() {
 	assert.Len(s.T(), wi.Data.Relationships.Assignees.Data, 1)
 	assert.Equal(s.T(), newUser.ID.String(), *wi.Data.Relationships.Assignees.Data[0].ID)
 	newUserID := newUser.ID.String()
-	_, list := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), nil, nil, &newUserID, nil, nil, nil, nil, nil, nil, nil)
+	_, list := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), nil, nil, &newUserID, nil, nil, nil, nil, nil, nil, nil, nil)
 	assert.Len(s.T(), list.Data, 1)
 	assert.Equal(s.T(), newUser.ID.String(), *list.Data[0].Relationships.Assignees.Data[0].ID)
 	assert.True(s.T(), strings.Contains(*list.Links.First, "filter[assignee]"))
@@ -1238,7 +1238,7 @@ func (s *WorkItem2Suite) TestWI2ListByWorkitemtypeFilter() {
 	assert.NotNil(s.T(), expected.Data)
 	require.NotNil(s.T(), expected.Data.ID)
 	require.NotNil(s.T(), expected.Data.Type)
-	_, actual := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), nil, nil, nil, nil, nil, &workitem.SystemBug, nil, nil, nil, nil)
+	_, actual := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, &workitem.SystemBug, nil, nil, nil, nil)
 	require.NotNil(s.T(), actual)
 	require.True(s.T(), len(actual.Data) > 1)
 	assert.Contains(s.T(), *actual.Links.First, fmt.Sprintf("filter[workitemtype]=%s", workitem.SystemBug))
@@ -1271,7 +1271,7 @@ func (s *WorkItem2Suite) TestWI2ListByWorkitemstateFilter() {
 	dataArray = append(dataArray, expected)
 	wiNew := workitem.SystemStateNew
 	// var foundExpected bool
-	_, actual := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), nil, nil, nil, nil, &wiNew, nil, nil, nil, nil, nil)
+	_, actual := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), nil, nil, nil, nil, nil, &wiNew, nil, nil, nil, nil, nil)
 
 	require.NotNil(s.T(), actual)
 	require.True(s.T(), len(actual.Data) > 1)
@@ -1323,7 +1323,7 @@ func (s *WorkItem2Suite) TestWI2ListByAreaFilterOK() {
 	// given
 	spaceID, areaID, _ := s.setupAreaWorkItem(true)
 	// when
-	res, workitems := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, spaceID, nil, &areaID, nil, nil, nil, nil, nil, nil, nil, nil)
+	res, workitems := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, spaceID, nil, &areaID, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	// then
 	assertAreaWorkItems(s.T(), areaID, workitems)
 	assertResponseHeaders(s.T(), res)
@@ -1333,7 +1333,7 @@ func (s *WorkItem2Suite) TestWI2ListByAreaFilterOKEmptyList() {
 	// given
 	spaceID, areaID, _ := s.setupAreaWorkItem(false)
 	// when
-	res, workitems := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, spaceID, nil, &areaID, nil, nil, nil, nil, nil, nil, nil, nil)
+	res, workitems := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, spaceID, nil, &areaID, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	// then
 	require.NotNil(s.T(), *workitems)
 	require.Empty(s.T(), workitems.Data)
@@ -1349,7 +1349,7 @@ func (s *WorkItem2Suite) TestWI2ListByAreaFilterOKUsingExpiredIfModifiedSinceHea
 	// when
 	updatedAt := wi.Data.Attributes[workitem.SystemUpdatedAt].(time.Time)
 	ifModifiedSince := app.ToHTTPTime(updatedAt.Add(-1 * time.Hour))
-	res, workitems := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, spaceID, nil, &areaID, nil, nil, nil, nil, nil, nil, &ifModifiedSince, nil)
+	res, workitems := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, spaceID, nil, &areaID, nil, nil, nil, nil, nil, nil, nil, &ifModifiedSince, nil)
 	// then
 	assertAreaWorkItems(s.T(), areaID, workitems)
 	assertResponseHeaders(s.T(), res)
@@ -1360,7 +1360,7 @@ func (s *WorkItem2Suite) TestWI2ListByAreaFilterOKUsingExpiredIfNoneMatchHeader(
 	spaceID, areaID, _ := s.setupAreaWorkItem(true)
 	// when
 	ifNoneMatch := "foo"
-	res, workitems := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, spaceID, nil, &areaID, nil, nil, nil, nil, nil, nil, nil, &ifNoneMatch)
+	res, workitems := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, spaceID, nil, &areaID, nil, nil, nil, nil, nil, nil, nil, nil, &ifNoneMatch)
 	// then
 	assertAreaWorkItems(s.T(), areaID, workitems)
 	assertResponseHeaders(s.T(), res)
@@ -1372,7 +1372,7 @@ func (s *WorkItem2Suite) TestWI2ListByAreaFilterNotModifiedUsingIfModifiedSinceH
 	// when
 	updatedAt := wi.Data.Attributes[workitem.SystemUpdatedAt].(time.Time)
 	ifModifiedSince := app.ToHTTPTime(updatedAt)
-	res := test.ListWorkitemNotModified(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, spaceID, nil, &areaID, nil, nil, nil, nil, nil, nil, &ifModifiedSince, nil)
+	res := test.ListWorkitemNotModified(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, spaceID, nil, &areaID, nil, nil, nil, nil, nil, nil, nil, &ifModifiedSince, nil)
 	// then
 	assertResponseHeaders(s.T(), res)
 }
@@ -1382,7 +1382,7 @@ func (s *WorkItem2Suite) TestWI2ListByAreaFilterNotModifiedUsingIfNoneMatchHeade
 	spaceID, areaID, wi := s.setupAreaWorkItem(true)
 	// when
 	ifNoneMatch := app.GenerateEntityTag(convertWorkItemToConditionalResponseEntity(*wi))
-	res := test.ListWorkitemNotModified(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, spaceID, nil, &areaID, nil, nil, nil, nil, nil, nil, nil, &ifNoneMatch)
+	res := test.ListWorkitemNotModified(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, spaceID, nil, &areaID, nil, nil, nil, nil, nil, nil, nil, nil, &ifNoneMatch)
 	// then
 	assertResponseHeaders(s.T(), res)
 }
@@ -1408,7 +1408,7 @@ func (s *WorkItem2Suite) TestWI2ListByIterationFilter() {
 	require.NotNil(s.T(), wi.Data.Relationships.Iteration)
 	assert.Equal(s.T(), iterationID, *wi.Data.Relationships.Iteration.Data.ID)
 
-	_, list := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), nil, nil, nil, &iterationID, nil, nil, nil, nil, nil, nil)
+	_, list := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), nil, nil, nil, &iterationID, nil, nil, nil, nil, nil, nil, nil)
 	require.Len(s.T(), list.Data, 1)
 	assert.Equal(s.T(), iterationID, *list.Data[0].Relationships.Iteration.Data.ID)
 	assert.True(s.T(), strings.Contains(*list.Links.First, "filter[iteration]"))
@@ -2143,15 +2143,15 @@ func (s *WorkItem2Suite) TestWI2ListForChildIteration() {
 	}
 
 	// list workitems for grandParentIteration
-	_, list := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), nil, nil, nil, &grandParentIterationID, nil, nil, nil, nil, nil, nil)
+	_, list := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), nil, nil, nil, &grandParentIterationID, nil, nil, nil, nil, nil, nil, nil)
 	require.Len(s.T(), list.Data, 7)
 
 	// list workitems for parentIteration
-	_, list = test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), nil, nil, nil, &parentIterationID, nil, nil, nil, nil, nil, nil)
+	_, list = test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), nil, nil, nil, &parentIterationID, nil, nil, nil, nil, nil, nil, nil)
 	require.Len(s.T(), list.Data, 4)
 
 	// list workitems for childIteraiton
-	_, list = test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), nil, nil, nil, &childIteraitonID, nil, nil, nil, nil, nil, nil)
+	_, list = test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), nil, nil, nil, &childIteraitonID, nil, nil, nil, nil, nil, nil, nil)
 	require.Len(s.T(), list.Data, 2)
 }
 

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -2259,3 +2259,12 @@ func convertWorkItemToConditionalResponseEntity(appWI app.WorkItemSingle) app.Co
 		},
 	}
 }
+
+func (s *workItemChildSuite) TestWorkItemListFilterByNoParents() {
+	_, result := test.ListWorkitemOK(s.T(), nil, nil, s.workItemCtrl, s.userSpaceID.String(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	assert.Len(s.T(), result.Data, 3)
+
+	pe := false
+	_, result2 := test.ListWorkitemOK(s.T(), nil, nil, s.workItemCtrl, s.userSpaceID.String(), nil, nil, nil, nil, &pe, nil, nil, nil, nil, nil, nil)
+	assert.Len(s.T(), result2.Data, 1)
+}

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -2262,19 +2262,29 @@ func convertWorkItemToConditionalResponseEntity(appWI app.WorkItemSingle) app.Co
 
 func (s *workItemChildSuite) TestWorkItemListFilterByNoParents() {
 	s.T().Run("without parentexists filter", func(t *testing.T) {
-		_, result := test.ListWorkitemOK(t, nil, nil, s.workItemCtrl, s.userSpaceID.String(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		// given
+		var pe *bool
+		// when
+		_, result := test.ListWorkitemOK(t, nil, nil, s.workItemCtrl, s.userSpaceID.String(), nil, nil, nil, nil, pe, nil, nil, nil, nil, nil, nil)
+		// then
 		assert.Len(t, result.Data, 3)
 	})
 
 	s.T().Run("with parentexists value set to false", func(t *testing.T) {
+		// given
 		pe := false
+		// when
 		_, result2 := test.ListWorkitemOK(t, nil, nil, s.workItemCtrl, s.userSpaceID.String(), nil, nil, nil, nil, &pe, nil, nil, nil, nil, nil, nil)
+		// then
 		assert.Len(t, result2.Data, 1)
 	})
 
 	s.T().Run("with parentexists value set to true", func(t *testing.T) {
+		// given
 		pe := true
+		// when
 		_, result2 := test.ListWorkitemOK(t, nil, nil, s.workItemCtrl, s.userSpaceID.String(), nil, nil, nil, nil, &pe, nil, nil, nil, nil, nil, nil)
+		// then
 		assert.Len(t, result2.Data, 3)
 	})
 

--- a/controller/workitem_test.go
+++ b/controller/workitem_test.go
@@ -64,28 +64,28 @@ func (s *TestPagingSuite) TestPagingErrors() {
 
 	var offset string = "-1"
 	var limit int = 2
-	_, result := test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result := test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	if !strings.Contains(*result.Links.First, "page[offset]=0") {
 		assert.Fail(s.T(), "Offset is negative", "Expected offset to be %d, but was %s", 0, *result.Links.First)
 	}
 
 	offset = "0"
 	limit = 0
-	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	if !strings.Contains(*result.Links.First, "page[limit]=20") {
 		assert.Fail(s.T(), "Limit is 0", "Expected limit to be default size %d, but was %s", 20, *result.Links.First)
 	}
 
 	offset = "0"
 	limit = -1
-	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	if !strings.Contains(*result.Links.First, "page[limit]=20") {
 		assert.Fail(s.T(), "Limit is negative", "Expected limit to be default size %d, but was %s", 20, *result.Links.First)
 	}
 
 	offset = "-3"
 	limit = -1
-	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	if !strings.Contains(*result.Links.First, "page[limit]=20") {
 		assert.Fail(s.T(), "Limit is negative", "Expected limit to be default size %d, but was %s", 20, *result.Links.First)
 	}
@@ -95,7 +95,7 @@ func (s *TestPagingSuite) TestPagingErrors() {
 
 	offset = "ALPHA"
 	limit = 40
-	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	if !strings.Contains(*result.Links.First, "page[limit]=40") {
 		assert.Fail(s.T(), "Limit is within range", "Expected limit to be size %d, but was %s", 40, *result.Links.First)
 	}
@@ -110,7 +110,7 @@ func (s *TestPagingSuite) TestPagingLinksHasAbsoluteURL() {
 	limit := 10
 	s.repo.ListReturns(makeWorkItems(10), uint64(100), nil)
 	// when
-	_, result := test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result := test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	// then
 	if !strings.HasPrefix(*result.Links.First, "http://") {
 		assert.Fail(s.T(), "Not Absolute URL", "Expected link %s to contain absolute URL but was %s", "First", *result.Links.First)
@@ -132,21 +132,21 @@ func (s *TestPagingSuite) TestPagingDefaultAndMaxSize() {
 	var limit int
 	s.repo.ListReturns(makeWorkItems(10), uint64(100), nil)
 	// when
-	_, result := test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, nil, &offset, nil, nil)
+	_, result := test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, nil, nil, &offset, nil, nil)
 	// then
 	if !strings.Contains(*result.Links.First, "page[limit]=20") {
 		assert.Fail(s.T(), "Limit is nil", "Expected limit to be default size %d, got %v", 20, *result.Links.First)
 	}
 	// when
 	limit = 1000
-	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	// then
 	if !strings.Contains(*result.Links.First, "page[limit]=100") {
 		assert.Fail(s.T(), "Limit is more than max", "Expected limit to be %d, got %v", 100, *result.Links.First)
 	}
 	// when
 	limit = 50
-	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	// then
 	if !strings.Contains(*result.Links.First, "page[limit]=50") {
 		assert.Fail(s.T(), "Limit is within range", "Expected limit to be %d, got %v", 50, *result.Links.First)

--- a/design/workitems.go
+++ b/design/workitems.go
@@ -138,6 +138,7 @@ var _ = a.Resource("workitem", func() {
 			a.Param("filter[workitemtype]", d.UUID, "ID of work item type to filter work items by")
 			a.Param("filter[area]", d.String, "AreaID to filter work items")
 			a.Param("filter[workitemstate]", d.String, "work item state to filter work items by")
+			a.Param("filter[parentexists]", d.Boolean, "if false list work items without any parent")
 		})
 		a.UseTrait("conditional")
 		a.Response(d.OK, workItemList)

--- a/test/work_item_repository.go
+++ b/test/work_item_repository.go
@@ -366,7 +366,7 @@ func (fake *WorkItemRepository) Count(ctx context.Context, spaceID uuid.UUID, c 
 	return fake.countReturns.result1, fake.countReturns.result2
 }
 
-func (fake *WorkItemRepository) List(ctx context.Context, spaceID uuid.UUID, c criteria.Expression, start *int, length *int) ([]workitem.WorkItem, uint64, error) {
+func (fake *WorkItemRepository) List(ctx context.Context, spaceID uuid.UUID, c criteria.Expression, parentExists *bool, start *int, length *int) ([]workitem.WorkItem, uint64, error) {
 	fake.listMutex.Lock()
 	fake.listArgsForCall = append(fake.listArgsForCall, struct {
 		ctx      context.Context

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -561,12 +561,9 @@ func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, spaceID uu
 	}
 	where = where + " AND space_id = ?"
 	parameters = append(parameters, spaceID)
-	pe := true
-	if parentExists == nil {
-		parentExists = &pe
-	}
-	if *parentExists == false {
-		where = where + " AND " + `
+
+	if parentExists != nil && !*parentExists {
+		where += ` AND
 			id not in (
 				SELECT target_id FROM work_item_links
 				WHERE link_type_id IN (

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/almighty/almighty-core/criteria"
 	"github.com/almighty/almighty-core/errors"
+
 	"github.com/almighty/almighty-core/log"
 	"github.com/almighty/almighty-core/rendering"
 
@@ -36,7 +37,7 @@ type WorkItemRepository interface {
 	Reorder(ctx context.Context, direction DirectionType, targetID *string, wi WorkItem, modifierID uuid.UUID) (*WorkItem, error)
 	Delete(ctx context.Context, spaceID uuid.UUID, ID string, suppressorID uuid.UUID) error
 	Create(ctx context.Context, spaceID uuid.UUID, typeID uuid.UUID, fields map[string]interface{}, creatorID uuid.UUID) (*WorkItem, error)
-	List(ctx context.Context, spaceID uuid.UUID, criteria criteria.Expression, start *int, length *int) ([]WorkItem, uint64, error)
+	List(ctx context.Context, spaceID uuid.UUID, criteria criteria.Expression, parentExists *bool, start *int, length *int) ([]WorkItem, uint64, error)
 	Fetch(ctx context.Context, spaceID uuid.UUID, criteria criteria.Expression) (*WorkItem, error)
 	GetCountsPerIteration(ctx context.Context, spaceID uuid.UUID) (map[string]WICountsPerIteration, error)
 	GetCountsForIteration(ctx context.Context, iterationID uuid.UUID) (map[string]WICountsPerIteration, error)
@@ -553,13 +554,27 @@ func ConvertWorkItemStorageToModel(wiType *WorkItemType, wi *WorkItemStorage) (*
 
 // extracted this function from List() in order to close the rows object with "defer" for more readability
 // workaround for https://github.com/lib/pq/issues/81
-func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, spaceID uuid.UUID, criteria criteria.Expression, start *int, limit *int) ([]WorkItemStorage, uint64, error) {
+func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, spaceID uuid.UUID, criteria criteria.Expression, parentExists *bool, start *int, limit *int) ([]WorkItemStorage, uint64, error) {
 	where, parameters, compileError := Compile(criteria)
 	if compileError != nil {
 		return nil, 0, errors.NewBadParameterError("expression", criteria)
 	}
 	where = where + " AND space_id = ?"
 	parameters = append(parameters, spaceID)
+	pe := true
+	if parentExists == nil {
+		parentExists = &pe
+	}
+	if *parentExists == false {
+		where = where + " AND " + `
+			id not in (
+				SELECT target_id FROM work_item_links
+				WHERE link_type_id IN (
+					SELECT id FROM work_item_link_types WHERE forward_name = 'parent of'
+				)
+			)`
+
+	}
 	db := r.db.Model(&WorkItemStorage{}).Where(where, parameters...)
 	orgDB := db
 	if start != nil {
@@ -628,8 +643,8 @@ func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, spaceID uu
 }
 
 // List returns work item selected by the given criteria.Expression, starting with start (zero-based) and returning at most limit items
-func (r *GormWorkItemRepository) List(ctx context.Context, spaceID uuid.UUID, criteria criteria.Expression, start *int, limit *int) ([]WorkItem, uint64, error) {
-	result, count, err := r.listItemsFromDB(ctx, spaceID, criteria, start, limit)
+func (r *GormWorkItemRepository) List(ctx context.Context, spaceID uuid.UUID, criteria criteria.Expression, parentExists *bool, start *int, limit *int) ([]WorkItem, uint64, error) {
+	result, count, err := r.listItemsFromDB(ctx, spaceID, criteria, parentExists, start, limit)
 	if err != nil {
 		return nil, 0, errs.WithStack(err)
 	}
@@ -665,7 +680,7 @@ func (r *GormWorkItemRepository) Count(ctx context.Context, spaceID uuid.UUID, c
 // Fetch fetches the (first) work item matching by the given criteria.Expression.
 func (r *GormWorkItemRepository) Fetch(ctx context.Context, spaceID uuid.UUID, criteria criteria.Expression) (*WorkItem, error) {
 	limit := 1
-	results, count, err := r.List(ctx, spaceID, criteria, nil, &limit)
+	results, count, err := r.List(ctx, spaceID, criteria, nil, nil, &limit)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The top-level listing of work items in the UI's tree view should only contain work items without any parent (aka the "root" work items).

This change adds a new boolean `parentexists` list-filter to the `workitems` endpoint:

   `/spaces/{id}/workitems?filter[parentexists]=false`

When filter is set to `false`, it lists all work items that have **no** parent; otherwise all work items (with and without parent) are listed.

Fixes https://github.com/fabric8io/fabric8-planner/issues/1661