### PR TITLE
Expose and Support registrationCompleted=True for HTTP PATCH

### DIFF
--- a/controller/users.go
+++ b/controller/users.go
@@ -170,7 +170,13 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		updatedRegistratedCompleted := ctx.Payload.Data.Attributes.RegistrationCompleted
 		if updatedRegistratedCompleted != nil {
 			if *updatedRegistratedCompleted == false {
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("invalid value assigned to registration_completed")))
+				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("invalid value assigned to registration_completed for idenitity with id %s and user with id %s", identity.ID, identity.UserID.UUID)))
+				log.Error(context.Background(), map[string]interface{}{
+					"registration_completed": *updatedRegistratedCompleted,
+					"user_id":                identity.UserID.UUID,
+					"idenitity_id":           identity.ID,
+				}, "invalid parameter assignment")
+
 				return ctx.BadRequest(jerrors)
 			}
 			identity.RegistrationCompleted = true

--- a/controller/users.go
+++ b/controller/users.go
@@ -227,6 +227,15 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 			}
 		}
 
+		updatedRegistratedCompleted := ctx.Payload.Data.Attributes.RegistrationCompleted
+		if updatedRegistratedCompleted != nil {
+			if *updatedRegistratedCompleted == false {
+				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("invalid value assigned to registration_completed")))
+				return ctx.Forbidden(jerrors)
+			}
+			identity.RegistrationCompleted = true
+		}
+
 		// The update of the keycloak needs to be attempted first because if that fails,
 		// we should't update the platform db since that would leave things in an
 		// inconsistent state.

--- a/controller/users.go
+++ b/controller/users.go
@@ -167,6 +167,15 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 			keycloakUserProfile.Username = updatedUserName
 		}
 
+		updatedRegistratedCompleted := ctx.Payload.Data.Attributes.RegistrationCompleted
+		if updatedRegistratedCompleted != nil {
+			if *updatedRegistratedCompleted == false {
+				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("invalid value assigned to registration_completed")))
+				return ctx.BadRequest(jerrors)
+			}
+			identity.RegistrationCompleted = true
+		}
+
 		updatedBio := ctx.Payload.Data.Attributes.Bio
 		if updatedBio != nil {
 			user.Bio = *updatedBio
@@ -225,15 +234,6 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 				// Save it as is, for short-term.
 				user.ContextInformation[fieldName] = fieldValue
 			}
-		}
-
-		updatedRegistratedCompleted := ctx.Payload.Data.Attributes.RegistrationCompleted
-		if updatedRegistratedCompleted != nil {
-			if *updatedRegistratedCompleted == false {
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("invalid value assigned to registration_completed")))
-				return ctx.Forbidden(jerrors)
-			}
-			identity.RegistrationCompleted = true
 		}
 
 		// The update of the keycloak needs to be attempted first because if that fails,

--- a/controller/users.go
+++ b/controller/users.go
@@ -138,7 +138,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		if updatedEmail != nil {
 			isUnique, err := isEmailUnique(appl, *updatedEmail, *user)
 			if err != nil {
-				return jsonapi.JSONErrorResponse(ctx, errors.Wrap(err, fmt.Sprintf("error updating idenitity with id %s and user with id %s", identity.ID, identity.UserID.UUID)))
+				return jsonapi.JSONErrorResponse(ctx, errors.Wrap(err, fmt.Sprintf("error updating identity with id %s and user with id %s", identity.ID, identity.UserID.UUID)))
 			}
 			if !isUnique {
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("email address: %s is already in use", *updatedEmail)))
@@ -151,12 +151,12 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		updatedUserName := ctx.Payload.Data.Attributes.Username
 		if updatedUserName != nil && *updatedUserName != identity.Username {
 			if identity.RegistrationCompleted {
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("username cannot be updated more than once for idenitity id %s ", *id)))
+				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("username cannot be updated more than once for identity id %s ", *id)))
 				return ctx.Forbidden(jerrors)
 			}
 			isUnique, err := isUsernameUnique(appl, *updatedUserName, *identity)
 			if err != nil {
-				return jsonapi.JSONErrorResponse(ctx, errors.Wrap(err, fmt.Sprintf("error updating idenitity with id %s and user with id %s", identity.ID, identity.UserID.UUID)))
+				return jsonapi.JSONErrorResponse(ctx, errors.Wrap(err, fmt.Sprintf("error updating identity with id %s and user with id %s", identity.ID, identity.UserID.UUID)))
 			}
 			if !isUnique {
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("username : %s is already in use", *updatedUserName)))
@@ -169,12 +169,12 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 
 		updatedRegistratedCompleted := ctx.Payload.Data.Attributes.RegistrationCompleted
 		if updatedRegistratedCompleted != nil {
-			if *updatedRegistratedCompleted == false {
-				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("invalid value assigned to registration_completed for idenitity with id %s and user with id %s", identity.ID, identity.UserID.UUID)))
+			if !*updatedRegistratedCompleted {
+				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("invalid value assigned to registration_completed for identity with id %s and user with id %s", identity.ID, identity.UserID.UUID)))
 				log.Error(context.Background(), map[string]interface{}{
 					"registration_completed": *updatedRegistratedCompleted,
 					"user_id":                identity.UserID.UUID,
-					"idenitity_id":           identity.ID,
+					"identity_id":            identity.ID,
 				}, "invalid parameter assignment")
 
 				return ctx.BadRequest(jerrors)

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -176,7 +176,7 @@ func (s *TestUsersSuite) TestUpdateUserNameMulitpleTimesOK() {
 func (s *TestUsersSuite) TestUpdateRegistrationCompletedOK() {
 	user := s.createRandomUser("OK")
 	identity := s.createRandomIdentity(user, account.KeycloakIDP)
-	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String())
+	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
 	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
 
 	secureService, secureController := s.SecuredController(identity)
@@ -198,7 +198,7 @@ func (s *TestUsersSuite) TestUpdateRegistrationCompletedOK() {
 func (s *TestUsersSuite) TestUpdateRegistrationCompletedBadRequest() {
 	user := s.createRandomUser("OKRegCompleted")
 	identity := s.createRandomIdentity(user, account.KeycloakIDP)
-	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String())
+	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
 	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
 
 	secureService, secureController := s.SecuredController(identity)
@@ -225,7 +225,7 @@ func (s *TestUsersSuite) TestUpdateRegistrationCompletedAndUsernameOK() {
 
 	user := s.createRandomUser("OKRegCompleted")
 	identity := s.createRandomIdentity(user, account.KeycloakIDP)
-	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String())
+	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String(), nil, nil)
 	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
 
 	secureService, secureController := s.SecuredController(identity)

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -106,7 +106,7 @@ func (s *TestUsersSuite) TestUpdateUserOK() {
 		"count":        3,
 	}
 	//secureController, secureService := createSecureController(t, identity)
-	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, &newCompany, nil, contextInformation)
+	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, &newCompany, nil, nil, contextInformation)
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 
 	// then
@@ -144,12 +144,12 @@ func (s *TestUsersSuite) TestUpdateUserNameMulitpleTimesForbidden() {
 		"last_visited": "yesterday",
 	}
 
-	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, &newUserName, contextInformation)
+	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, &newUserName, nil, contextInformation)
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 
 	// next attempt should fail.
 	newUserName = identity.Username + uuid.NewV4().String()
-	updateUsersPayload = createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, &newUserName, contextInformation)
+	updateUsersPayload = createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, &newUserName, nil, contextInformation)
 	test.UpdateUsersForbidden(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 }
 
@@ -167,7 +167,7 @@ func (s *TestUsersSuite) TestUpdateUserNameMulitpleTimesOK() {
 		"last_visited": "yesterday",
 	}
 
-	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, &newUserName, contextInformation)
+	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, &newUserName, nil, contextInformation)
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 	require.False(s.T(), *result.Data.Attributes.RegistrationCompleted)
 
@@ -175,6 +175,50 @@ func (s *TestUsersSuite) TestUpdateUserNameMulitpleTimesOK() {
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 	require.False(s.T(), *result.Data.Attributes.RegistrationCompleted)
 
+}
+
+func (s *TestUsersSuite) TestUpdateRegistrationCompletedOK() {
+	user := s.createRandomUser("OK")
+	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String())
+	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
+
+	secureService, secureController := s.SecuredController(identity)
+
+	contextInformation := map[string]interface{}{
+		"last_visited": "yesterday",
+	}
+
+	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, nil, nil, contextInformation)
+	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
+	require.False(s.T(), *result.Data.Attributes.RegistrationCompleted)
+
+	// next attempt should PASS.
+	boolTrue := true
+	updateUsersPayload = createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, nil, &boolTrue, contextInformation)
+	test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
+}
+
+func (s *TestUsersSuite) TestUpdateRegistrationCompletedForbidden() {
+	user := s.createRandomUser("OK")
+	identity := s.createRandomIdentity(user, account.KeycloakIDP)
+	_, result := test.ShowUsersOK(s.T(), nil, nil, s.controller, identity.ID.String())
+	assert.Equal(s.T(), identity.ID.String(), *result.Data.ID)
+
+	secureService, secureController := s.SecuredController(identity)
+
+	contextInformation := map[string]interface{}{
+		"last_visited": "yesterday",
+	}
+
+	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, nil, nil, contextInformation)
+	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
+	require.False(s.T(), *result.Data.Attributes.RegistrationCompleted)
+
+	// next attempt should PASS.
+	boolFalse := false
+	updateUsersPayload = createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, nil, &boolFalse, contextInformation)
+	test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 }
 
 func (s *TestUsersSuite) TestUpdateExistingUsernameForbidden() {
@@ -197,7 +241,7 @@ func (s *TestUsersSuite) TestUpdateExistingUsernameForbidden() {
 	}
 
 	newUserName := identity.Username
-	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, &newUserName, contextInformation)
+	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, &newUserName, nil, contextInformation)
 	test.UpdateUsersConflict(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 }
 
@@ -221,7 +265,7 @@ func (s *TestUsersSuite) TestUpdateExistingEmailForbidden() {
 	}
 
 	newEmail := user.Email
-	updateUsersPayload := createUpdateUsersPayload(&newEmail, nil, nil, nil, nil, nil, nil, contextInformation)
+	updateUsersPayload := createUpdateUsersPayload(&newEmail, nil, nil, nil, nil, nil, nil, nil, contextInformation)
 	test.UpdateUsersConflict(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 }
 
@@ -262,7 +306,7 @@ func (s *TestUsersSuite) TestUpdateUserVariableSpacesInNameOK() {
 		"count":        3,
 	}
 	//secureController, secureService := createSecureController(t, identity)
-	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, &newCompany, nil, contextInformation)
+	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, &newCompany, nil, nil, contextInformation)
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 	// then
 	require.NotNil(s.T(), result)
@@ -317,7 +361,7 @@ func (s *TestUsersSuite) TestUpdateUserUnsetVariableInContextInfo() {
 		"count":        3,
 	}
 	//secureController, secureService := createSecureController(t, identity)
-	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, nil, nil, contextInformation)
+	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, nil, nil, nil, contextInformation)
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 	// then
 	require.NotNil(s.T(), result)
@@ -340,7 +384,7 @@ func (s *TestUsersSuite) TestUpdateUserUnsetVariableInContextInfo() {
 		"count":        3,
 	}
 
-	updateUsersPayload = createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, nil, nil, contextInformation)
+	updateUsersPayload = createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, nil, nil, nil, contextInformation)
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 	// then
 	require.NotNil(s.T(), result)
@@ -406,7 +450,7 @@ func (s *TestUsersSuite) TestPatchUserContextInformation() {
 		"count":        3,
 	}
 	//secureController, secureService := createSecureController(t, identity)
-	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, nil, contextInformation)
+	updateUsersPayload := createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, nil, nil, contextInformation)
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 	// then
 	require.NotNil(s.T(), result)
@@ -428,7 +472,7 @@ func (s *TestUsersSuite) TestPatchUserContextInformation() {
 		"count": 5,
 	}
 
-	updateUsersPayload = createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, nil, patchedContextInformation)
+	updateUsersPayload = createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, nil, nil, patchedContextInformation)
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 	require.NotNil(s.T(), result)
 
@@ -467,7 +511,7 @@ func (s *TestUsersSuite) TestUpdateUserUnauthorized() {
 		"space":        "3d6dab8d-f204-42e8-ab29-cdb1c93130ad",
 	}
 	//secureController, secureService := createSecureController(t, identity)
-	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, nil, nil, contextInformation)
+	updateUsersPayload := createUpdateUsersPayload(&newEmail, &newFullName, &newBio, &newImageURL, &newProfileURL, nil, nil, nil, contextInformation)
 	// when/then
 	test.UpdateUsersUnauthorized(s.T(), context.Background(), nil, s.controller, updateUsersPayload)
 }
@@ -611,7 +655,7 @@ func assertUser(t *testing.T, actual *app.IdentityData, expectedUser account.Use
 
 }
 
-func createUpdateUsersPayload(email, fullName, bio, imageURL, profileURL, company, username *string, contextInformation map[string]interface{}) *app.UpdateUsersPayload {
+func createUpdateUsersPayload(email, fullName, bio, imageURL, profileURL, company, username *string, registrationCompleted *bool, contextInformation map[string]interface{}) *app.UpdateUsersPayload {
 	return &app.UpdateUsersPayload{
 		Data: &app.UpdateIdentityData{
 			Type: "identities",

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -242,7 +242,6 @@ func (s *TestUsersSuite) TestUpdateRegistrationCompletedAndUsernameOK() {
 	_, result = test.UpdateUsersOK(s.T(), secureService.Context, secureService, secureController, updateUsersPayload)
 	require.False(s.T(), *result.Data.Attributes.RegistrationCompleted)
 
-	// next attempt should fail.
 	boolTrue := true
 	newUserName := identity.Username + uuid.NewV4().String()
 	updateUsersPayload = createUpdateUsersPayload(nil, nil, nil, nil, nil, nil, &newUserName, &boolTrue, contextInformation)

--- a/design/account.go
+++ b/design/account.go
@@ -205,7 +205,7 @@ var updateIdentityDataAttributes = a.Type("UpdateIdentityDataAttributes", func()
 	a.Attribute("url", d.String, "The url")
 	a.Attribute("company", d.String, "The company")
 	a.Attribute("providerType", d.String, "The IDP provided this identity")
-	a.Attribute("registrationCompleted", d.Boolean, "Complete the registration to proceed. Setting this to true is allowed.")
+	a.Attribute("registrationCompleted", d.Boolean, "Complete the registration to proceed. This can only be set to true")
 	a.Attribute("contextInformation", a.HashOf(d.String, d.Any), "User context information of any type as a json", func() {
 		a.Example(map[string]interface{}{"last_visited_url": "https://a.openshift.io", "space": "3d6dab8d-f204-42e8-ab29-cdb1c93130ad"})
 	})

--- a/design/account.go
+++ b/design/account.go
@@ -205,6 +205,7 @@ var updateIdentityDataAttributes = a.Type("UpdateIdentityDataAttributes", func()
 	a.Attribute("url", d.String, "The url")
 	a.Attribute("company", d.String, "The company")
 	a.Attribute("providerType", d.String, "The IDP provided this identity")
+	a.Attribute("registrationCompleted", d.Boolean, "Complete the registration to proceed. Setting this to true is allowed.")
 	a.Attribute("contextInformation", a.HashOf(d.String, d.Any), "User context information of any type as a json", func() {
 		a.Example(map[string]interface{}{"last_visited_url": "https://a.openshift.io", "space": "3d6dab8d-f204-42e8-ab29-cdb1c93130ad"})
 	})


### PR DESCRIPTION
fixes #1232

- User Profile registrationCompleted should support PATCH'ed to true
-  but PATCH to false should not be supported.

Initial discussion : 
https://github.com/almighty/almighty-core/issues/1225