### PR TITLE
Refactored codebase package

### DIFF
--- a/codebase/codebase.go
+++ b/codebase/codebase.go
@@ -14,8 +14,8 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-// CodebaseContent defines all parameters those are useful to associate Che Editor's window to a WI
-type CodebaseContent struct {
+// Content defines all parameters those are useful to associate Che Editor's window to a WI
+type Content struct {
 	Repository string `json:"repository"`
 	Branch     string `json:"branch"`
 	FileName   string `json:"filename"`
@@ -30,8 +30,8 @@ const (
 	LineNumberKey = "linenumber"
 )
 
-// ToMap converts CodebaseContent to a map of string->Interface{}
-func (c *CodebaseContent) ToMap() map[string]interface{} {
+// ToMap converts Content to a map of string->Interface{}
+func (c *Content) ToMap() map[string]interface{} {
 	res := make(map[string]interface{})
 	res[RepositoryKey] = c.Repository
 	res[BranchKey] = c.Branch
@@ -42,16 +42,16 @@ func (c *CodebaseContent) ToMap() map[string]interface{} {
 
 // IsValid perform following checks
 // Repository value is mandatory
-func (c *CodebaseContent) IsValid() error {
+func (c *Content) IsValid() error {
 	if c.Repository == "" {
 		return errors.NewBadParameterError("system.codebase", RepositoryKey+" is mandatory")
 	}
 	return nil
 }
 
-// NewCodebaseContent builds CodebaseContent instance from input Map.
-func NewCodebaseContent(value map[string]interface{}) (CodebaseContent, error) {
-	cb := CodebaseContent{}
+// NewContent builds Content instance from input Map.
+func NewCodebaseContent(value map[string]interface{}) (Content, error) {
+	cb := Content{}
 	validKeys := []string{RepositoryKey, BranchKey, FileNameKey, LineNumberKey}
 	for _, key := range validKeys {
 		if v, ok := value[key]; ok {
@@ -80,14 +80,14 @@ func NewCodebaseContent(value map[string]interface{}) (CodebaseContent, error) {
 	return cb, nil
 }
 
-// NewCodebaseContentFromValue builds CodebaseContent from interface{}
-func NewCodebaseContentFromValue(value interface{}) (*CodebaseContent, error) {
+// NewCodebaseContentFromValue builds Content from interface{}
+func NewCodebaseContentFromValue(value interface{}) (*Content, error) {
 	if value == nil {
 		return nil, nil
 	}
 	switch value.(type) {
-	case CodebaseContent:
-		result := value.(CodebaseContent)
+	case Content:
+		result := value.(Content)
 		return &result, nil
 	case map[string]interface{}:
 		result, err := NewCodebaseContent(value.(map[string]interface{}))

--- a/codebase/codebase_test.go
+++ b/codebase/codebase_test.go
@@ -22,7 +22,7 @@ func TestCodebaseToMap(t *testing.T) {
 	repo := "golang-project"
 	file := "main.go"
 	line := 200
-	cb := codebase.CodebaseContent{
+	cb := codebase.Content{
 		Branch:     branch,
 		Repository: repo,
 		FileName:   file,
@@ -67,12 +67,12 @@ func TestNewCodebase(t *testing.T) {
 }
 
 func TestIsValid(t *testing.T) {
-	cb := codebase.CodebaseContent{
+	cb := codebase.Content{
 		Repository: "hello",
 	}
 	assert.Nil(t, cb.IsValid())
 
-	cb = codebase.CodebaseContent{}
+	cb = codebase.Content{}
 	assert.NotNil(t, cb.IsValid())
 }
 

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -2115,7 +2115,7 @@ func (s *WorkItem2Suite) TestCreateWIWithCodebase() {
 	repo := "golang-project"
 	file := "main.go"
 	line := 200
-	cbase := codebase.CodebaseContent{
+	cbase := codebase.Content{
 		Branch:     branch,
 		Repository: repo,
 		FileName:   file,
@@ -2130,7 +2130,7 @@ func (s *WorkItem2Suite) TestCreateWIWithCodebase() {
 	require.NotNil(s.T(), fetchedWI.Data)
 	require.NotNil(s.T(), fetchedWI.Data.Attributes)
 	assert.Equal(s.T(), title, fetchedWI.Data.Attributes[workitem.SystemTitle])
-	cb := fetchedWI.Data.Attributes[workitem.SystemCodebase].(codebase.CodebaseContent)
+	cb := fetchedWI.Data.Attributes[workitem.SystemCodebase].(codebase.Content)
 	assert.Equal(s.T(), repo, cb.Repository)
 	assert.Equal(s.T(), branch, cb.Branch)
 	assert.Equal(s.T(), file, cb.FileName)
@@ -2151,7 +2151,7 @@ func (s *WorkItem2Suite) TestFailToCreateWIWithCodebase() {
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemPlannerItem)
 	branch := "earth-recycle-101"
-	cbase := codebase.CodebaseContent{
+	cbase := codebase.Content{
 		Branch: branch,
 	}
 	c.Data.Attributes[workitem.SystemCodebase] = cbase.ToMap()

--- a/workitem/simple_type.go
+++ b/workitem/simple_type.go
@@ -96,8 +96,8 @@ func (fieldType SimpleType) ConvertToModel(value interface{}) (interface{}, erro
 		}
 	case KindCodebase:
 		switch value.(type) {
-		case codebase.CodebaseContent:
-			cb := value.(codebase.CodebaseContent)
+		case codebase.Content:
+			cb := value.(codebase.Content)
 			return cb.ToMap(), nil
 		default:
 			return nil, errs.Errorf("value %v should be %s, but is %s", value, "CodebaseContent", valueType)

--- a/workitem/workitem_repository_blackbox_test.go
+++ b/workitem/workitem_repository_blackbox_test.go
@@ -274,7 +274,7 @@ func (s *workItemRepoBlackBoxTest) TestCodebaseAttributes() {
 	repo := "golang-project"
 	file := "main.go"
 	line := 200
-	cbase := codebase.CodebaseContent{
+	cbase := codebase.Content{
 		Branch:     branch,
 		Repository: repo,
 		FileName:   file,
@@ -295,7 +295,7 @@ func (s *workItemRepoBlackBoxTest) TestCodebaseAttributes() {
 	require.Nil(s.T(), err)
 	assert.Equal(s.T(), title, wi.Fields[workitem.SystemTitle].(string))
 	require.NotNil(s.T(), wi.Fields[workitem.SystemCodebase])
-	cb := wi.Fields[workitem.SystemCodebase].(codebase.CodebaseContent)
+	cb := wi.Fields[workitem.SystemCodebase].(codebase.Content)
 	assert.Equal(s.T(), repo, cb.Repository)
 	assert.Equal(s.T(), branch, cb.Branch)
 	assert.Equal(s.T(), file, cb.FileName)


### PR DESCRIPTION
ongoing fix for #1165
refactored `/tmp/go/src/github.com/almighty/almighty-core/codebase/codebase.go:18:6: type name will be used as codebase.CodebaseContent by other packages, and that stutters; consider calling this Content`