### PR TITLE
Fix KC profile attribute name for username

### DIFF
--- a/login/profile.go
+++ b/login/profile.go
@@ -22,7 +22,7 @@ const ApprovedAttributeName = "approved"
 type KeycloakUserProfile struct {
 	ID         *string                        `json:"id,omitempty"`
 	CreatedAt  int64                          `json:"createdTimestamp,omitempty"`
-	Username   *string                        `json:"id,omitempty"`
+	Username   *string                        `json:"username,omitempty"`
 	FirstName  *string                        `json:"firstName,omitempty"`
 	LastName   *string                        `json:"lastName,omitempty"`
 	Email      *string                        `json:"email,omitempty"`

--- a/login/profile_blackbox_test.go
+++ b/login/profile_blackbox_test.go
@@ -129,6 +129,7 @@ func (s *ProfileBlackBoxTest) TestKeycloakUserProfileUpdate() {
 	testBio := "updatedBioNew" + uuid.NewV4().String()
 	testURL := "updatedURLNew" + uuid.NewV4().String()
 	testImageURL := "updatedBio" + uuid.NewV4().String()
+	testUserName := "testuser"
 
 	testKeycloakUserProfileAttributes := &login.KeycloakUserProfileAttributes{
 		login.ImageURLAttributeName: []string{testImageURL},
@@ -137,6 +138,7 @@ func (s *ProfileBlackBoxTest) TestKeycloakUserProfileUpdate() {
 	}
 
 	testKeycloakUserProfileData := login.NewKeycloakUserProfile(&testFirstName, &testLastName, &testEmail, testKeycloakUserProfileAttributes)
+	//testKeycloakUserProfileData.Username = &testUserName
 
 	updateProfileFunc := s.updateUserProfile(testKeycloakUserProfileData)
 	updateProfileFunc()
@@ -149,6 +151,7 @@ func (s *ProfileBlackBoxTest) TestKeycloakUserProfileUpdate() {
 
 	assert.Equal(s.T(), testFirstName, *retrievedkeycloakUserProfileData.FirstName)
 	assert.Equal(s.T(), testLastName, *retrievedkeycloakUserProfileData.LastName)
+	assert.Equal(s.T(), testUserName, *retrievedkeycloakUserProfileData.Username)
 
 	// email is automatically stored in lower case
 	assert.Equal(s.T(), strings.ToLower(testEmail), *retrievedkeycloakUserProfileData.Email)

--- a/login/profile_blackbox_test.go
+++ b/login/profile_blackbox_test.go
@@ -129,7 +129,7 @@ func (s *ProfileBlackBoxTest) TestKeycloakUserProfileUpdate() {
 	testBio := "updatedBioNew" + uuid.NewV4().String()
 	testURL := "updatedURLNew" + uuid.NewV4().String()
 	testImageURL := "updatedBio" + uuid.NewV4().String()
-	testUserName := "testuser"
+	testUserName := "testuserupdated"
 
 	testKeycloakUserProfileAttributes := &login.KeycloakUserProfileAttributes{
 		login.ImageURLAttributeName: []string{testImageURL},
@@ -138,7 +138,7 @@ func (s *ProfileBlackBoxTest) TestKeycloakUserProfileUpdate() {
 	}
 
 	testKeycloakUserProfileData := login.NewKeycloakUserProfile(&testFirstName, &testLastName, &testEmail, testKeycloakUserProfileAttributes)
-	//testKeycloakUserProfileData.Username = &testUserName
+	testKeycloakUserProfileData.Username = &testUserName
 
 	updateProfileFunc := s.updateUserProfile(testKeycloakUserProfileData)
 	updateProfileFunc()
@@ -159,6 +159,13 @@ func (s *ProfileBlackBoxTest) TestKeycloakUserProfileUpdate() {
 	// validate Attributes
 	retrievedBio := (*retrievedkeycloakUserProfileData.Attributes)[login.BioAttributeName]
 	assert.Equal(s.T(), retrievedBio[0], testBio)
+
+	// put it back to testuser.
+	testUserName = "testuser"
+	testKeycloakUserProfileData.Username = &testUserName
+
+	updateProfileFunc()
+
 }
 
 func (s *ProfileBlackBoxTest) TestKeycloakUserProfileGet() {


### PR DESCRIPTION
This fix ensures that KC username is updated.
Fixes #1129  