### PR TITLE
wip: Update Keycloak with PATCH User only when necessary

### DIFF
--- a/login/profile.go
+++ b/login/profile.go
@@ -16,6 +16,7 @@ const ImageURLAttributeName = "imageURL"
 const BioAttributeName = "bio"
 const URLAttributeName = "url"
 const CompanyAttributeName = "company"
+const RegistrationCompletedAttributeName = "registrationCompleted"
 const ApprovedAttributeName = "approved"
 
 // KeycloakUserProfile represents standard Keycloak User profile api request payload
@@ -99,6 +100,11 @@ func (userProfileClient *KeycloakUserProfileClient) Update(keycloakUserProfile *
 		}, "Unable to update Keycloak user profile")
 		return errors.NewInternalError(err.Error())
 	} else if resp != nil {
+		log.Info(context.Background(), map[string]interface{}{
+			"keycloak_user_profile_url": keycloakProfileURL,
+			"err": err,
+		}, "Successfully updated Keycloak user profile")
+
 		defer resp.Body.Close()
 	}
 
@@ -142,6 +148,12 @@ func (userProfileClient *KeycloakUserProfileClient) Get(accessToken string, keyc
 		}, "Unable to fetch Keycloak user profile")
 		return nil, errors.NewInternalError(err.Error())
 	} else if resp != nil {
+
+		log.Info(context.Background(), map[string]interface{}{
+			"keycloak_user_profile_url": keycloakProfileURL,
+			"err": err,
+		}, "Successfully fetched Keycloak user profile")
+
 		defer resp.Body.Close()
 	}
 

--- a/login/profile.go
+++ b/login/profile.go
@@ -16,7 +16,6 @@ const ImageURLAttributeName = "imageURL"
 const BioAttributeName = "bio"
 const URLAttributeName = "url"
 const CompanyAttributeName = "company"
-const RegistrationCompletedAttributeName = "registrationCompleted"
 const ApprovedAttributeName = "approved"
 
 // KeycloakUserProfile represents standard Keycloak User profile api request payload


### PR DESCRIPTION
1. Ensure `PATCH` of  `contextInformation` in Users API does not call Keycloak.
2. Compare old/new values and decide if keycloak needs to be updated 
3. Conditionally call keycloak only if any of the keycloak related user properties change.

fixes #1256 