### PR TITLE
Replace MAINTAINER with LABEL in Dockerfile

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,5 +1,5 @@
 FROM centos:7
-MAINTAINER "Devtools <devtools@redhat.com>"
+LABEL maintainer "Devtools <devtools@redhat.com>"
 ENV LANG=en_US.utf8
 
 # Some packages might seem weird but they are required by the RVM installer.

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,5 +1,6 @@
 FROM centos:7
 LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Konrad Kleine <kkleine@redhat.com>"
 ENV LANG=en_US.utf8
 
 # Some packages might seem weird but they are required by the RVM installer.

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,5 +1,5 @@
 FROM centos:7
-MAINTAINER "Devtools <devtools@redhat.com>"
+LABEL maintainer "Devtools <devtools@redhat.com>"
 ENV LANG=en_US.utf8
 ENV ALMIGHTY_INSTALL_PREFIX=/usr/local/alm
 

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,5 +1,6 @@
 FROM centos:7
 LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Konrad Kleine <kkleine@redhat.com>"
 ENV LANG=en_US.utf8
 ENV ALMIGHTY_INSTALL_PREFIX=/usr/local/alm
 


### PR DESCRIPTION
This is a followup for #1273 according to @maxandersen 's [comment](https://github.com/almighty/almighty-core/pull/1273#issuecomment-297939758) about [`MAINTAINER` being deprecated](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated) and keeping the original author in the file as well.