### PR TITLE
Use fixed IDs for system-defined link types and categories

### DIFF
--- a/controller/work_item_link.go
+++ b/controller/work_item_link.go
@@ -83,7 +83,7 @@ func getTypesOfLinks(ctx *workItemLinkContext, linksDataArr []*app.WorkItemLinkD
 	// Now include the optional link type data in the work item link "included" array
 	linkTypeModels := []link.WorkItemLinkType{}
 	for typeID := range typeIDMap {
-		linkTypeModel, err := ctx.Application.WorkItemLinkTypes().LoadByID(ctx.Context, typeID)
+		linkTypeModel, err := ctx.Application.WorkItemLinkTypes().Load(ctx.Context, typeID)
 		if err != nil {
 			return nil, errs.WithStack(err)
 		}
@@ -141,7 +141,7 @@ func getCategoriesOfLinkTypes(ctx *workItemLinkContext, linkTypeDataArr []*app.W
 // enrichLinkSingle includes related resources in the link's "included" array
 func enrichLinkSingle(ctx *workItemLinkContext, appLinks *app.WorkItemLinkSingle) error {
 	// include link type
-	modelLinkType, err := ctx.Application.WorkItemLinkTypes().LoadByID(ctx.Context, appLinks.Data.Relationships.LinkType.Data.ID)
+	modelLinkType, err := ctx.Application.WorkItemLinkTypes().Load(ctx.Context, appLinks.Data.Relationships.LinkType.Data.ID)
 	if err != nil {
 		return errs.WithStack(err)
 	}

--- a/controller/work_item_link_category.go
+++ b/controller/work_item_link_category.go
@@ -58,12 +58,13 @@ func (c *WorkItemLinkCategoryController) Create(ctx *app.CreateWorkItemLinkCateg
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
 	return application.Transactional(c.db, func(appl application.Application) error {
-		modelCategory, err := appl.WorkItemLinkCategories().Create(ctx.Context, ctx.Payload.Data.Attributes.Name, ctx.Payload.Data.Attributes.Description)
+		modelCategory := convertLinkCategoryToModel(app.WorkItemLinkCategorySingle{Data: ctx.Payload.Data})
+		_, err := appl.WorkItemLinkCategories().Create(ctx.Context, &modelCategory)
 		if err != nil {
 			jerrors, httpStatusCode := jsonapi.ErrorToJSONAPIErrors(err)
 			return ctx.ResponseData.Service.Send(ctx.Context, httpStatusCode, jerrors)
 		}
-		appCategory := convertLinkCategoryFromModel(*modelCategory)
+		appCategory := convertLinkCategoryFromModel(modelCategory)
 		linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkCategoryHref, currentUserIdentityID)
 		err = enrichLinkCategorySingle(linkCtx, appCategory)
 		if err != nil {

--- a/controller/work_item_link_type.go
+++ b/controller/work_item_link_type.go
@@ -147,7 +147,7 @@ func (c *WorkItemLinkTypeController) Create(ctx *app.CreateWorkItemLinkTypeConte
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
 	return application.Transactional(c.db, func(appl application.Application) error {
-		createdModelLinkType, err := appl.WorkItemLinkTypes().Create(ctx.Context, modelLinkType.Name, modelLinkType.Description, modelLinkType.SourceTypeID, modelLinkType.TargetTypeID, modelLinkType.ForwardName, modelLinkType.ReverseName, modelLinkType.Topology, modelLinkType.LinkCategoryID, modelLinkType.SpaceID)
+		createdModelLinkType, err := appl.WorkItemLinkTypes().Create(ctx.Context, modelLinkType)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
@@ -235,7 +235,7 @@ func (c *WorkItemLinkTypeController) Show(ctx *app.ShowWorkItemLinkTypeContext) 
 			return jsonapi.JSONErrorResponse(ctx, errors.NewNotFoundError("work item link type ID", ctx.WiltID))
 		}
 
-		modelLinkType, err := appl.WorkItemLinkTypes().Load(ctx.Context, spaceID, wiltID)
+		modelLinkType, err := appl.WorkItemLinkTypes().Load(ctx.Context, wiltID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}

--- a/migration/sql-files/059-fixed-ids-for-system-link-types-and-categories.sql
+++ b/migration/sql-files/059-fixed-ids-for-system-link-types-and-categories.sql
@@ -1,0 +1,83 @@
+-- 1. First make sure that the link type IDs are consistent across all systems.
+--    We therefore copy the existing link types and only change the ID value to
+--    the ones pre-defined in code.
+-- 2. Then we make sure all existing links that pointed to the old ID now point
+--    to the duplicated row with the new ID.
+-- 3. Then we can delete all the old link types.
+
+-- The same we do for the "user" and "system" link categories.
+
+--------------------
+-- HANDLE LINK TYPES
+--------------------
+
+-- Duplicate the old SystemWorkItemLinkTypeBugBlocker and use a new ID
+-- We have to use a different name in order to not violate the uniq key
+-- "work_item_link_types_name_idx". The name will later be updated through
+-- the migration.
+INSERT INTO work_item_link_types(id, created_at, updated_at, deleted_at,
+    name, version, topology, forward_name, reverse_name, link_category_id,
+    source_type_id, target_type_id, space_id)
+    SELECT '{{index . 0}}', created_at, updated_at, deleted_at,
+    '{{index . 0}}', version, topology, forward_name, reverse_name, link_category_id,
+    source_type_id, target_type_id, space_id 
+    FROM work_item_link_types
+    WHERE name='Bug blocker';
+
+-- Duplicate the old SystemWorkItemLinkPlannerItemRelated and use a new ID
+INSERT INTO work_item_link_types(id, created_at, updated_at, deleted_at,
+    name, version, topology, forward_name, reverse_name, link_category_id,
+    source_type_id, target_type_id, space_id)
+    SELECT '{{index . 1}}', created_at, updated_at, deleted_at,
+    '{{index . 1}}', version, topology, forward_name, reverse_name, link_category_id,
+    source_type_id, target_type_id, space_id 
+    FROM work_item_link_types
+    WHERE name='Related planner item';
+
+INSERT INTO work_item_link_types(id, created_at, updated_at, deleted_at,
+    name, version, topology, forward_name, reverse_name, link_category_id,
+    source_type_id, target_type_id, space_id)
+    SELECT '{{index . 2}}', created_at, updated_at, deleted_at,
+    '{{index . 2}}', version, topology, forward_name, reverse_name, link_category_id,
+    source_type_id, target_type_id, space_id 
+    FROM work_item_link_types
+    WHERE name='Parent child item';
+
+-- Update existing links to use the new link type ID
+UPDATE work_item_links SET link_type_id='{{index . 0}}'
+    WHERE link_type_id = (SELECT id FROM work_item_link_types WHERE name='Bug blocker' AND id <> '{{index . 0}}');
+
+UPDATE work_item_links SET link_type_id='{{index . 1}}'
+    WHERE link_type_id = (SELECT id FROM work_item_link_types WHERE name='Related planner item' AND id <> '{{index . 1}}');
+    
+UPDATE work_item_links SET link_type_id='{{index . 2}}'
+    WHERE link_type_id = (SELECT id FROM work_item_link_types WHERE name='Parent child item' AND id <> '{{index . 2}}');
+
+-- Delete old link types and only leave the new ones.
+DELETE FROM work_item_link_types WHERE id NOT IN ('{{index . 0}}', '{{index . 1}}', '{{index . 2}}');
+
+--------------------
+-- HANDLE CATEGORIES
+--------------------
+
+-- Duplicate "system" link category
+INSERT INTO work_item_link_categories (id, created_at, updated_at, deleted_at, name, version, description)
+    SELECT '{{index . 3}}', created_at, updated_at, deleted_at, '{{index . 3}}', version, description
+    FROM work_item_link_categories
+    WHERE name='system';
+
+-- Duplicate "user" link category
+INSERT INTO work_item_link_categories (id, created_at, updated_at, deleted_at, name, version, description)
+    SELECT '{{index . 4}}', created_at, updated_at, deleted_at, '{{index . 4}}', version, description
+    FROM work_item_link_categories
+    WHERE name='user';
+
+-- Update existing link types to use the new category IDs
+UPDATE work_item_link_types SET link_category_id='{{index . 3}}'
+    WHERE link_category_id = (SELECT id FROM work_item_link_categories WHERE name='system' AND id <> '{{index . 3}}');
+
+UPDATE work_item_link_types SET link_category_id='{{index . 4}}'
+    WHERE link_category_id = (SELECT id FROM work_item_link_categories WHERE name='user' AND id <> '{{index . 4}}');
+
+-- Delete old link categories and only leave the new ones.
+DELETE FROM work_item_link_categories WHERE id NOT IN ('{{index . 3}}', '{{index . 4}}');

--- a/workitem/link/category.go
+++ b/workitem/link/category.go
@@ -6,9 +6,10 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-const (
-	SystemWorkItemLinkCategorySystem = "system"
-	SystemWorkItemLinkCategoryUser   = "user"
+// Never ever change these UUIDs!!!
+var (
+	SystemWorkItemLinkCategorySystemID = uuid.FromStringOrNil("B1482C65-A64D-4058-BEB0-62F7198CB0F4")
+	SystemWorkItemLinkCategoryUserID   = uuid.FromStringOrNil("2F24724F-797C-4073-8B16-4BB8CE9E84A6")
 )
 
 // WorkItemLinkCategory represents the category of a work item link as it is stored in the db

--- a/workitem/link/link_repository.go
+++ b/workitem/link/link_repository.go
@@ -64,7 +64,7 @@ type GormWorkItemLinkRepository struct {
 // the source WIT as defined by the work item link type is not part of
 // the actual source's WIT; the same applies for the target.
 func (r *GormWorkItemLinkRepository) ValidateCorrectSourceAndTargetType(ctx context.Context, sourceID, targetID uint64, linkTypeID uuid.UUID) error {
-	linkType, err := r.workItemLinkTypeRepo.LoadTypeFromDBByID(ctx, linkTypeID)
+	linkType, err := r.workItemLinkTypeRepo.Load(ctx, linkTypeID)
 	if err != nil {
 		return errs.WithStack(err)
 	}

--- a/workitem/link/link_revision_repository_blackbox_test.go
+++ b/workitem/link/link_revision_repository_blackbox_test.go
@@ -66,7 +66,7 @@ func (s *revisionRepositoryBlackBoxTest) SetupTest() {
 	s.testIdentity3 = testIdentity3
 	// create a space
 	spaceRepository := space.NewRepository(s.DB)
-	spaceName := "test-space" + uuid.NewV4().String()
+	spaceName := testsupport.CreateRandomValidTestName("test-space")
 	testSpace, err := spaceRepository.Create(s.ctx, &space.Space{
 		Name: spaceName,
 	})
@@ -96,16 +96,40 @@ func (s *revisionRepositoryBlackBoxTest) SetupTest() {
 
 	// Create a work item link category
 	linkCategoryRepository := link.NewWorkItemLinkCategoryRepository(s.DB)
-	categoryName := "test-category" + uuid.NewV4().String()
+	categoryName := testsupport.CreateRandomValidTestName("test-category")
 	categoryDescription := "testing work item link revisions"
-	linkCategory, err := linkCategoryRepository.Create(s.ctx, &categoryName, &categoryDescription)
+	linkCategory := link.WorkItemLinkCategory{
+		Name:        categoryName,
+		Description: &categoryDescription,
+	}
+	_, err = linkCategoryRepository.Create(s.ctx, &linkCategory)
 	require.Nil(s.T(), err)
 	// create link types
 	linkTypeRepository := link.NewWorkItemLinkTypeRepository(s.DB)
-	linkType1, err := linkTypeRepository.Create(s.ctx, "test link type 1", nil, workitem.SystemBug, workitem.SystemBug, "foo", "foo", "dependency", linkCategory.ID, testSpace.ID)
+	linkTypeModel1 := link.WorkItemLinkType{
+		Name:           "test link type 1",
+		SourceTypeID:   workitem.SystemBug,
+		TargetTypeID:   workitem.SystemBug,
+		ForwardName:    "foo",
+		ReverseName:    "foo",
+		Topology:       "dependency",
+		LinkCategoryID: linkCategory.ID,
+		SpaceID:        testSpace.ID,
+	}
+	linkType1, err := linkTypeRepository.Create(s.ctx, &linkTypeModel1)
 	require.Nil(s.T(), err)
 	s.testLinkType1ID = linkType1.ID
-	linkType2, err := linkTypeRepository.Create(s.ctx, "test link type 2", nil, workitem.SystemBug, workitem.SystemBug, "bar", "bar", "dependency", linkCategory.ID, testSpace.ID)
+	linkTypeModel2 := link.WorkItemLinkType{
+		Name:           "test link type 2",
+		SourceTypeID:   workitem.SystemBug,
+		TargetTypeID:   workitem.SystemBug,
+		ForwardName:    "bar",
+		ReverseName:    "bar",
+		Topology:       "dependency",
+		LinkCategoryID: linkCategory.ID,
+		SpaceID:        testSpace.ID,
+	}
+	linkType2, err := linkTypeRepository.Create(s.ctx, &linkTypeModel2)
 	require.Nil(s.T(), err)
 	s.testLinkType2ID = linkType2.ID
 }

--- a/workitem/link/type.go
+++ b/workitem/link/type.go
@@ -16,13 +16,13 @@ const (
 	TopologyDirectedNetwork = "directed_network"
 	TopologyDependency      = "dependency"
 	TopologyTree            = "tree"
+)
 
-	// The names of a work item link type are basically the "system.title" field
-	// as in work items. The actual linking is done with UUIDs. Hence, the names
-	// hare are more human-readable.
-	SystemWorkItemLinkTypeBugBlocker     = "Bug blocker"
-	SystemWorkItemLinkPlannerItemRelated = "Related planner item"
-	SystemWorkItemLinkTypeParentChild    = "Parent child item"
+// Never ever change these UUIDs!!!
+var (
+	SystemWorkItemLinkTypeBugBlockerID     = uuid.FromStringOrNil("2CEA3C79-3B79-423B-90F4-1E59174C8F43")
+	SystemWorkItemLinkPlannerItemRelatedID = uuid.FromStringOrNil("9B631885-83B1-4ABB-A340-3A9EDE8493FA")
+	SystemWorkItemLinkTypeParentChildID    = uuid.FromStringOrNil("25C326A7-6D03-4F5A-B23B-86A9EE4171E9")
 )
 
 // returns true if the left hand and right hand side string


### PR DESCRIPTION
In order to update the link system later I first need to make sure that work item link types and categories that have been created by the system use a pre-defined ID.

As a side-effect this will allow us to remove various loading functions that didn't properly load a category or type by an ID but by a name.

You can now pass in a complete or partial model of a category or type to the repository and have it created for you in the database. Before you needed to pass a bunch of parameters.
