### PR TITLE
Set registrationCompleted=True only if a distinct username is used

### DIFF
--- a/controller/users.go
+++ b/controller/users.go
@@ -149,7 +149,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		}
 
 		updatedUserName := ctx.Payload.Data.Attributes.Username
-		if updatedUserName != nil {
+		if updatedUserName != nil && *updatedUserName != identity.Username {
 			if identity.RegistrationCompleted {
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("username cannot be updated more than once for idenitity id %s ", *id)))
 				return ctx.Forbidden(jerrors)

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -148,6 +148,8 @@ func (s *TestUsersSuite) TestUpdateUserNameMulitpleTimesForbidden() {
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 
 	// next attempt should fail.
+	newUserName = identity.Username + uuid.NewV4().String()
+	updateUsersPayload = createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, &newUserName, contextInformation)
 	test.UpdateUsersForbidden(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 }
 

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -169,11 +169,11 @@ func (s *TestUsersSuite) TestUpdateUserNameMulitpleTimesOK() {
 
 	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, &newUserName, contextInformation)
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
-	require.False(s.T(), result.RegistrationCompleted)
+	require.False(s.T(), *result.Data.Attributes.RegistrationCompleted)
 
 	// next attempt should PASS.
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
-	require.False(s.T(), result.RegistrationCompleted)
+	require.False(s.T(), *result.Data.Attributes.RegistrationCompleted)
 
 }
 

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -151,6 +151,27 @@ func (s *TestUsersSuite) TestUpdateUserNameMulitpleTimesForbidden() {
 	test.UpdateUsersForbidden(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 }
 
+func (s *TestUsersSuite) TestUpdateUserNameMulitpleTimesOK() {
+
+	user := s.createRandomUser("OK")
+	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String())
+	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
+
+	newUserName := identity.Username // new username = old userame
+	secureService, secureController := s.SecuredController(identity)
+
+	contextInformation := map[string]interface{}{
+		"last_visited": "yesterday",
+	}
+
+	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, &newUserName, contextInformation)
+	test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
+
+	// next attempt should PASS.
+	test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
+}
+
 func (s *TestUsersSuite) TestUpdateExistingUsernameForbidden() {
 	// create 2 users.
 	user := s.createRandomUser("OK")

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -166,10 +166,13 @@ func (s *TestUsersSuite) TestUpdateUserNameMulitpleTimesOK() {
 	}
 
 	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, &newUserName, contextInformation)
-	test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
+	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
+	require.False(s.T(), result.RegistrationCompleted)
 
 	// next attempt should PASS.
-	test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
+	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
+	require.False(s.T(), result.RegistrationCompleted)
+
 }
 
 func (s *TestUsersSuite) TestUpdateExistingUsernameForbidden() {


### PR DESCRIPTION
Fixes https://github.com/almighty/almighty-core/issues/1225

If the current username is sent as part of `PATCH /api/users` , it should not be considered as an update. This fix resolves the problem of (re)setting the username to the older/same username which was causing the `registration_completed` to be set to True.