### PR TITLE
Logout from RHD when logging out from SSO

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -107,6 +107,7 @@ keycloak.testuser.name : testuser
 keycloak.testuser.secret : testuser
 keycloak.testuser2.name : testuser2
 keycloak.testuser2.secret : testuser2
+keycloak.rhd.url : https://developers.redhat.com/auth/realms/rhd
 
 # Uncomment if FQDN URL's should be used instead of relative URL's:
 # keycloak.url : https://sso.prod-preview.openshift.io

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -66,6 +66,7 @@ const (
 	varKeycloakEndpointBroker           = "keycloak.endpoint.broker"
 	varKeycloakEndpointAccount          = "keycloak.endpoint.account"
 	varKeycloakEndpointLogout           = "keycloak.endpoint.logout"
+	varKeycloakRhdURL                   = "keycloak.rhd.url"
 	varTokenPublicKey                   = "token.publickey"
 	varTokenPrivateKey                  = "token.privatekey"
 	varHeaderMaxLength                  = "header.maxlength"
@@ -180,6 +181,7 @@ func (c *ConfigurationData) setConfigDefaults() {
 	c.v.SetDefault(varKeycloakDomainPrefix, defaultKeycloakDomainPrefix)
 	c.v.SetDefault(varKeycloakTesUserName, defaultKeycloakTesUserName)
 	c.v.SetDefault(varKeycloakTesUserSecret, defaultKeycloakTesUserSecret)
+	c.v.SetDefault(varKeycloakRhdURL, defaultKeycloakRhdURL)
 
 	// HTTP Cache-Control/max-age default
 	c.v.SetDefault(varCacheControlWorkItems, "max-age=2") // very short life in cache, to allow for quick, repetitive updates.
@@ -507,6 +509,11 @@ func (c *ConfigurationData) GetKeycloakDevModeURL() string {
 	return devModeKeycloakURL
 }
 
+// GetKeycloakRhdURL returns Red Hat Developers SSO URL
+func (c *ConfigurationData) GetKeycloakRhdURL() string {
+	return c.v.GetString(varKeycloakRhdURL)
+}
+
 func (c *ConfigurationData) getKeycloakOpenIDConnectEndpoint(req *goa.RequestData, endpointVarName string, pathSufix string) (string, error) {
 	return c.getKeycloakEndpoint(req, endpointVarName, c.openIDConnectPath(pathSufix))
 }
@@ -677,6 +684,8 @@ vwIDAQAB
 
 	defaultOpenshiftTenantMasterURL = "https://tsrv.devshift.net:8443"
 	defaultCheStarterURL            = "che-server"
+
+	defaultKeycloakRhdURL = "https://developers.redhat.com/auth/realms/rhd"
 
 	// DefaultValidRedirectURLs is a regex to be used to whitelist redirect URL for auth
 	// If the ALMIGHTY_REDIRECT_VALID env var is not set then in Dev Mode all redirects allowed - *

--- a/controller/logout.go
+++ b/controller/logout.go
@@ -12,6 +12,7 @@ import (
 type logoutConfiguration interface {
 	GetKeycloakEndpointLogout(*goa.RequestData) (string, error)
 	GetValidRedirectURLs(*goa.RequestData) (string, error)
+	GetKeycloakRhdURL() string
 }
 
 // LogoutController implements the logout resource.
@@ -39,5 +40,5 @@ func (c *LogoutController) Logout(ctx *app.LogoutLogoutContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(err.Error()))
 	}
-	return c.logoutService.Logout(ctx, logoutEndpoint, whitelist)
+	return c.logoutService.Logout(ctx, logoutEndpoint, whitelist, c.configuration.GetKeycloakRhdURL())
 }

--- a/login/logout_blackbox_test.go
+++ b/login/logout_blackbox_test.go
@@ -42,11 +42,11 @@ func (s *TestLogoutSuite) TearDownSuite() {
 }
 
 func (s *TestLogoutSuite) TestLogoutRedirectsToKeycloakWithRedirectParam() {
-	s.checkRedirects("", "https://url.example.org/path", "https%3A%2F%2Furl.example.org%2Fpath")
+	s.checkRedirects("", "https://url.example.org/path", "https%3A%2F%2Fdevelopers.redhat.com%2Fauth%2Frealms%2Frhd%2Fprotocol%2Fopenid-connect%2Flogout%3Fredirect_uri%3Dhttps%253A%252F%252Furl.example.org%252Fpath")
 }
 
 func (s *TestLogoutSuite) TestLogoutRedirectsToKeycloakWithReferrer() {
-	s.checkRedirects("http://openshift.io/home", "https://url.example.org/path", "http%3A%2F%2Fopenshift.io%2Fhome")
+	s.checkRedirects("http://openshift.io/home", "https://url.example.org/path", "https%3A%2F%2Fdevelopers.redhat.com%2Fauth%2Frealms%2Frhd%2Fprotocol%2Fopenid-connect%2Flogout%3Fredirect_uri%3Dhttp%253A%252F%252Fopenshift.io%252Fhome")
 }
 
 func (s *TestLogoutSuite) checkRedirects(redirectParam string, referrerURL string, expectedRedirectParam string) {
@@ -75,7 +75,7 @@ func (s *TestLogoutSuite) checkRedirects(redirectParam string, referrerURL strin
 	validURLs, err := s.configuration.GetValidRedirectURLs(r)
 	require.Nil(s.T(), err)
 
-	err = s.logoutService.Logout(logoutCtx, logoutEndpoint, validURLs)
+	err = s.logoutService.Logout(logoutCtx, logoutEndpoint, validURLs, s.configuration.GetKeycloakRhdURL())
 
 	assert.Equal(s.T(), 307, rw.Code)
 	assert.Equal(s.T(), fmt.Sprintf("%s?redirect_uri=%s", logoutEndpoint, expectedRedirectParam), rw.Header().Get("Location"))


### PR DESCRIPTION
Currently when our api/logout endpoint called we redirects to our sso to logout. But for some reason our SSO not always redirects to RHD to logout. So we should logout from both sso.osio and developers.redhat.com to make sure we are properly logout.

Fixes https://github.com/almighty/almighty-core/issues/1217