### PR TITLE
Remove redundant calls to Keycloak for User Profile PATCH

### DIFF
--- a/controller/users.go
+++ b/controller/users.go
@@ -206,7 +206,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		if updatedRegistratedCompleted != nil {
 			if !*updatedRegistratedCompleted {
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("invalid value assigned to registration_completed for identity with id %s and user with id %s", identity.ID, identity.UserID.UUID)))
-				log.Error(context.Background(), map[string]interface{}{
+				log.Error(nil, map[string]interface{}{
 					"registration_completed": *updatedRegistratedCompleted,
 					"user_id":                identity.UserID.UUID,
 					"identity_id":            identity.ID,
@@ -343,7 +343,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 func isUsernameUnique(appl application.Application, username string, identity account.Identity) (bool, error) {
 	usersWithSameUserName, err := appl.Identities().Query(account.IdentityFilterByUsername(username), account.IdentityFilterByProviderType(account.KeycloakIDP))
 	if err != nil {
-		log.Error(context.Background(), map[string]interface{}{
+		log.Error(nil, map[string]interface{}{
 			"user_name": username,
 			"err":       err,
 		}, "error fetching users with username filter")
@@ -360,7 +360,7 @@ func isUsernameUnique(appl application.Application, username string, identity ac
 func isEmailUnique(appl application.Application, email string, user account.User) (bool, error) {
 	usersWithSameEmail, err := appl.Users().Query(account.UserFilterByEmail(email))
 	if err != nil {
-		log.Error(context.Background(), map[string]interface{}{
+		log.Error(nil, map[string]interface{}{
 			"email": email,
 			"err":   err,
 		}, "error fetching identities with email filter")

--- a/controller/users.go
+++ b/controller/users.go
@@ -206,7 +206,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		if updatedRegistratedCompleted != nil {
 			if !*updatedRegistratedCompleted {
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("invalid value assigned to registration_completed for identity with id %s and user with id %s", identity.ID, identity.UserID.UUID)))
-				log.Error(nil, map[string]interface{}{
+				log.Error(ctx, map[string]interface{}{
 					"registration_completed": *updatedRegistratedCompleted,
 					"user_id":                identity.UserID.UUID,
 					"identity_id":            identity.ID,
@@ -553,7 +553,7 @@ func ConvertToAppUser(request *goa.RequestData, user *account.User, identity *ac
 		}
 		convertedValue, err := simpleFieldDefinition.ConvertFromModel(name, value)
 		if err != nil {
-			log.Error(nil, map[string]interface{}{
+			log.Error(ctx, map[string]interface{}{
 				"err": err,
 			}, "Unable to convert user context field %s ", name)
 			converted.Data.Attributes.ContextInformation[name] = nil

--- a/controller/users.go
+++ b/controller/users.go
@@ -553,7 +553,7 @@ func ConvertToAppUser(request *goa.RequestData, user *account.User, identity *ac
 		}
 		convertedValue, err := simpleFieldDefinition.ConvertFromModel(name, value)
 		if err != nil {
-			log.Error(ctx, map[string]interface{}{
+			log.Error(nil, map[string]interface{}{
 				"err": err,
 			}, "Unable to convert user context field %s ", name)
 			converted.Data.Attributes.ContextInformation[name] = nil

--- a/controller/users.go
+++ b/controller/users.go
@@ -77,7 +77,7 @@ func (c *UsersController) Show(ctx *app.ShowUsersContext) error {
 	})
 }
 
-func (c *UsersController) copyExistingKeycloakUserProfileInfo(keycloakUserProfile *login.KeycloakUserProfile, tokenString string, accountAPIEndpoint string) (*login.KeycloakUserProfile, error) {
+func (c *UsersController) copyExistingKeycloakUserProfileInfo(ctx context.Context, keycloakUserProfile *login.KeycloakUserProfile, tokenString string, accountAPIEndpoint string) (*login.KeycloakUserProfile, error) {
 
 	// avoid multiple calls to KC
 
@@ -92,7 +92,7 @@ func (c *UsersController) copyExistingKeycloakUserProfileInfo(keycloakUserProfil
 	keycloakUserProfile = &login.KeycloakUserProfile{}
 	keycloakUserProfile.Attributes = &login.KeycloakUserProfileAttributes{}
 
-	existingProfile, err := c.getKeycloakProfileInformation(tokenString, accountAPIEndpoint)
+	existingProfile, err := c.getKeycloakProfileInformation(ctx, tokenString, accountAPIEndpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -117,11 +117,11 @@ func (c *UsersController) copyExistingKeycloakUserProfileInfo(keycloakUserProfil
 	return keycloakUserProfile, nil
 }
 
-func (c *UsersController) getKeycloakProfileInformation(tokenString string, accountAPIEndpoint string) (*login.KeycloakUserProfileResponse, error) {
+func (c *UsersController) getKeycloakProfileInformation(ctx context.Context, tokenString string, accountAPIEndpoint string) (*login.KeycloakUserProfileResponse, error) {
 
 	response, err := c.userProfileService.Get(tokenString, accountAPIEndpoint)
 	if err != nil {
-		log.Error(context.Background(), map[string]interface{}{
+		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "failed to fetch keycloak account information")
 	}
@@ -164,14 +164,14 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		if updatedEmail != nil && *updatedEmail != user.Email {
 			isUnique, err := isEmailUnique(appl, *updatedEmail, *user)
 			if err != nil {
-				return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("error updating idenitity with id %s and user with id %s", identity.ID, identity.UserID.UUID)))
+				return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("error updating identitity with id %s and user with id %s", identity.ID, identity.UserID.UUID)))
 			}
 			if !isUnique {
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("email address: %s is already in use", *updatedEmail)))
 				return ctx.Conflict(jerrors)
 			}
 			user.Email = *updatedEmail
-			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
+			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(ctx, keycloakUserProfile, tokenString, accountAPIEndpoint)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)
 			}
@@ -187,14 +187,14 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 			}
 			isUnique, err := isUsernameUnique(appl, *updatedUserName, *identity)
 			if err != nil {
-				return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("error updating idenitity with id %s and user with id %s", identity.ID, identity.UserID.UUID)))
+				return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("error updating identitity with id %s and user with id %s", identity.ID, identity.UserID.UUID)))
 			}
 			if !isUnique {
 				jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrInvalidRequest(fmt.Sprintf("username : %s is already in use", *updatedUserName)))
 				return ctx.Conflict(jerrors)
 			}
 			identity.Username = *updatedUserName
-			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
+			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(ctx, keycloakUserProfile, tokenString, accountAPIEndpoint)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)
 			}
@@ -220,7 +220,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		updatedBio := ctx.Payload.Data.Attributes.Bio
 		if updatedBio != nil && *updatedBio != user.Bio {
 			user.Bio = *updatedBio
-			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
+			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(ctx, keycloakUserProfile, tokenString, accountAPIEndpoint)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)
 			}
@@ -239,7 +239,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 			if len(nameComponents) > 1 {
 				lastName = strings.Join(nameComponents[1:], " ")
 			}
-			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
+			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(ctx, keycloakUserProfile, tokenString, accountAPIEndpoint)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)
 			}
@@ -250,7 +250,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		updatedImageURL := ctx.Payload.Data.Attributes.ImageURL
 		if updatedImageURL != nil && *updatedImageURL != user.ImageURL {
 			user.ImageURL = *updatedImageURL
-			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
+			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(ctx, keycloakUserProfile, tokenString, accountAPIEndpoint)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)
 			}
@@ -260,7 +260,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		updateURL := ctx.Payload.Data.Attributes.URL
 		if updateURL != nil && *updateURL != user.URL {
 			user.URL = *updateURL
-			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
+			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(ctx, keycloakUserProfile, tokenString, accountAPIEndpoint)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)
 			}
@@ -270,7 +270,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		updatedCompany := ctx.Payload.Data.Attributes.Company
 		if updatedCompany != nil && *updatedCompany != user.Company {
 			user.Company = *updatedCompany
-			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
+			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(ctx, keycloakUserProfile, tokenString, accountAPIEndpoint)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)
 			}

--- a/controller/users.go
+++ b/controller/users.go
@@ -77,12 +77,12 @@ func (c *UsersController) Show(ctx *app.ShowUsersContext) error {
 	})
 }
 
-func (c *UsersController) copyExistingKeycloakUserProfileInfo(keycloakUserProfile *login.KeycloakUserProfile, tokenString string, accountAPIEndpoint string) *login.KeycloakUserProfile {
+func (c *UsersController) copyExistingKeycloakUserProfileInfo(keycloakUserProfile *login.KeycloakUserProfile, tokenString string, accountAPIEndpoint string) (*login.KeycloakUserProfile, error) {
 
 	// avoid multiple calls to KC
 
 	if keycloakUserProfile != nil {
-		return keycloakUserProfile
+		return keycloakUserProfile, nil
 	}
 
 	// The keycloak API doesn't support PATCH, hence the entire info needs
@@ -94,7 +94,7 @@ func (c *UsersController) copyExistingKeycloakUserProfileInfo(keycloakUserProfil
 
 	existingProfile, err := c.getKeycloakProfileInformation(tokenString, accountAPIEndpoint)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	if existingProfile.FirstName != nil {
@@ -114,7 +114,7 @@ func (c *UsersController) copyExistingKeycloakUserProfileInfo(keycloakUserProfil
 	if existingProfile.Username != nil {
 		keycloakUserProfile.Username = existingProfile.Username
 	}
-	return keycloakUserProfile
+	return keycloakUserProfile, nil
 }
 
 func (c *UsersController) getKeycloakProfileInformation(tokenString string, accountAPIEndpoint string) (*login.KeycloakUserProfileResponse, error) {
@@ -171,7 +171,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 				return ctx.Conflict(jerrors)
 			}
 			user.Email = *updatedEmail
-			keycloakUserProfile = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
+			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)
 			}
@@ -194,7 +194,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 				return ctx.Conflict(jerrors)
 			}
 			identity.Username = *updatedUserName
-			keycloakUserProfile = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
+			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)
 			}
@@ -220,7 +220,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		updatedBio := ctx.Payload.Data.Attributes.Bio
 		if updatedBio != nil && *updatedBio != user.Bio {
 			user.Bio = *updatedBio
-			keycloakUserProfile = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
+			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)
 			}
@@ -239,7 +239,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 			if len(nameComponents) > 1 {
 				lastName = strings.Join(nameComponents[1:], " ")
 			}
-			keycloakUserProfile = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
+			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)
 			}
@@ -250,7 +250,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		updatedImageURL := ctx.Payload.Data.Attributes.ImageURL
 		if updatedImageURL != nil && *updatedImageURL != user.ImageURL {
 			user.ImageURL = *updatedImageURL
-			keycloakUserProfile = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
+			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)
 			}
@@ -260,7 +260,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		updateURL := ctx.Payload.Data.Attributes.URL
 		if updateURL != nil && *updateURL != user.URL {
 			user.URL = *updateURL
-			keycloakUserProfile = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
+			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)
 			}
@@ -270,7 +270,7 @@ func (c *UsersController) Update(ctx *app.UpdateUsersContext) error {
 		updatedCompany := ctx.Payload.Data.Attributes.Company
 		if updatedCompany != nil && *updatedCompany != user.Company {
 			user.Company = *updatedCompany
-			keycloakUserProfile = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
+			keycloakUserProfile, err = c.copyExistingKeycloakUserProfileInfo(keycloakUserProfile, tokenString, accountAPIEndpoint)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)
 			}

--- a/login/profile.go
+++ b/login/profile.go
@@ -117,6 +117,12 @@ func (userProfileClient *KeycloakUserProfileClient) Update(keycloakUserProfile *
 
 		return errors.NewInternalError(fmt.Sprintf("Received a non-200 response %s while updating keycloak user profile %s", resp.Status, keycloakProfileURL))
 	}
+	log.Info(context.Background(), map[string]interface{}{
+		"response_status":           resp.Status,
+		"response_body":             rest.ReadBody(resp.Body),
+		"keycloak_user_profile_url": keycloakProfileURL,
+	}, "Successfully updated Keycloak user profile")
+
 	return nil
 }
 

--- a/login/profile.go
+++ b/login/profile.go
@@ -2,7 +2,6 @@ package login
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -93,7 +92,7 @@ func (userProfileClient *KeycloakUserProfileClient) Update(keycloakUserProfile *
 	resp, err := userProfileClient.client.Do(req)
 
 	if err != nil {
-		log.Error(context.Background(), map[string]interface{}{
+		log.Error(nil, map[string]interface{}{
 			"keycloak_user_profile_url": keycloakProfileURL,
 			"err": err,
 		}, "Unable to update Keycloak user profile")
@@ -104,7 +103,7 @@ func (userProfileClient *KeycloakUserProfileClient) Update(keycloakUserProfile *
 
 	if resp.StatusCode != http.StatusOK {
 
-		log.Error(context.Background(), map[string]interface{}{
+		log.Error(nil, map[string]interface{}{
 			"response_status":           resp.Status,
 			"response_body":             rest.ReadBody(resp.Body),
 			"keycloak_user_profile_url": keycloakProfileURL,
@@ -117,7 +116,7 @@ func (userProfileClient *KeycloakUserProfileClient) Update(keycloakUserProfile *
 
 		return errors.NewInternalError(fmt.Sprintf("Received a non-200 response %s while updating keycloak user profile %s", resp.Status, keycloakProfileURL))
 	}
-	log.Info(context.Background(), map[string]interface{}{
+	log.Info(nil, map[string]interface{}{
 		"response_status":           resp.Status,
 		"response_body":             rest.ReadBody(resp.Body),
 		"keycloak_user_profile_url": keycloakProfileURL,
@@ -142,7 +141,7 @@ func (userProfileClient *KeycloakUserProfileClient) Get(accessToken string, keyc
 	resp, err := userProfileClient.client.Do(req)
 
 	if err != nil {
-		log.Error(context.Background(), map[string]interface{}{
+		log.Error(nil, map[string]interface{}{
 			"keycloak_user_profile_url": keycloakProfileURL,
 			"err": err,
 		}, "Unable to fetch Keycloak user profile")
@@ -152,7 +151,7 @@ func (userProfileClient *KeycloakUserProfileClient) Get(accessToken string, keyc
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		log.Error(context.Background(), map[string]interface{}{
+		log.Error(nil, map[string]interface{}{
 			"response_status":           resp.Status,
 			"response_body":             rest.ReadBody(resp.Body),
 			"keycloak_user_profile_url": keycloakProfileURL,


### PR DESCRIPTION

Fixes #1256 

- Update KC only if a user property managed in KC is PATCH'd.
- Update KC only if a user property managed in KC is PATCH'd and is different from the existing value.
- Do not pre-fetch KC info. Get KC info only if a property managed in Keycloak was changed.