### PR TITLE
Split DeveloperMode and LogFormat

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -87,6 +87,7 @@ const (
 	varCheStarterURL                    = "chestarterurl"
 	varValidRedirectURLs                = "redirect.valid"
 	varLogLevel                         = "log.level"
+	varLogJSON                          = "log.json"
 	varTenantServiceURL                 = "tenant.serviceurl"
 )
 
@@ -602,6 +603,17 @@ func (c *ConfigurationData) GetOpenshiftTenantMasterURL() string {
 // GetLogLevel returns the loggging level (as set via config file or environment variable)
 func (c *ConfigurationData) GetLogLevel() string {
 	return c.v.GetString(varLogLevel)
+}
+
+// IsLogJSON returns if we should log json format (as set via config file or environment variable)
+func (c *ConfigurationData) IsLogJSON() bool {
+	if c.v.IsSet(varLogJSON) {
+		return c.v.GetBool(varLogJSON)
+	}
+	if c.IsPostgresDeveloperModeEnabled() {
+		return false
+	}
+	return true
 }
 
 // GetValidRedirectURLs returns the RegEx of valid redirect URLs for auth requests

--- a/log/log.go
+++ b/log/log.go
@@ -23,9 +23,8 @@ var (
 	}
 )
 
-// InitializeLogger creates a default logger whose ouput format, log level differs
-// depending of whether the developer mode flag is enable/disabled.
-func InitializeLogger(developerModeFlag bool, lvl string) {
+// InitializeLogger creates a default logger with the given ouput format and log level
+func InitializeLogger(logJSON bool, lvl string) {
 	logger = log.New()
 
 	logLevel, err := log.ParseLevel(lvl)
@@ -36,18 +35,18 @@ func InitializeLogger(developerModeFlag bool, lvl string) {
 	log.SetLevel(logLevel)
 	logger.Level = logLevel
 
-	if developerModeFlag {
-		customFormatter := new(log.TextFormatter)
-		customFormatter.FullTimestamp = true
-		customFormatter.TimestampFormat = "2006-01-02 15:04:05"
-		log.SetFormatter(customFormatter)
-		logger.Formatter = customFormatter
-	} else {
+	if logJSON {
 		customFormatter := new(log.JSONFormatter)
 		customFormatter.TimestampFormat = "2006-01-02 15:04:05"
 
 		log.SetFormatter(customFormatter)
 		customFormatter.DisableTimestamp = false
+		logger.Formatter = customFormatter
+	} else {
+		customFormatter := new(log.TextFormatter)
+		customFormatter.FullTimestamp = true
+		customFormatter.TimestampFormat = "2006-01-02 15:04:05"
+		log.SetFormatter(customFormatter)
 		logger.Formatter = customFormatter
 	}
 
@@ -55,8 +54,8 @@ func InitializeLogger(developerModeFlag bool, lvl string) {
 }
 
 // NewCustomizedLogger creates a custom logger specifying the desired log level
-// and the developer mode flag. Returns the logger object and the error.
-func NewCustomizedLogger(level string, developerModeFlag bool) (*log.Logger, error) {
+// and the log format flag. Returns the logger object and the error.
+func NewCustomizedLogger(level string, logJSON bool) (*log.Logger, error) {
 	logger := log.New()
 
 	lv, err := log.ParseLevel(level)
@@ -65,16 +64,7 @@ func NewCustomizedLogger(level string, developerModeFlag bool) (*log.Logger, err
 	}
 	logger.Level = lv
 
-	if developerModeFlag {
-		customFormatter := new(log.TextFormatter)
-		customFormatter.FullTimestamp = true
-		customFormatter.TimestampFormat = "2006-01-02 15:04:05"
-		log.SetFormatter(customFormatter)
-
-		log.SetLevel(log.DebugLevel)
-		logger.Level = lv
-		logger.Formatter = customFormatter
-	} else {
+	if logJSON {
 		customFormatter := new(log.JSONFormatter)
 		customFormatter.TimestampFormat = "2006-01-02 15:04:05"
 
@@ -82,6 +72,15 @@ func NewCustomizedLogger(level string, developerModeFlag bool) (*log.Logger, err
 		customFormatter.DisableTimestamp = false
 
 		log.SetLevel(log.InfoLevel)
+		logger.Level = lv
+		logger.Formatter = customFormatter
+	} else {
+		customFormatter := new(log.TextFormatter)
+		customFormatter.FullTimestamp = true
+		customFormatter.TimestampFormat = "2006-01-02 15:04:05"
+		log.SetFormatter(customFormatter)
+
+		log.SetLevel(log.DebugLevel)
 		logger.Level = lv
 		logger.Formatter = customFormatter
 	}

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -13,7 +13,7 @@ func LogAndAssertJSON(t *testing.T, log func(), assertions func(fields logrus.Fi
 	var buffer bytes.Buffer
 	var fields logrus.Fields
 
-	InitializeLogger(false, "debug")
+	InitializeLogger(true, "debug")
 	logger.Out = &buffer
 	logger.Level = logrus.DebugLevel
 	log()

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 	}
 
 	// Initialized developer mode flag and log level for the logger
-	log.InitializeLogger(configuration.IsPostgresDeveloperModeEnabled(), configuration.GetLogLevel())
+	log.InitializeLogger(configuration.IsLogJSON(), configuration.GetLogLevel())
 
 	printUserInfo()
 


### PR DESCRIPTION
Default to log plain text if dev mode, but
allow to log JSON if specified

Required by Performance tests to still log in JSON
while using dev mode features of the server.

