### PR TITLE
Test that planneritem is not returned when listing work item types

### DIFF
--- a/controller/planner_backlog.go
+++ b/controller/planner_backlog.go
@@ -93,10 +93,11 @@ func generateBacklogExpression(ctx context.Context, db application.DB, spaceID u
 
 		// Get the list of work item types that derive of PlannerItem in the space
 		var expWits criteria.Expression
-		wits, err := appl.WorkItemTypes().ListPlannerItems(ctx, spaceID)
+		witsOrig, err := appl.WorkItemTypes().ListPlannerItems(ctx, spaceID)
 		if err != nil {
 			return errs.Wrap(err, "unable to fetch work item types that derive from planner item")
 		}
+		wits := stripBaseWorkItemTypes(witsOrig)
 		if len(wits) >= 1 {
 			expWits = criteria.Equals(criteria.Field("Type"), criteria.Literal(wits[0].ID.String()))
 			for _, wit := range wits[1:] {

--- a/controller/workitemtype.go
+++ b/controller/workitemtype.go
@@ -120,12 +120,7 @@ func (c *WorkitemtypeController) List(ctx *app.ListWorkitemtypeContext) error {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "Error listing work item types"))
 		}
 		// Remove "planneritem" from the list of WITs
-		witModels := []workitem.WorkItemType{}
-		for _, wit := range witModelsOrig {
-			if wit.ID != workitem.SystemPlannerItem {
-				witModels = append(witModels, wit)
-			}
-		}
+		witModels := stripBaseWorkItemTypes(witModelsOrig)
 		return ctx.ConditionalEntities(witModels, c.config.GetCacheControlWorkItemTypes, func() error {
 			// TEMP!!!!! Until Space Template can setup a Space, redirect to SystemSpace WITs if non are found
 			// for the space.
@@ -145,6 +140,19 @@ func (c *WorkitemtypeController) List(ctx *app.ListWorkitemtypeContext) error {
 			return ctx.OK(result)
 		})
 	})
+}
+
+// stripBaseWorkItemTypes finds base types (e.g. "planneritem") in a slice of
+// given work item types and returns a slice without those base types that shall
+// not appear in the UI.
+func stripBaseWorkItemTypes(wits []workitem.WorkItemType) []workitem.WorkItemType {
+	res := []workitem.WorkItemType{}
+	for _, wit := range wits {
+		if wit.ID != workitem.SystemPlannerItem {
+			res = append(res, wit)
+		}
+	}
+	return res
 }
 
 // ListSourceLinkTypes runs the list-source-link-types action.

--- a/controller/workitemtype_blackbox_test.go
+++ b/controller/workitemtype_blackbox_test.go
@@ -391,6 +391,10 @@ func (s *workItemTypeSuite) TestListWorkItemType200OK() {
 	assert.NotNil(s.T(), res.Header()[app.CacheControl][0])
 	require.NotNil(s.T(), res.Header()[app.ETag])
 	assert.Equal(s.T(), generateWorkItemTypesTag(*witCollection), res.Header()[app.ETag][0])
+	// make sure the planneritem work item type is not included
+	for _, wit := range witCollection.Data {
+		require.NotEqual(s.T(), workitem.SystemPlannerItem, *wit.ID, "planner item must not be returned")
+	}
 }
 
 // TestListWorkItemType200UsingExpiredIfModifiedSinceHeader tests if we can find the work item types

--- a/controller/workitemtype_whitebox_test.go
+++ b/controller/workitemtype_whitebox_test.go
@@ -169,3 +169,18 @@ func TestConvertFieldTypeToModel(t *testing.T) {
 	_, err := convertFieldTypeToModel(app.FieldType{Kind: "DefinitivelyNotAType"})
 	assert.NotNil(t, err)
 }
+
+func TestStripBaseWorkItemTypes(t *testing.T) {
+	// given
+	wits := []workitem.WorkItemType{
+		{ID: workitem.SystemBug},
+		{ID: workitem.SystemPlannerItem},
+		{ID: workitem.SystemFeature},
+	}
+	// when
+	stripped := stripBaseWorkItemTypes(wits)
+	// then
+	require.Len(t, stripped, 2)
+	require.Equal(t, workitem.WorkItemType{ID: workitem.SystemBug}, stripped[0])
+	require.Equal(t, workitem.WorkItemType{ID: workitem.SystemFeature}, stripped[1])
+}


### PR DESCRIPTION
Make sure that every action in every controller that returns a list of work item types (`app.WorkItemTypeList`) returns them without the base types (e.g. `planneritem` included). 

This is a follow up PR for #1265 and especially in order to address this comment: https://github.com/almighty/almighty-core/pull/1265#discussion_r113763532 and get rid of this hack in the UI https://github.com/fabric8io/fabric8-planner/pull/1800