### PR TITLE
Added validation for the names of areas, iterations, link categories,…

### DIFF
--- a/controller/area_blackbox_test.go
+++ b/controller/area_blackbox_test.go
@@ -137,6 +137,27 @@ func (rest *TestAreaREST) TestFailCreateChildAreaNotAuthorized() {
 	test.CreateChildAreaUnauthorized(rest.T(), svc.Context, svc, ctrl, parentID.String(), createChildAreaPayload)
 }
 
+func (rest *TestAreaREST) TestFailValidationAreaNameLength() {
+	// given
+	ci := getCreateChildAreaPayload(&testsupport.TestOversizedNameObj)
+
+	err := ci.Validate()
+	// Validate payload function returns an error
+	assert.NotNil(rest.T(), err)
+	assert.Contains(rest.T(), err.Error(), "length of response.name must be less than or equal to than 62")
+}
+
+func (rest *TestAreaREST) TestFailValidationAreaNameStartWith() {
+	// given
+	name := "_TestSuccessCreateChildArea"
+	ci := getCreateChildAreaPayload(&name)
+
+	err := ci.Validate()
+	// Validate payload function returns an error
+	assert.NotNil(rest.T(), err)
+	assert.Contains(rest.T(), err.Error(), "response.name must match the regexp")
+}
+
 func (rest *TestAreaREST) TestFailShowAreaNotFound() {
 	// given
 	svc, ctrl := rest.SecuredController()

--- a/controller/iteration_test.go
+++ b/controller/iteration_test.go
@@ -88,6 +88,33 @@ func (rest *TestIterationREST) TestSuccessCreateChildIteration() {
 	assert.Equal(rest.T(), 0, created.Data.Relationships.Workitems.Meta["closed"])
 }
 
+func (rest *TestIterationREST) TestFailValidationIterationNameLength() {
+	// given
+	_, _, _, parent := createSpaceAndRootAreaAndIterations(rest.T(), rest.db)
+	_, err := rest.db.Iterations().Root(context.Background(), parent.SpaceID)
+	require.Nil(rest.T(), err)
+	ci := getChildIterationPayload(&testsupport.TestOversizedNameObj)
+
+	err = ci.Validate()
+	// Validate payload function returns an error
+	assert.NotNil(rest.T(), err)
+	assert.Contains(rest.T(), err.Error(), "length of response.name must be less than or equal to than 62")
+}
+
+func (rest *TestIterationREST) TestFailValidationIterationNameStartWith() {
+	// given
+	_, _, _, parent := createSpaceAndRootAreaAndIterations(rest.T(), rest.db)
+	_, err := rest.db.Iterations().Root(context.Background(), parent.SpaceID)
+	require.Nil(rest.T(), err)
+	name := "_Sprint #21"
+	ci := getChildIterationPayload(&name)
+
+	err = ci.Validate()
+	// Validate payload function returns an error
+	assert.NotNil(rest.T(), err)
+	assert.Contains(rest.T(), err.Error(), "response.name must match the regexp")
+}
+
 func (rest *TestIterationREST) TestFailCreateChildIterationMissingName() {
 	// given
 	_, _, _, itr := createSpaceAndRootAreaAndIterations(rest.T(), rest.db)

--- a/controller/space_test.go
+++ b/controller/space_test.go
@@ -29,8 +29,6 @@ import (
 
 var spaceConfiguration *configuration.ConfigurationData
 
-var testOversizedSpaceName = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-
 type DummyResourceManager struct {
 }
 
@@ -95,7 +93,7 @@ func (rest *TestSpaceREST) TestFailCreateSpaceUnsecure() {
 func (rest *TestSpaceREST) TestFailValidationSpaceNameLength() {
 	// given
 	p := minimumRequiredCreateSpace()
-	p.Data.Attributes.Name = &testOversizedSpaceName
+	p.Data.Attributes.Name = &testsupport.TestOversizedNameObj
 
 	err := p.Validate()
 	// Validate payload function returns an error
@@ -228,7 +226,7 @@ func (rest *TestSpaceREST) TestFailUpdateSpaceNameLength() {
 	u := minimumRequiredUpdateSpace()
 	u.Data.ID = created.Data.ID
 	u.Data.Attributes.Version = created.Data.Attributes.Version
-	p.Data.Attributes.Name = &testOversizedSpaceName
+	p.Data.Attributes.Name = &testsupport.TestOversizedNameObj
 	svc2, ctrl2 := rest.SecuredController(testsupport.TestIdentity2)
 
 	test.UpdateSpaceBadRequest(rest.T(), svc2.Context, svc2, ctrl2, created.Data.ID.String(), u)

--- a/controller/work_item_link_category_blackbox_test.go
+++ b/controller/work_item_link_category_blackbox_test.go
@@ -20,10 +20,10 @@ import (
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-
-	uuid "github.com/satori/go.uuid"
 )
 
 // In order for 'go test' to run this suite, we need to create
@@ -171,7 +171,55 @@ func (s *workItemLinkCategorySuite) TestCreateWorkItemLinkCategoryBadRequest() {
 			},
 		},
 	}
-	test.CreateWorkItemLinkCategoryBadRequest(s.T(), s.svc.Context, s.svc, s.linkCatCtrl, payload)
+	err := payload.Validate()
+
+	// Validate payload function returns an error
+	assert.NotNil(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "response.name must match the regexp")
+}
+
+func (s *workItemLinkCategorySuite) TestFailValidationWorkItemLinkCategoryNameLength() {
+	// given
+	description := "New description for work item link category."
+	id := uuid.FromStringOrNil("88727441-4a21-4b35-aabe-007f8273cdBB")
+	payload := &app.CreateWorkItemLinkCategoryPayload{
+		Data: &app.WorkItemLinkCategoryData{
+			ID:   &id,
+			Type: link.EndpointWorkItemLinkCategories,
+			Attributes: &app.WorkItemLinkCategoryAttributes{
+				Name:        &testsupport.TestOversizedNameObj,
+				Description: &description,
+			},
+		},
+	}
+
+	err := payload.Validate()
+
+	// Validate payload function returns an error
+	assert.NotNil(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "length of response.name must be less than or equal to than 62")
+}
+
+func (s *workItemLinkCategorySuite) TestFailValidationWorkItemLinkCategoryNameStartWith() {
+	// given
+	description := "New description for work item link category."
+	name := "_Name" // This will lead to a bad parameter error
+	id := uuid.FromStringOrNil("88727441-4a21-4b35-aabe-007f8273cdBB")
+	payload := &app.CreateWorkItemLinkCategoryPayload{
+		Data: &app.WorkItemLinkCategoryData{
+			ID:   &id,
+			Type: link.EndpointWorkItemLinkCategories,
+			Attributes: &app.WorkItemLinkCategoryAttributes{
+				Name:        &name,
+				Description: &description,
+			},
+		},
+	}
+
+	err := payload.Validate()
+	// Validate payload function returns an error
+	assert.NotNil(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "response.name must match the regexp")
 }
 
 func (s *workItemLinkCategorySuite) TestDeleteWorkItemLinkCategoryNotFound() {

--- a/controller/workitemtype_blackbox_test.go
+++ b/controller/workitemtype_blackbox_test.go
@@ -270,6 +270,73 @@ func (s *workItemTypeSuite) TestCreateWorkItemType() {
 	_, _ = s.createWorkItemTypePerson()
 }
 
+func (s *workItemTypeSuite) TestFailValidationIterationNameLength() {
+	// given
+	nameFieldDef := app.FieldDefinition{
+		Required: true,
+		Type: &app.FieldType{
+			Kind: "string",
+		},
+	}
+
+	// Use the goa generated code to create a work item type
+	desc := "Description for 'person'"
+	id := personID
+	payload := app.CreateWorkitemtypePayload{
+		Data: &app.WorkItemTypeData{
+			ID:   &id,
+			Type: "workitemtypes",
+			Attributes: &app.WorkItemTypeAttributes{
+				Name:        testsupport.TestOversizedNameObj,
+				Description: &desc,
+				Icon:        "fa-user",
+				Fields: map[string]*app.FieldDefinition{
+					"name": &nameFieldDef,
+				},
+			},
+		},
+	}
+
+	err := payload.Validate()
+	// Validate payload function returns an error
+	assert.NotNil(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "length of response.name must be less than or equal to than 62")
+}
+
+func (s *workItemTypeSuite) TestFailValidationWorkItemTypeNameStartWith() {
+	// Create the type for the "color" field
+	nameFieldDef := app.FieldDefinition{
+		Required: true,
+		Type: &app.FieldType{
+			Kind: "string",
+		},
+	}
+
+	// Use the goa generated code to create a work item type
+	desc := "Description for 'person'"
+	id := personID
+	payload := app.CreateWorkitemtypePayload{
+		Data: &app.WorkItemTypeData{
+			ID:   &id,
+			Type: "workitemtypes",
+			Attributes: &app.WorkItemTypeAttributes{
+				Name:        "_person",
+				Description: &desc,
+				Icon:        "fa-user",
+				Fields: map[string]*app.FieldDefinition{
+					"name": &nameFieldDef,
+				},
+			},
+		},
+	}
+
+	err := payload.Validate()
+
+	// Validate payload function returns an error
+	assert.NotNil(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "response.name must match the regexp")
+}
+
 // TestShowWorkItemType200OK tests if we can fetch the work item type "animal".
 func (s *workItemTypeSuite) TestShowWorkItemType200OK() {
 	// given

--- a/design/areas.go
+++ b/design/areas.go
@@ -22,6 +22,9 @@ var area = a.Type("Area", func() {
 var areaAttributes = a.Type("AreaAttributes", func() {
 	a.Description(`JSONAPI store for all the "attributes" of a Area. See also see http://jsonapi.org/format/#document-resource-object-attributes`)
 	a.Attribute("name", d.String, "The Area name", func() {
+		a.MaxLength(62) // maximum area name length is 62 characters
+		a.MinLength(1)  // minimum area name length is 1 characters
+		a.Pattern("^[^_|-].*")
 		a.Example("Area for Build related stuff")
 	})
 	a.Attribute("created-at", d.DateTime, "When the area was created", func() {

--- a/design/areas.go
+++ b/design/areas.go
@@ -21,12 +21,7 @@ var area = a.Type("Area", func() {
 
 var areaAttributes = a.Type("AreaAttributes", func() {
 	a.Description(`JSONAPI store for all the "attributes" of a Area. See also see http://jsonapi.org/format/#document-resource-object-attributes`)
-	a.Attribute("name", d.String, "The Area name", func() {
-		a.MaxLength(62) // maximum area name length is 62 characters
-		a.MinLength(1)  // minimum area name length is 1 characters
-		a.Pattern("^[^_|-].*")
-		a.Example("Area for Build related stuff")
-	})
+	a.Attribute("name", d.String, "The Area name", nameValidationFunction)
 	a.Attribute("created-at", d.DateTime, "When the area was created", func() {
 		a.Example("2016-11-29T23:18:14Z")
 	})

--- a/design/iterations.go
+++ b/design/iterations.go
@@ -21,12 +21,7 @@ var iteration = a.Type("Iteration", func() {
 
 var iterationAttributes = a.Type("IterationAttributes", func() {
 	a.Description(`JSONAPI store for all the "attributes" of a iteration. +See also see http://jsonapi.org/format/#document-resource-object-attributes`)
-	a.Attribute("name", d.String, "The iteration name", func() {
-		a.MaxLength(62) // maximum iteration name length is 62 characters
-		a.MinLength(1)  // minimum iteration name length is 1 characters
-		a.Pattern("^[^_|-].*")
-		a.Example("Sprint #24")
-	})
+	a.Attribute("name", d.String, "The iteration name", nameValidationFunction)
 	a.Attribute("description", d.String, "Description of the iteration ", func() {
 		a.Example("Sprint #42 focusing on UI and build process improvements")
 	})

--- a/design/iterations.go
+++ b/design/iterations.go
@@ -22,6 +22,9 @@ var iteration = a.Type("Iteration", func() {
 var iterationAttributes = a.Type("IterationAttributes", func() {
 	a.Description(`JSONAPI store for all the "attributes" of a iteration. +See also see http://jsonapi.org/format/#document-resource-object-attributes`)
 	a.Attribute("name", d.String, "The iteration name", func() {
+		a.MaxLength(62) // maximum iteration name length is 62 characters
+		a.MinLength(1)  // minimum iteration name length is 1 characters
+		a.Pattern("^[^_|-].*")
 		a.Example("Sprint #24")
 	})
 	a.Attribute("description", d.String, "Description of the iteration ", func() {

--- a/design/resources.go
+++ b/design/resources.go
@@ -179,3 +179,10 @@ var _ = a.Resource("trackerquery", func() {
 		a.Response(d.NotFound, JSONAPIErrors)
 	})
 })
+
+var nameValidationFunction = func() {
+	a.MaxLength(62) // maximum name length is 62 characters
+	a.MinLength(1)  // minimum name length is 1 characters
+	a.Pattern("^[^_|-].*")
+	a.Example("name for the object")
+}

--- a/design/spaces.go
+++ b/design/spaces.go
@@ -57,11 +57,7 @@ var spaceOwnedBy = a.Type("SpaceOwnedBy", func() {
 })
 
 var spaceAttributes = a.Type("SpaceAttributes", func() {
-	a.Attribute("name", d.String, "Name for the space", func() {
-		a.MaxLength(62) // maximum space name length is 62 characters
-		a.MinLength(1)  // minimum space name length is 1 characters
-		a.Pattern("^[^_|-].*")
-	})
+	a.Attribute("name", d.String, "Name for the space", nameValidationFunction)
 	a.Attribute("description", d.String, "Description for the space", func() {
 		a.Example("This is the foobar collaboration space")
 	})

--- a/design/spaces.go
+++ b/design/spaces.go
@@ -57,14 +57,7 @@ var spaceOwnedBy = a.Type("SpaceOwnedBy", func() {
 })
 
 var spaceAttributes = a.Type("SpaceAttributes", func() {
-	a.Attribute("name", d.String, "Name for the space", func() {
-		a.MaxLength(62) // maximum name length is 62 characters
-		a.MinLength(1)  // minimum name length is 1 characters
-		// Avoid the creation of a space name using the name 'home' (case insensitive)
-		// Avoid space names that start with _ or -
-		a.Pattern("^(?i)(h(o(m([^e]|$)|[^m]|$)|[^o]|$)|[^h_-]).*$")
-		a.Example("name for the space")
-	})
+	a.Attribute("name", d.String, "Name for the space", nameValidationFunction)
 	a.Attribute("description", d.String, "Description for the space", func() {
 		a.Example("This is the foobar collaboration space")
 	})

--- a/design/spaces.go
+++ b/design/spaces.go
@@ -58,9 +58,11 @@ var spaceOwnedBy = a.Type("SpaceOwnedBy", func() {
 
 var spaceAttributes = a.Type("SpaceAttributes", func() {
 	a.Attribute("name", d.String, "Name for the space", func() {
-		a.MaxLength(62)                                             // maximum name length is 62 characters
-		a.MinLength(1)                                              // minimum name length is 1 characters
-		a.Pattern("^(?i)(h(o(m([^e]|$)|[^m]|$)|[^o]|$)|[^h_-]).*$") // Match _|-|home space name
+		a.MaxLength(62) // maximum name length is 62 characters
+		a.MinLength(1)  // minimum name length is 1 characters
+		// Avoid the creation of a space name using the name 'home' (case insensitive)
+		// Avoid space names that start with _ or -
+		a.Pattern("^(?i)(h(o(m([^e]|$)|[^m]|$)|[^o]|$)|[^h_-]).*$")
 		a.Example("name for the space")
 	})
 	a.Attribute("description", d.String, "Description for the space", func() {

--- a/design/spaces.go
+++ b/design/spaces.go
@@ -57,7 +57,12 @@ var spaceOwnedBy = a.Type("SpaceOwnedBy", func() {
 })
 
 var spaceAttributes = a.Type("SpaceAttributes", func() {
-	a.Attribute("name", d.String, "Name for the space", nameValidationFunction)
+	a.Attribute("name", d.String, "Name for the space", func() {
+		a.MaxLength(62)                                             // maximum name length is 62 characters
+		a.MinLength(1)                                              // minimum name length is 1 characters
+		a.Pattern("^(?i)(h(o(m([^e]|$)|[^m]|$)|[^o]|$)|[^h_-]).*$") // Match _|-|home space name
+		a.Example("name for the space")
+	})
 	a.Attribute("description", d.String, "Description for the space", func() {
 		a.Example("This is the foobar collaboration space")
 	})

--- a/design/work_item_link_category.go
+++ b/design/work_item_link_category.go
@@ -53,6 +53,9 @@ var workItemLinkCategoryAttributes = a.Type("WorkItemLinkCategoryAttributes", fu
 	a.Description(`JSONAPI store for all the "attributes" of a work item link category.
 See also http://jsonapi.org/format/#document-resource-object-attributes`)
 	a.Attribute("name", d.String, "Name of the work item link category (required on creation, optional on update)", func() {
+		a.MaxLength(62) // maximum work item link category name length is 62 characters
+		a.MinLength(1)  // minimum work item link category name length is 1 characters
+		a.Pattern("^[^_|-].*")
 		a.Example("system")
 	})
 	a.Attribute("description", d.String, "Description of the work item link category (optional)", func() {

--- a/design/work_item_link_category.go
+++ b/design/work_item_link_category.go
@@ -52,12 +52,7 @@ See also http://jsonapi.org/format/#document-resource-object`)
 var workItemLinkCategoryAttributes = a.Type("WorkItemLinkCategoryAttributes", func() {
 	a.Description(`JSONAPI store for all the "attributes" of a work item link category.
 See also http://jsonapi.org/format/#document-resource-object-attributes`)
-	a.Attribute("name", d.String, "Name of the work item link category (required on creation, optional on update)", func() {
-		a.MaxLength(62) // maximum work item link category name length is 62 characters
-		a.MinLength(1)  // minimum work item link category name length is 1 characters
-		a.Pattern("^[^_|-].*")
-		a.Example("system")
-	})
+	a.Attribute("name", d.String, "Name of the work item link category (required on creation, optional on update)", nameValidationFunction)
 	a.Attribute("description", d.String, "Description of the work item link category (optional)", func() {
 		a.Example("A work item link category that is meant only for work item link types goverened by the system alone.")
 	})

--- a/design/work_item_link_type.go
+++ b/design/work_item_link_type.go
@@ -44,6 +44,9 @@ var workItemLinkTypeAttributes = a.Type("WorkItemLinkTypeAttributes", func() {
 	a.Description(`JSONAPI store for all the "attributes" of a work item link type.
 See also see http://jsonapi.org/format/#document-resource-object-attributes`)
 	a.Attribute("name", d.String, "Name of the work item link type (required on creation, optional on update)", func() {
+		a.MaxLength(62) // maximum work item link type name length is 62 characters
+		a.MinLength(1)  // minimum work item link type name length is 1 characters
+		a.Pattern("^[^_|-].*")
 		a.Example("tested-by-link-type")
 	})
 	a.Attribute("description", d.String, "Description of the work item link type (optional)", func() {

--- a/design/work_item_link_type.go
+++ b/design/work_item_link_type.go
@@ -43,12 +43,7 @@ See also http://jsonapi.org/format/#document-resource-object`)
 var workItemLinkTypeAttributes = a.Type("WorkItemLinkTypeAttributes", func() {
 	a.Description(`JSONAPI store for all the "attributes" of a work item link type.
 See also see http://jsonapi.org/format/#document-resource-object-attributes`)
-	a.Attribute("name", d.String, "Name of the work item link type (required on creation, optional on update)", func() {
-		a.MaxLength(62) // maximum work item link type name length is 62 characters
-		a.MinLength(1)  // minimum work item link type name length is 1 characters
-		a.Pattern("^[^_|-].*")
-		a.Example("tested-by-link-type")
-	})
+	a.Attribute("name", d.String, "Name of the work item link type (required on creation, optional on update)", nameValidationFunction)
 	a.Attribute("description", d.String, "Description of the work item link type (optional)", func() {
 		a.Example("A test work item can 'test' if a the code in a pull request passes the tests.")
 	})

--- a/design/workitemtype.go
+++ b/design/workitemtype.go
@@ -39,7 +39,9 @@ var workItemTypeAttributes = a.Type("WorkItemTypeAttributes", func() {
 	a.Attribute("updated-at", d.DateTime, "timestamp of last entity update")
 	a.Attribute("name", d.String, "The human readable name of the work item type", func() {
 		a.Example("User story")
-		a.MinLength(1)
+		a.MaxLength(62) // maximum work item type name length is 62 characters
+		a.MinLength(1)  // minimum work item type name length is 1 characters
+		a.Pattern("^[^_|-].*")
 	})
 	a.Attribute("description", d.String, "A human readable description for the work item type", func() {
 		a.Example(`A user story encapsulates the action of one function making it possible for software developers to create a vertical slice of their work.`)

--- a/design/workitemtype.go
+++ b/design/workitemtype.go
@@ -37,12 +37,7 @@ var workItemTypeAttributes = a.Type("WorkItemTypeAttributes", func() {
 	a.Attribute("version", d.Integer, "Version for optimistic concurrency control")
 	a.Attribute("created-at", d.DateTime, "timestamp of entity creation")
 	a.Attribute("updated-at", d.DateTime, "timestamp of last entity update")
-	a.Attribute("name", d.String, "The human readable name of the work item type", func() {
-		a.Example("User story")
-		a.MaxLength(62) // maximum work item type name length is 62 characters
-		a.MinLength(1)  // minimum work item type name length is 1 characters
-		a.Pattern("^[^_|-].*")
-	})
+	a.Attribute("name", d.String, "The human readable name of the work item type", nameValidationFunction)
 	a.Attribute("description", d.String, "A human readable description for the work item type", func() {
 		a.Example(`A user story encapsulates the action of one function making it possible for software developers to create a vertical slice of their work.`)
 	})

--- a/test/common.go
+++ b/test/common.go
@@ -7,6 +7,8 @@ import (
 
 const maxValidNameLength = 62
 
+var TestOversizedNameObj = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
 // CreateRandomValidTestName functions creates a valid lenght name
 func CreateRandomValidTestName(name string) string {
 	randomName := name + uuid.NewV4().String()


### PR DESCRIPTION
I thought about adding an issue but it'll take me the same amount of time to create a PR. 

I think we need to validate the name for areas, iterations, work item types, link category, link type as specified in this document (https://docs.google.com/spreadsheets/d/1cNSDuek0v1EBPpdPlFwG_Y_yOlux86m9MYf9UrF82l4/edit#gid=208615194). We already did that for the spaces: https://github.com/almighty/almighty-core/pull/1175/files

ping @joshuawilson @aslakknutsen

TODO:
- [x] Add their respective tests

 
