### PR TITLE
GO_TEST_VERBOSITY_FLAG to toggle t.Log() output

### DIFF
--- a/.make/test.mk
+++ b/.make/test.mk
@@ -88,9 +88,9 @@
 COVERAGE_MODE ?= set
 
 # By default all go test calls will use the -v switch when running tests.
-# But if you want you can disable that by unsetting GO_TEST_VERBOSITY_SWITCH=
+# But if you want you can disable that by unsetting GO_TEST_VERBOSITY_FLAG=
 # in the terminal and don't use the switch. This will hide all testing.T.Log() outputs.
-GO_TEST_VERBOSITY_SWITCH ?= -v
+GO_TEST_VERBOSITY_FLAG ?= -v
 
 # By default use the "localhost" or specify manually during make invocation:
 #
@@ -144,7 +144,7 @@ test-unit: prebuild-check clean-coverage-unit $(COV_PATH_UNIT)
 test-unit-no-coverage: prebuild-check $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	ALMIGHTY_DEVELOPER_MODE_ENABLED=1 ALMIGHTY_RESOURCE_UNIT_TEST=1 go test $(GO_TEST_VERBOSITY_SWITCH) $(TEST_PACKAGES)
+	ALMIGHTY_DEVELOPER_MODE_ENABLED=1 ALMIGHTY_RESOURCE_UNIT_TEST=1 go test $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
 
 .PHONY: test-integration
 ## Runs the integration tests and produces coverage files for each package.
@@ -157,7 +157,7 @@ test-integration: prebuild-check clean-coverage-integration migrate-database $(C
 test-integration-no-coverage: prebuild-check migrate-database $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	ALMIGHTY_DEVELOPER_MODE_ENABLED=1 ALMIGHTY_RESOURCE_DATABASE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test $(GO_TEST_VERBOSITY_SWITCH) $(TEST_PACKAGES)
+	ALMIGHTY_DEVELOPER_MODE_ENABLED=1 ALMIGHTY_RESOURCE_DATABASE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
 
 .PHONY: test-remote
 ## Runs the remote tests and produces coverage files for each package.
@@ -168,13 +168,13 @@ test-remote: prebuild-check clean-coverage-remote $(COV_PATH_REMOTE)
 test-remote-no-coverage: prebuild-check $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	ALMIGHTY_DEVELOPER_MODE_ENABLED=1 ALMIGHTY_RESOURCE_REMOTE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test $(GO_TEST_VERBOSITY_SWITCH) $(TEST_PACKAGES)
+	ALMIGHTY_DEVELOPER_MODE_ENABLED=1 ALMIGHTY_RESOURCE_REMOTE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
 
 .PHONY: test-migration
 ## Runs the migration tests and should be executed before running the integration tests
 ## in order to have a clean database
 test-migration: prebuild-check
-	ALMIGHTY_RESOURCE_DATABASE=1 go test github.com/almighty/almighty-core/migration -v
+	ALMIGHTY_RESOURCE_DATABASE=1 go test $(GO_TEST_VERBOSITY_FLAG) github.com/almighty/almighty-core/migration
 
 # Downloads docker-compose to tmp/docker-compose if it does not already exist.
 define download-docker-compose
@@ -413,7 +413,7 @@ $(eval ALL_PKGS_COMMA_SEPARATED := $(6))
 $(eval COV_OUT_FILE := $(COV_DIR)/$(PACKAGE_NAME)/coverage.$(TEST_NAME).mode-$(COVERAGE_MODE))
 @$(ENV_VAR) ALMIGHTY_DEVELOPER_MODE_ENABLED=1 ALMIGHTY_POSTGRES_HOST=$(ALMIGHTY_POSTGRES_HOST) \
 	go test $(PACKAGE_NAME) \
-		$(GO_TEST_VERBOSITY_SWITCH) \
+		$(GO_TEST_VERBOSITY_FLAG) \
 		-coverprofile $(COV_OUT_FILE) \
 		-coverpkg $(ALL_PKGS_COMMA_SEPARATED) \
 		-covermode=$(COVERAGE_MODE) \

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -87,7 +87,7 @@
 # mode can be: set, count, or atomic
 COVERAGE_MODE ?= set
 
-# By default all go test calls will use the -v switch when running go test.
+# By default all go test calls will use the -v switch when running tests.
 # But if you want you can disable that by unsetting GO_TEST_VERBOSITY_SWITCH=
 # in the terminal and don't use the switch. This will hide all testing.T.Log() outputs.
 GO_TEST_VERBOSITY_SWITCH ?= -v

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -87,7 +87,7 @@
 # mode can be: set, count, or atomic
 COVERAGE_MODE ?= set
 
-# By default all go test calls with use the -v switch when running go test.
+# By default all go test calls will use the -v switch when running go test.
 # But if you want you can disable that by unsetting GO_TEST_VERBOSITY_SWITCH=
 # in the terminal and don't use the switch. This will hide all testing.T.Log() outputs.
 GO_TEST_VERBOSITY_SWITCH ?= -v

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -87,6 +87,11 @@
 # mode can be: set, count, or atomic
 COVERAGE_MODE ?= set
 
+# By default all go test calls with use the -v switch when running go test.
+# But if you want you can disable that by unsetting GO_TEST_VERBOSITY_SWITCH=
+# in the terminal and don't use the switch. This will hide all testing.T.Log() outputs.
+GO_TEST_VERBOSITY_SWITCH ?= -v
+
 # By default use the "localhost" or specify manually during make invocation:
 #
 # 	ALMIGHTY_POSTGRES_HOST=somehost make test-integration
@@ -139,7 +144,7 @@ test-unit: prebuild-check clean-coverage-unit $(COV_PATH_UNIT)
 test-unit-no-coverage: prebuild-check $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	ALMIGHTY_DEVELOPER_MODE_ENABLED=1 ALMIGHTY_RESOURCE_UNIT_TEST=1 go test -v $(TEST_PACKAGES)
+	ALMIGHTY_DEVELOPER_MODE_ENABLED=1 ALMIGHTY_RESOURCE_UNIT_TEST=1 go test $(GO_TEST_VERBOSITY_SWITCH) $(TEST_PACKAGES)
 
 .PHONY: test-integration
 ## Runs the integration tests and produces coverage files for each package.
@@ -152,7 +157,7 @@ test-integration: prebuild-check clean-coverage-integration migrate-database $(C
 test-integration-no-coverage: prebuild-check migrate-database $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	ALMIGHTY_DEVELOPER_MODE_ENABLED=1 ALMIGHTY_RESOURCE_DATABASE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test -v $(TEST_PACKAGES)
+	ALMIGHTY_DEVELOPER_MODE_ENABLED=1 ALMIGHTY_RESOURCE_DATABASE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test $(GO_TEST_VERBOSITY_SWITCH) $(TEST_PACKAGES)
 
 .PHONY: test-remote
 ## Runs the remote tests and produces coverage files for each package.
@@ -163,7 +168,7 @@ test-remote: prebuild-check clean-coverage-remote $(COV_PATH_REMOTE)
 test-remote-no-coverage: prebuild-check $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	ALMIGHTY_DEVELOPER_MODE_ENABLED=1 ALMIGHTY_RESOURCE_REMOTE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test -v $(TEST_PACKAGES)
+	ALMIGHTY_DEVELOPER_MODE_ENABLED=1 ALMIGHTY_RESOURCE_REMOTE=1 ALMIGHTY_RESOURCE_UNIT_TEST=0 go test $(GO_TEST_VERBOSITY_SWITCH) $(TEST_PACKAGES)
 
 .PHONY: test-migration
 ## Runs the migration tests and should be executed before running the integration tests
@@ -408,7 +413,7 @@ $(eval ALL_PKGS_COMMA_SEPARATED := $(6))
 $(eval COV_OUT_FILE := $(COV_DIR)/$(PACKAGE_NAME)/coverage.$(TEST_NAME).mode-$(COVERAGE_MODE))
 @$(ENV_VAR) ALMIGHTY_DEVELOPER_MODE_ENABLED=1 ALMIGHTY_POSTGRES_HOST=$(ALMIGHTY_POSTGRES_HOST) \
 	go test $(PACKAGE_NAME) \
-		-v \
+		$(GO_TEST_VERBOSITY_SWITCH) \
 		-coverprofile $(COV_OUT_FILE) \
 		-coverpkg $(ALL_PKGS_COMMA_SEPARATED) \
 		-covermode=$(COVERAGE_MODE) \


### PR DESCRIPTION
By default all go test calls will use the `-v` switch when running tests. But if you want you can disable that by unsetting `GO_TEST_VERBOSITY_FLAG=` in the terminal and don't use the switch. This will hide all `testing.T.Log()` outputs.

