### PR TITLE
Validate uniqueness of user email/username from database

### DIFF
--- a/controller/users.go
+++ b/controller/users.go
@@ -156,7 +156,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 			}
 			isUnique, err := isUsernameUnique(appl, *updatedUserName, *identity)
 			if err != nil {
-				return jsonapi.JSONErrorResponse(ctx, errors.Wrap(err, fmt.Sprintf("error updating user with id %s", identity.UserID.UUID)))
+				return jsonapi.JSONErrorResponse(ctx, errors.Wrap(err, fmt.Sprintf("error updating idenitity with id %s and user with id %s", identity.ID, identity.UserID.UUID)))
 			}
 			if !isUnique {
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("username : %s is already in use", *updatedUserName)))

--- a/controller/users.go
+++ b/controller/users.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -133,11 +134,16 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		// to have everything - whatever we are updating, and whatever are not.
 		keycloakUserProfile := copyExistingKeycloakUserProfileInfo(keycloakUserExistingInfo)
 
-		// Disabling updation of email till we figure out how to do the same in Keycloak Error-free.
-		//
-
 		updatedEmail := ctx.Payload.Data.Attributes.Email
 		if updatedEmail != nil {
+			isUnique, err := isEmailUnique(appl, *updatedEmail, *user)
+			if err != nil {
+				return jsonapi.JSONErrorResponse(ctx, errors.Wrap(err, fmt.Sprintf("error updating user with id %s", identity.UserID.UUID)))
+			}
+			if !isUnique {
+				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("email address: %s is already in use", *updatedEmail)))
+				return ctx.Conflict(jerrors)
+			}
 			user.Email = *updatedEmail
 			keycloakUserProfile.Email = updatedEmail
 		}
@@ -147,6 +153,14 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 			if identity.RegistrationCompleted {
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("username cannot be updated more than once for idenitity id %s ", *id)))
 				return ctx.Forbidden(jerrors)
+			}
+			isUnique, err := isUsernameUnique(appl, *updatedUserName, *identity)
+			if err != nil {
+				return jsonapi.JSONErrorResponse(ctx, errors.Wrap(err, fmt.Sprintf("error updating user with id %s", identity.UserID.UUID)))
+			}
+			if !isUnique {
+				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("username : %s is already in use", *updatedUserName)))
+				return ctx.Conflict(jerrors)
 			}
 			identity.Username = *updatedUserName
 			identity.RegistrationCompleted = true
@@ -252,6 +266,40 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		c.userProfileService.Update(keycloakUserProfile, tokenString, accountAPIEndpoint)
 		return ctx.OK(ConvertUser(ctx.RequestData, identity, user))
 	})
+}
+
+func isUsernameUnique(appl application.Application, username string, identity account.Identity) (bool, error) {
+	usersWithSameUserName, err := appl.Identities().Query(account.IdentityFilterByUsername(username))
+	if err != nil {
+		log.Error(context.Background(), map[string]interface{}{
+			"user_name": username,
+			"err":       err,
+		}, "error fetching users with username filter")
+		return false, err
+	}
+	for _, u := range usersWithSameUserName {
+		if u.UserID.UUID != identity.UserID.UUID {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func isEmailUnique(appl application.Application, email string, user account.User) (bool, error) {
+	usersWithSameEmail, err := appl.Identities().Query(account.UserFilterByEmail(email))
+	if err != nil {
+		log.Error(context.Background(), map[string]interface{}{
+			"email": email,
+			"err":   err,
+		}, "error fetching identities with email filter")
+		return false, err
+	}
+	for _, u := range usersWithSameEmail {
+		if u.UserID.UUID != user.ID {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // List runs the list action.

--- a/controller/users.go
+++ b/controller/users.go
@@ -138,7 +138,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		if updatedEmail != nil {
 			isUnique, err := isEmailUnique(appl, *updatedEmail, *user)
 			if err != nil {
-				return jsonapi.JSONErrorResponse(ctx, errors.Wrap(err, fmt.Sprintf("error updating user with id %s", identity.UserID.UUID)))
+				return jsonapi.JSONErrorResponse(ctx, errors.Wrap(err, fmt.Sprintf("error updating idenitity with id %s and user with id %s", identity.UserID.UUID, user.ID)))
 			}
 			if !isUnique {
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("email address: %s is already in use", *updatedEmail)))
@@ -269,7 +269,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 }
 
 func isUsernameUnique(appl application.Application, username string, identity account.Identity) (bool, error) {
-	usersWithSameUserName, err := appl.Identities().Query(account.IdentityFilterByUsername(username))
+	usersWithSameUserName, err := appl.Identities().Query(account.IdentityFilterByUsername(username), account.IdentityFilterByProviderType(account.KeycloakIDP))
 	if err != nil {
 		log.Error(context.Background(), map[string]interface{}{
 			"user_name": username,
@@ -286,7 +286,7 @@ func isUsernameUnique(appl application.Application, username string, identity ac
 }
 
 func isEmailUnique(appl application.Application, email string, user account.User) (bool, error) {
-	usersWithSameEmail, err := appl.Identities().Query(account.UserFilterByEmail(email))
+	usersWithSameEmail, err := appl.Users().Query(account.UserFilterByEmail(email))
 	if err != nil {
 		log.Error(context.Background(), map[string]interface{}{
 			"email": email,
@@ -295,7 +295,7 @@ func isEmailUnique(appl application.Application, email string, user account.User
 		return false, err
 	}
 	for _, u := range usersWithSameEmail {
-		if u.UserID.UUID != user.ID {
+		if u.ID != user.ID {
 			return false, nil
 		}
 	}

--- a/controller/users.go
+++ b/controller/users.go
@@ -138,7 +138,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		if updatedEmail != nil {
 			isUnique, err := isEmailUnique(appl, *updatedEmail, *user)
 			if err != nil {
-				return jsonapi.JSONErrorResponse(ctx, errors.Wrap(err, fmt.Sprintf("error updating idenitity with id %s and user with id %s", identity.UserID.UUID, user.ID)))
+				return jsonapi.JSONErrorResponse(ctx, errors.Wrap(err, fmt.Sprintf("error updating idenitity with id %s and user with id %s", identity.ID, identity.UserID.UUID)))
 			}
 			if !isUnique {
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("email address: %s is already in use", *updatedEmail)))

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -164,7 +164,7 @@ func (s *TestUsersSuite) TestUpdateExistingUsernameForbidden() {
 	assert.Equal(s.T(), identity2.ID.String(), *result2.Data.ID)
 
 	// try updating using the username of an existing ( just created ) user.
-	secureService, secureController := s.SecuredController(identity)
+	secureService, secureController := s.SecuredController(identity2)
 
 	contextInformation := map[string]interface{}{
 		"last_visited": "yesterday",
@@ -172,7 +172,7 @@ func (s *TestUsersSuite) TestUpdateExistingUsernameForbidden() {
 
 	newUserName := identity.Username
 	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, &newUserName, contextInformation)
-	test.UpdateUsersForbidden(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
+	test.UpdateUsersConflict(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 }
 
 func (s *TestUsersSuite) TestUpdateExistingEmailForbidden() {
@@ -188,7 +188,7 @@ func (s *TestUsersSuite) TestUpdateExistingEmailForbidden() {
 	assert.Equal(s.T(), identity2.ID.String(), *result2.Data.ID)
 
 	// try updating using the email of an existing ( just created ) user.
-	secureService, secureController := s.SecuredController(identity)
+	secureService, secureController := s.SecuredController(identity2)
 
 	contextInformation := map[string]interface{}{
 		"last_visited": "yesterday",
@@ -196,7 +196,7 @@ func (s *TestUsersSuite) TestUpdateExistingEmailForbidden() {
 
 	newEmail := user.Email
 	updateUsersPayload := createUpdateUsersPayload(&newEmail, nil, nil, nil, nil, nil, nil, contextInformation)
-	test.UpdateUsersForbidden(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
+	test.UpdateUsersConflict(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 }
 
 func (s *TestUsersSuite) TestUpdateUserVariableSpacesInNameOK() {

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -151,6 +151,54 @@ func (s *TestUsersSuite) TestUpdateUserNameMulitpleTimesForbidden() {
 	test.UpdateUsersForbidden(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 }
 
+func (s *TestUsersSuite) TestUpdateExistingUsernameForbidden() {
+	// create 2 users.
+	user := s.createRandomUser("OK")
+	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String())
+	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
+
+	user2 := s.createRandomUser("OK2")
+	identity2 := s.createRandomIdentity(user2, account.KeycloakIDP)
+	_, result2 := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity2.ID.String())
+	assert.Equal(s.T(), identity2.ID.String(), *result2.Data.ID)
+
+	// try updating using the username of an existing ( just created ) user.
+	secureService, secureController := s.SecuredController(identity)
+
+	contextInformation := map[string]interface{}{
+		"last_visited": "yesterday",
+	}
+
+	newUserName := identity.Username
+	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, &newUserName, contextInformation)
+	test.UpdateUsersForbidden(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
+}
+
+func (s *TestUsersSuite) TestUpdateExistingEmailForbidden() {
+	// create 2 users.
+	user := s.createRandomUser("OK")
+	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String())
+	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
+
+	user2 := s.createRandomUser("OK2")
+	identity2 := s.createRandomIdentity(user2, account.KeycloakIDP)
+	_, result2 := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity2.ID.String())
+	assert.Equal(s.T(), identity2.ID.String(), *result2.Data.ID)
+
+	// try updating using the email of an existing ( just created ) user.
+	secureService, secureController := s.SecuredController(identity)
+
+	contextInformation := map[string]interface{}{
+		"last_visited": "yesterday",
+	}
+
+	newEmail := user.Email
+	updateUsersPayload := createUpdateUsersPayload(&newEmail, nil, nil, nil, nil, nil, nil, contextInformation)
+	test.UpdateUsersForbidden(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
+}
+
 func (s *TestUsersSuite) TestUpdateUserVariableSpacesInNameOK() {
 
 	// given


### PR DESCRIPTION
As part of this PR, we update email/username for a user only if it wasn't found in the database for another user/identity.

Prior to this, we validated the email/username inside keycloak only.