### PR TITLE
Set the space id type to UUID in the REST API (#1326)

### DIFF
--- a/controller/collaborators.go
+++ b/controller/collaborators.go
@@ -13,7 +13,7 @@ import (
 	"github.com/almighty/almighty-core/log"
 	"github.com/almighty/almighty-core/space/authz"
 	"github.com/goadesign/goa"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 // CollaboratorsController implements the collaborators resource.
@@ -40,7 +40,7 @@ func NewCollaboratorsController(service *goa.Service, db application.DB, config 
 
 // List collaborators for the given space ID.
 func (c *CollaboratorsController) List(ctx *app.ListCollaboratorsContext) error {
-	policy, _, err := c.getPolicy(ctx, ctx.RequestData, ctx.ID)
+	policy, _, err := c.getPolicy(ctx, ctx.RequestData, ctx.SpaceID)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
@@ -105,7 +105,7 @@ func (c *CollaboratorsController) List(ctx *app.ListCollaboratorsContext) error 
 // Add user's identity to the list of space collaborators.
 func (c *CollaboratorsController) Add(ctx *app.AddCollaboratorsContext) error {
 	identityIDs := []*app.UpdateUserID{{ID: ctx.IdentityID}}
-	err := c.updatePolicy(ctx, ctx.RequestData, ctx.ID, identityIDs, c.policyManager.AddUserToPolicy)
+	err := c.updatePolicy(ctx, ctx.RequestData, ctx.SpaceID, identityIDs, c.policyManager.AddUserToPolicy)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
@@ -115,7 +115,7 @@ func (c *CollaboratorsController) Add(ctx *app.AddCollaboratorsContext) error {
 // AddMany adds user's identities to the list of space collaborators.
 func (c *CollaboratorsController) AddMany(ctx *app.AddManyCollaboratorsContext) error {
 	if ctx.Payload != nil && ctx.Payload.Data != nil {
-		err := c.updatePolicy(ctx, ctx.RequestData, ctx.ID, ctx.Payload.Data, c.policyManager.AddUserToPolicy)
+		err := c.updatePolicy(ctx, ctx.RequestData, ctx.SpaceID, ctx.Payload.Data, c.policyManager.AddUserToPolicy)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
@@ -126,20 +126,13 @@ func (c *CollaboratorsController) AddMany(ctx *app.AddManyCollaboratorsContext) 
 // Remove user from the list of space collaborators.
 func (c *CollaboratorsController) Remove(ctx *app.RemoveCollaboratorsContext) error {
 	// Don't remove the space owner
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		log.Error(ctx, map[string]interface{}{
-			"space_id": ctx.ID,
-		}, "unable to convert the space ID to uuid v4")
-		return jsonapi.JSONErrorResponse(ctx, goa.ErrBadRequest(err.Error()))
-	}
-	err = c.checkSpaceOwner(ctx, spaceID, ctx.IdentityID)
+	err := c.checkSpaceOwner(ctx, ctx.SpaceID, ctx.IdentityID)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
 
 	identityIDs := []*app.UpdateUserID{{ID: ctx.IdentityID}}
-	err = c.updatePolicy(ctx, ctx.RequestData, ctx.ID, identityIDs, c.policyManager.RemoveUserFromPolicy)
+	err = c.updatePolicy(ctx, ctx.RequestData, ctx.SpaceID, identityIDs, c.policyManager.RemoveUserFromPolicy)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
@@ -150,22 +143,15 @@ func (c *CollaboratorsController) Remove(ctx *app.RemoveCollaboratorsContext) er
 func (c *CollaboratorsController) RemoveMany(ctx *app.RemoveManyCollaboratorsContext) error {
 	if ctx.Payload != nil && ctx.Payload.Data != nil {
 		// Don't remove the space owner
-		spaceID, err := uuid.FromString(ctx.ID)
-		if err != nil {
-			log.Error(ctx, map[string]interface{}{
-				"space_id": ctx.ID,
-			}, "unable to convert the space ID to uuid v4")
-			return jsonapi.JSONErrorResponse(ctx, goa.ErrBadRequest(err.Error()))
-		}
 		for _, idn := range ctx.Payload.Data {
 			if idn != nil {
-				err := c.checkSpaceOwner(ctx, spaceID, idn.ID)
+				err := c.checkSpaceOwner(ctx, ctx.SpaceID, idn.ID)
 				if err != nil {
 					return jsonapi.JSONErrorResponse(ctx, err)
 				}
 			}
 		}
-		err = c.updatePolicy(ctx, ctx.RequestData, ctx.ID, ctx.Payload.Data, c.policyManager.RemoveUserFromPolicy)
+		err := c.updatePolicy(ctx, ctx.RequestData, ctx.SpaceID, ctx.Payload.Data, c.policyManager.RemoveUserFromPolicy)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
@@ -197,9 +183,9 @@ func (c *CollaboratorsController) checkSpaceOwner(ctx context.Context, spaceID u
 	return nil
 }
 
-func (c *CollaboratorsController) updatePolicy(ctx collaboratorContext, req *goa.RequestData, spaceID string, identityIDs []*app.UpdateUserID, update func(policy *auth.KeycloakPolicy, identityID string) bool) error {
+func (c *CollaboratorsController) updatePolicy(ctx collaboratorContext, req *goa.RequestData, spaceID uuid.UUID, identityIDs []*app.UpdateUserID, update func(policy *auth.KeycloakPolicy, identityID string) bool) error {
 	// Authorize current user
-	authorized, err := authz.Authorize(ctx, spaceID)
+	authorized, err := authz.Authorize(ctx, spaceID.String())
 	if err != nil {
 		return goa.ErrUnauthorized(err.Error())
 	}
@@ -259,17 +245,13 @@ func (c *CollaboratorsController) updatePolicy(ctx collaboratorContext, req *goa
 	}
 
 	// We need to update the resource to triger RPT token refreshing when users try to access this space
-	spaceUUID, err := uuid.FromString(spaceID)
-	if err != nil {
-		return goa.ErrInternal(err.Error())
-	}
 	err = application.Transactional(c.db, func(appl application.Application) error {
-		resource, err := appl.SpaceResources().LoadBySpace(ctx, &spaceUUID)
+		resource, err := appl.SpaceResources().LoadBySpace(ctx, &spaceID)
 		_, err = appl.SpaceResources().Save(ctx, resource)
 		if err != nil {
 			log.Error(ctx, map[string]interface{}{
 				"resource":   resource,
-				"space_uuid": spaceUUID,
+				"space_uuid": spaceID.String(),
 				"err":        err,
 			}, "unable to update the space resource")
 			return err
@@ -283,15 +265,11 @@ func (c *CollaboratorsController) updatePolicy(ctx collaboratorContext, req *goa
 	return nil
 }
 
-func (c *CollaboratorsController) getPolicy(ctx collaboratorContext, req *goa.RequestData, spaceID string) (*auth.KeycloakPolicy, *string, error) {
-	spaceUUID, err := uuid.FromString(spaceID)
-	if err != nil {
-		return nil, nil, goa.ErrBadRequest(err.Error())
-	}
+func (c *CollaboratorsController) getPolicy(ctx collaboratorContext, req *goa.RequestData, spaceID uuid.UUID) (*auth.KeycloakPolicy, *string, error) {
 	var policyID string
-	err = application.Transactional(c.db, func(appl application.Application) error {
+	err := application.Transactional(c.db, func(appl application.Application) error {
 		// Load associated space resource
-		resource, err := appl.SpaceResources().LoadBySpace(ctx, &spaceUUID)
+		resource, err := appl.SpaceResources().LoadBySpace(ctx, &spaceID)
 		if err != nil {
 			return err
 		}

--- a/controller/collaborators_test.go
+++ b/controller/collaborators_test.go
@@ -79,7 +79,7 @@ type TestCollaboratorsREST struct {
 	testIdentity1 account.Identity
 	testIdentity2 account.Identity
 	testIdentity3 account.Identity
-	spaceID       string
+	spaceID       uuid.UUID
 }
 
 func TestRunCollaboratorsREST(t *testing.T) {
@@ -107,7 +107,7 @@ func (rest *TestCollaboratorsREST) SetupTest() {
 	require.Nil(rest.T(), err)
 	rest.testIdentity3 = testIdentity
 	space := rest.createSpace()
-	rest.spaceID = space.ID.String()
+	rest.spaceID = *space.ID
 }
 
 func (rest *TestCollaboratorsREST) TearDownTest() {
@@ -128,12 +128,7 @@ func (rest *TestCollaboratorsREST) UnSecuredController() (*goa.Service, *Collabo
 
 func (rest *TestCollaboratorsREST) TestListCollaboratorsWithRandomSpaceIDNotFound() {
 	svc, ctrl := rest.UnSecuredController()
-	test.ListCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4().String(), nil, nil)
-}
-
-func (rest *TestCollaboratorsREST) TestListCollaboratorsWithWrongSpaceIDFormatReturnsBadRequest() {
-	svc, ctrl := rest.UnSecuredController()
-	test.ListCollaboratorsBadRequest(rest.T(), svc.Context, svc, ctrl, "wrongFormatID", nil, nil)
+	test.ListCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4(), nil, nil)
 }
 
 func (rest *TestCollaboratorsREST) TestListCollaboratorsOk() {
@@ -148,14 +143,14 @@ func (rest *TestCollaboratorsREST) TestListCollaboratorsOk() {
 func (rest *TestCollaboratorsREST) TestAddCollaboratorsWithRandomSpaceIDNotFound() {
 	rest.policy.AddUserToPolicy(rest.testIdentity1.ID.String())
 	svc, ctrl := rest.SecuredController()
-	test.AddCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4().String(), uuid.NewV4().String())
+	test.AddCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4(), uuid.NewV4().String())
 }
 
 func (rest *TestCollaboratorsREST) TestAddManyCollaboratorsWithRandomSpaceIDNotFound() {
 	rest.policy.AddUserToPolicy(rest.testIdentity1.ID.String())
 	svc, ctrl := rest.SecuredController()
 	payload := &app.AddManyCollaboratorsPayload{Data: []*app.UpdateUserID{}}
-	test.AddManyCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4().String(), payload)
+	test.AddManyCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4(), payload)
 }
 
 func (rest *TestCollaboratorsREST) TestAddCollaboratorsWithWrongUserIDFormatReturnsBadRequest() {
@@ -172,10 +167,8 @@ func (rest *TestCollaboratorsREST) TestAddManyCollaboratorsWithWrongUserIDFormat
 }
 
 func (rest *TestCollaboratorsREST) TestAddCollaboratorsOk() {
-	spaceUUID, err := uuid.FromString(rest.spaceID)
-	require.Nil(rest.T(), err)
 	appl := gormapplication.NewGormDB(rest.DB)
-	resource, err := appl.SpaceResources().LoadBySpace(context.Background(), &spaceUUID)
+	resource, err := appl.SpaceResources().LoadBySpace(context.Background(), &rest.spaceID)
 	require.Nil(rest.T(), err)
 
 	svc, ctrl := rest.SecuredController()
@@ -188,16 +181,14 @@ func (rest *TestCollaboratorsREST) TestAddCollaboratorsOk() {
 	rest.policy.AddUserToPolicy(rest.testIdentity2.ID.String())
 	rest.checkCollaborators([]string{rest.testIdentity1.ID.String(), rest.testIdentity2.ID.String()})
 
-	updatedResource, err := appl.SpaceResources().LoadBySpace(context.Background(), &spaceUUID)
+	updatedResource, err := appl.SpaceResources().LoadBySpace(context.Background(), &rest.spaceID)
 	require.Nil(rest.T(), err)
 	require.True(rest.T(), resource.UpdatedAt.Before(updatedResource.UpdatedAt))
 }
 
 func (rest *TestCollaboratorsREST) TestAddManyCollaboratorsOk() {
-	spaceUUID, err := uuid.FromString(rest.spaceID)
-	require.Nil(rest.T(), err)
 	appl := gormapplication.NewGormDB(rest.DB)
-	resource, err := appl.SpaceResources().LoadBySpace(context.Background(), &spaceUUID)
+	resource, err := appl.SpaceResources().LoadBySpace(context.Background(), &rest.spaceID)
 	require.Nil(rest.T(), err)
 
 	svc, ctrl := rest.SecuredController()
@@ -212,7 +203,7 @@ func (rest *TestCollaboratorsREST) TestAddManyCollaboratorsOk() {
 	rest.policy.AddUserToPolicy(rest.testIdentity3.ID.String())
 	rest.checkCollaborators([]string{rest.testIdentity1.ID.String(), rest.testIdentity2.ID.String(), rest.testIdentity3.ID.String()})
 
-	updatedResource, err := appl.SpaceResources().LoadBySpace(context.Background(), &spaceUUID)
+	updatedResource, err := appl.SpaceResources().LoadBySpace(context.Background(), &rest.spaceID)
 	require.Nil(rest.T(), err)
 	require.True(rest.T(), resource.UpdatedAt.Before(updatedResource.UpdatedAt))
 }
@@ -305,7 +296,7 @@ func (rest *TestCollaboratorsREST) TestRemoveManyCollaboratorsFailsIfTryToRemove
 func (rest *TestCollaboratorsREST) TestRemoveCollaboratorsWithRandomSpaceIDNotFound() {
 	rest.policy.AddUserToPolicy(rest.testIdentity1.ID.String())
 	svc, ctrl := rest.SecuredController()
-	test.RemoveCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4().String(), uuid.NewV4().String())
+	test.RemoveCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4(), uuid.NewV4().String())
 }
 
 func (rest *TestCollaboratorsREST) TestRemoveManyCollaboratorsWithRandomSpaceIDNotFound() {
@@ -313,7 +304,7 @@ func (rest *TestCollaboratorsREST) TestRemoveManyCollaboratorsWithRandomSpaceIDN
 	svc, ctrl := rest.SecuredController()
 	payload := &app.RemoveManyCollaboratorsPayload{Data: []*app.UpdateUserID{{ID: uuid.NewV4().String(), Type: idnType}}}
 
-	test.RemoveManyCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4().String(), payload)
+	test.RemoveManyCollaboratorsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4(), payload)
 }
 
 func (rest *TestCollaboratorsREST) TestRemoveCollaboratorsWithWrongUserIDFormatReturnsBadRequest() {
@@ -343,10 +334,8 @@ func (rest *TestCollaboratorsREST) checkCollaborators(userIDs []string) {
 }
 
 func (rest *TestCollaboratorsREST) TestRemoveCollaboratorsOk() {
-	spaceUUID, err := uuid.FromString(rest.spaceID)
-	require.Nil(rest.T(), err)
 	appl := gormapplication.NewGormDB(rest.DB)
-	resource, err := appl.SpaceResources().LoadBySpace(context.Background(), &spaceUUID)
+	resource, err := appl.SpaceResources().LoadBySpace(context.Background(), &rest.spaceID)
 	require.Nil(rest.T(), err)
 
 	svc, ctrl := rest.SecuredController()
@@ -357,16 +346,14 @@ func (rest *TestCollaboratorsREST) TestRemoveCollaboratorsOk() {
 
 	test.RemoveCollaboratorsOK(rest.T(), svc.Context, svc, ctrl, rest.spaceID, rest.testIdentity2.ID.String())
 
-	updatedResource, err := appl.SpaceResources().LoadBySpace(context.Background(), &spaceUUID)
+	updatedResource, err := appl.SpaceResources().LoadBySpace(context.Background(), &rest.spaceID)
 	require.Nil(rest.T(), err)
 	require.True(rest.T(), resource.UpdatedAt.Before(updatedResource.UpdatedAt))
 }
 
 func (rest *TestCollaboratorsREST) TestRemoveManyCollaboratorsOk() {
-	spaceUUID, err := uuid.FromString(rest.spaceID)
-	require.Nil(rest.T(), err)
 	appl := gormapplication.NewGormDB(rest.DB)
-	resource, err := appl.SpaceResources().LoadBySpace(context.Background(), &spaceUUID)
+	resource, err := appl.SpaceResources().LoadBySpace(context.Background(), &rest.spaceID)
 	require.Nil(rest.T(), err)
 
 	svc, ctrl := rest.SecuredController()
@@ -379,7 +366,7 @@ func (rest *TestCollaboratorsREST) TestRemoveManyCollaboratorsOk() {
 
 	test.RemoveManyCollaboratorsOK(rest.T(), svc.Context, svc, ctrl, rest.spaceID, payload)
 
-	updatedResource, err := appl.SpaceResources().LoadBySpace(context.Background(), &spaceUUID)
+	updatedResource, err := appl.SpaceResources().LoadBySpace(context.Background(), &rest.spaceID)
 	require.Nil(rest.T(), err)
 	require.True(rest.T(), resource.UpdatedAt.Before(updatedResource.UpdatedAt))
 }

--- a/controller/comments_blackbox_test.go
+++ b/controller/comments_blackbox_test.go
@@ -111,7 +111,7 @@ func (s *CommentsSuite) createWorkItem(identity account.Identity) string {
 		},
 	}
 	userSvc, workitemCtrl, _, _ := s.securedControllers(identity)
-	_, wi := test.CreateWorkitemCreated(s.T(), userSvc.Context, userSvc, workitemCtrl, createWorkitemPayload.Data.Relationships.Space.Data.ID.String(), &createWorkitemPayload)
+	_, wi := test.CreateWorkitemCreated(s.T(), userSvc.Context, userSvc, workitemCtrl, *createWorkitemPayload.Data.Relationships.Space.Data.ID, &createWorkitemPayload)
 	wID := *wi.Data.ID
 	s.T().Log(fmt.Sprintf("Created workitem with id %v", wID))
 	return wID
@@ -145,7 +145,7 @@ func (s *CommentsSuite) newUpdateCommentsPayload(body string, markup *string) *a
 func (s *CommentsSuite) createWorkItemComment(identity account.Identity, wID string, body string, markup *string) app.CommentSingle {
 	createWorkItemCommentPayload := s.newCreateWorkItemCommentsPayload(body, markup)
 	userSvc, _, workitemCommentsCtrl, _ := s.securedControllers(identity)
-	_, c := test.CreateWorkItemCommentsOK(s.T(), userSvc.Context, userSvc, workitemCommentsCtrl, space.SystemSpace.String(), wID, createWorkItemCommentPayload)
+	_, c := test.CreateWorkItemCommentsOK(s.T(), userSvc.Context, userSvc, workitemCommentsCtrl, space.SystemSpace, wID, createWorkItemCommentPayload)
 	s.T().Log(fmt.Sprintf("Created comment with id %v", *c.Data.ID))
 	return *c
 }

--- a/controller/planner_backlog_blackbox_test.go
+++ b/controller/planner_backlog_blackbox_test.go
@@ -153,7 +153,7 @@ func (rest *TestPlannerBacklogBlackboxREST) TestListPlannerBacklogWorkItemsOK() 
 	offset := "0"
 	filter := ""
 	limit := -1
-	res, workitems := test.ListPlannerBacklogOK(rest.T(), svc.Context, svc, ctrl, testSpace.ID.String(), &filter, nil, nil, nil, &limit, &offset, nil, nil)
+	res, workitems := test.ListPlannerBacklogOK(rest.T(), svc.Context, svc, ctrl, testSpace.ID, &filter, nil, nil, nil, &limit, &offset, nil, nil)
 	// then
 	assertPlannerBacklogWorkItems(rest.T(), workitems, testSpace, parentIteration)
 	assertResponseHeaders(rest.T(), res)
@@ -162,13 +162,14 @@ func (rest *TestPlannerBacklogBlackboxREST) TestListPlannerBacklogWorkItemsOK() 
 func (rest *TestPlannerBacklogBlackboxREST) TestListPlannerBacklogWorkItemsOkUsingExpiredIfModifiedSinceHeader() {
 	// given
 	testSpace, parentIteration, _ := rest.setupPlannerBacklogWorkItems()
+	rest.T().Log("Test Space: " + testSpace.ID.String())
 	svc, ctrl := rest.UnSecuredController()
 	// when
 	offset := "0"
 	filter := ""
 	limit := -1
 	ifModifiedSince := app.ToHTTPTime(parentIteration.UpdatedAt.Add(-1 * time.Hour))
-	res, workitems := test.ListPlannerBacklogOK(rest.T(), svc.Context, svc, ctrl, testSpace.ID.String(), &filter, nil, nil, nil, &limit, &offset, &ifModifiedSince, nil)
+	res, workitems := test.ListPlannerBacklogOK(rest.T(), svc.Context, svc, ctrl, testSpace.ID, &filter, nil, nil, nil, &limit, &offset, &ifModifiedSince, nil)
 	// then
 	assertPlannerBacklogWorkItems(rest.T(), workitems, testSpace, parentIteration)
 	assertResponseHeaders(rest.T(), res)
@@ -183,7 +184,7 @@ func (rest *TestPlannerBacklogBlackboxREST) TestListPlannerBacklogWorkItemsOkUsi
 	filter := ""
 	limit := -1
 	ifNoneMatch := "foo"
-	res, workitems := test.ListPlannerBacklogOK(rest.T(), svc.Context, svc, ctrl, testSpace.ID.String(), &filter, nil, nil, nil, &limit, &offset, nil, &ifNoneMatch)
+	res, workitems := test.ListPlannerBacklogOK(rest.T(), svc.Context, svc, ctrl, testSpace.ID, &filter, nil, nil, nil, &limit, &offset, nil, &ifNoneMatch)
 	// then
 	assertPlannerBacklogWorkItems(rest.T(), workitems, testSpace, parentIteration)
 	assertResponseHeaders(rest.T(), res)
@@ -198,7 +199,7 @@ func (rest *TestPlannerBacklogBlackboxREST) TestListPlannerBacklogWorkItemsNotMo
 	filter := ""
 	limit := -1
 	ifModifiedSince := app.ToHTTPTime(lastWorkItem.Fields[workitem.SystemUpdatedAt].(time.Time))
-	res := test.ListPlannerBacklogNotModified(rest.T(), svc.Context, svc, ctrl, testSpace.ID.String(), &filter, nil, nil, nil, &limit, &offset, &ifModifiedSince, nil)
+	res := test.ListPlannerBacklogNotModified(rest.T(), svc.Context, svc, ctrl, testSpace.ID, &filter, nil, nil, nil, &limit, &offset, &ifModifiedSince, nil)
 	// then
 	assertResponseHeaders(rest.T(), res)
 }
@@ -210,10 +211,10 @@ func (rest *TestPlannerBacklogBlackboxREST) TestListPlannerBacklogWorkItemsNotMo
 	offset := "0"
 	filter := ""
 	limit := -1
-	_, workitems := test.ListPlannerBacklogOK(rest.T(), svc.Context, svc, ctrl, testSpace.ID.String(), &filter, nil, nil, nil, &limit, &offset, nil, nil)
+	_, workitems := test.ListPlannerBacklogOK(rest.T(), svc.Context, svc, ctrl, testSpace.ID, &filter, nil, nil, nil, &limit, &offset, nil, nil)
 	// when
 	ifNoneMatch := generateWorkitemsTag(workitems)
-	res := test.ListPlannerBacklogNotModified(rest.T(), svc.Context, svc, ctrl, testSpace.ID.String(), &filter, nil, nil, nil, &limit, &offset, nil, &ifNoneMatch)
+	res := test.ListPlannerBacklogNotModified(rest.T(), svc.Context, svc, ctrl, testSpace.ID, &filter, nil, nil, nil, &limit, &offset, nil, &ifNoneMatch)
 	// then
 	assertResponseHeaders(rest.T(), res)
 }
@@ -253,15 +254,7 @@ func (rest *TestPlannerBacklogBlackboxREST) TestSuccessEmptyListPlannerBacklogWo
 	offset := "0"
 	filter := ""
 	limit := -1
-	_, workitems := test.ListPlannerBacklogOK(rest.T(), svc.Context, svc, ctrl, spaceID.String(), &filter, nil, nil, nil, &limit, &offset, nil, nil)
+	_, workitems := test.ListPlannerBacklogOK(rest.T(), svc.Context, svc, ctrl, spaceID, &filter, nil, nil, nil, &limit, &offset, nil, nil)
 	// The list has to be empty
 	assert.Len(rest.T(), workitems.Data, 0)
-}
-
-func (rest *TestPlannerBacklogBlackboxREST) TestFailListPlannerBacklogByMissingSpace() {
-	svc, ctrl := rest.UnSecuredController()
-	offset := "0"
-	filter := ""
-	limit := 2
-	test.ListPlannerBacklogNotFound(rest.T(), svc.Context, svc, ctrl, "xxxxx", &filter, nil, nil, nil, &limit, &offset, nil, nil)
 }

--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -342,7 +342,7 @@ func (s *searchBlackBoxTest) TestAutoRegisterHostURL() {
 	wiCtrl := NewWorkitemController(s.svc, gormapplication.NewGormDB(s.DB), s.Configuration)
 	// create a WI, search by `list view URL` of newly created item
 	newWI := s.getWICreatePayload()
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, wiCtrl, newWI.Data.Relationships.Space.Data.ID.String(), newWI)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, wiCtrl, *newWI.Data.Relationships.Space.Data.ID, newWI)
 	require.NotNil(s.T(), wi)
 	customHost := "own.domain.one"
 	queryString := fmt.Sprintf("http://%s/work-item/list/detail/%s", customHost, *wi.Data.ID)

--- a/controller/space.go
+++ b/controller/space.go
@@ -157,29 +157,26 @@ func (c *SpaceController) Delete(ctx *app.DeleteSpaceContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(err.Error()))
 	}
-	id, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
-	}
 	var resourceID string
 	var permissionID string
 	var policyID string
 	err = application.Transactional(c.db, func(appl application.Application) error {
-		s, err := appl.Spaces().Load(ctx.Context, id)
+		s, err := appl.Spaces().Load(ctx.Context, ctx.SpaceID)
 		if err != nil {
 			return err
 		}
 		if !uuid.Equal(*currentUser, s.OwnerId) {
 			log.Warn(ctx, map[string]interface{}{
-				"space_id":     id,
+				"space_id":     ctx.SpaceID,
 				"space_owner":  s.OwnerId,
 				"current_user": *currentUser,
 			}, "user is not the space owner")
 			return errors.NewForbiddenError("user is not the space owner")
 		}
 
+		// FIXME: what about relying on CASCADE DELETE in the DB instead of doing this ?
 		// Delete associated space resource
-		resource, err := appl.SpaceResources().LoadBySpace(ctx, &id)
+		resource, err := appl.SpaceResources().LoadBySpace(ctx, &ctx.SpaceID)
 		if err != nil {
 			return err
 		}
@@ -191,7 +188,7 @@ func (c *SpaceController) Delete(ctx *app.DeleteSpaceContext) error {
 		if err != nil {
 			return err
 		}
-		return appl.Spaces().Delete(ctx.Context, id)
+		return appl.Spaces().Delete(ctx.Context, ctx.SpaceID)
 	})
 
 	if err != nil {
@@ -242,18 +239,12 @@ func (c *SpaceController) List(ctx *app.ListSpaceContext) error {
 
 // Show runs the show action.
 func (c *SpaceController) Show(ctx *app.ShowSpaceContext) error {
-	id, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
-	}
-
 	var result app.SpaceSingle
 	txnErr := application.Transactional(c.db, func(appl application.Application) error {
-		s, err := appl.Spaces().Load(ctx.Context, id)
+		s, err := appl.Spaces().Load(ctx.Context, ctx.SpaceID)
 		if err != nil {
 			return err
 		}
-
 		entityErr := ctx.ConditionalEntity(*s, c.config.GetCacheControlSpaces, func() error {
 			spaceData, err := ConvertSpaceFromModel(ctx.Context, c.db, ctx.RequestData, *s)
 			if err != nil {
@@ -281,11 +272,6 @@ func (c *SpaceController) Update(ctx *app.UpdateSpaceContext) error {
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(err.Error()))
 	}
-	id, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
-	}
-
 	err = validateUpdateSpace(ctx)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
@@ -293,7 +279,7 @@ func (c *SpaceController) Update(ctx *app.UpdateSpaceContext) error {
 
 	var response app.SpaceSingle
 	txnErr := application.Transactional(c.db, func(appl application.Application) error {
-		s, err := appl.Spaces().Load(ctx.Context, id)
+		s, err := appl.Spaces().Load(ctx.Context, ctx.SpaceID)
 		if err != nil {
 			return err
 		}

--- a/controller/space_areas.go
+++ b/controller/space_areas.go
@@ -7,7 +7,6 @@ import (
 	"github.com/almighty/almighty-core/log"
 
 	"github.com/goadesign/goa"
-	uuid "github.com/satori/go.uuid"
 )
 
 // SpaceAreasController implements the space-Areas resource.
@@ -33,16 +32,12 @@ func NewSpaceAreasController(service *goa.Service, db application.DB, config Spa
 
 // List runs the list action.
 func (c *SpaceAreasController) List(ctx *app.ListSpaceAreasContext) error {
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
-	}
 	return application.Transactional(c.db, func(appl application.Application) error {
-		_, err = appl.Spaces().Load(ctx, spaceID)
+		_, err := appl.Spaces().Load(ctx, ctx.SpaceID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
 		}
-		areas, err := appl.Areas().List(ctx, spaceID)
+		areas, err := appl.Areas().List(ctx, ctx.SpaceID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}

--- a/controller/space_areas_blackbox_test.go
+++ b/controller/space_areas_blackbox_test.go
@@ -121,7 +121,7 @@ func (rest *TestSpaceAreaREST) TestListAreasOK() {
 	// given
 	parentArea, createdAreaUuids, _ := rest.setupAreas()
 	// when
-	res, areaList := test.ListSpaceAreasOK(rest.T(), rest.svcSpaceAreas.Context, rest.svcSpaceAreas, rest.ctrlSpaceAreas, parentArea.SpaceID.String(), nil, nil)
+	res, areaList := test.ListSpaceAreasOK(rest.T(), rest.svcSpaceAreas.Context, rest.svcSpaceAreas, rest.ctrlSpaceAreas, parentArea.SpaceID, nil, nil)
 	// then
 	assertSpaceAreas(rest.T(), areaList, createdAreaUuids)
 	assertResponseHeaders(rest.T(), res)
@@ -132,7 +132,7 @@ func (rest *TestSpaceAreaREST) TestListAreasOKUsingExpiredIfModifiedSinceHeader(
 	parentArea, createdAreaUuids, _ := rest.setupAreas()
 	// when
 	ifModifiedSince := app.ToHTTPTime(parentArea.UpdatedAt.Add(-1 * time.Hour))
-	res, areaList := test.ListSpaceAreasOK(rest.T(), rest.svcSpaceAreas.Context, rest.svcSpaceAreas, rest.ctrlSpaceAreas, parentArea.SpaceID.String(), &ifModifiedSince, nil)
+	res, areaList := test.ListSpaceAreasOK(rest.T(), rest.svcSpaceAreas.Context, rest.svcSpaceAreas, rest.ctrlSpaceAreas, parentArea.SpaceID, &ifModifiedSince, nil)
 	// then
 	assertSpaceAreas(rest.T(), areaList, createdAreaUuids)
 	assertResponseHeaders(rest.T(), res)
@@ -143,7 +143,7 @@ func (rest *TestSpaceAreaREST) TestListAreasOKUsingExpiredIfNoneMatchHeader() {
 	parentArea, createdAreaUuids, _ := rest.setupAreas()
 	// when
 	ifNoneMatch := "foo"
-	res, areaList := test.ListSpaceAreasOK(rest.T(), rest.svcSpaceAreas.Context, rest.svcSpaceAreas, rest.ctrlSpaceAreas, parentArea.SpaceID.String(), nil, &ifNoneMatch)
+	res, areaList := test.ListSpaceAreasOK(rest.T(), rest.svcSpaceAreas.Context, rest.svcSpaceAreas, rest.ctrlSpaceAreas, parentArea.SpaceID, nil, &ifNoneMatch)
 	// then
 	assertSpaceAreas(rest.T(), areaList, createdAreaUuids)
 	assertResponseHeaders(rest.T(), res)
@@ -154,7 +154,7 @@ func (rest *TestSpaceAreaREST) TestListAreasNotModifiedUsingIfModifiedSinceHeade
 	parentArea, _, areas := rest.setupAreas()
 	// when
 	ifModifiedSince := app.ToHTTPTime(areas[len(areas)-1].UpdatedAt)
-	res := test.ListSpaceAreasNotModified(rest.T(), rest.svcSpaceAreas.Context, rest.svcSpaceAreas, rest.ctrlSpaceAreas, parentArea.SpaceID.String(), &ifModifiedSince, nil)
+	res := test.ListSpaceAreasNotModified(rest.T(), rest.svcSpaceAreas.Context, rest.svcSpaceAreas, rest.ctrlSpaceAreas, parentArea.SpaceID, &ifModifiedSince, nil)
 	// then
 	assertResponseHeaders(rest.T(), res)
 }
@@ -168,7 +168,7 @@ func (rest *TestSpaceAreaREST) TestListAreasNotModifiedUsingIfNoneMatchHeader() 
 		createdAreas[1],
 		createdAreas[2],
 	})
-	res := test.ListSpaceAreasNotModified(rest.T(), rest.svcSpaceAreas.Context, rest.svcSpaceAreas, rest.ctrlSpaceAreas, parentArea.SpaceID.String(), nil, &ifNoneMatch)
+	res := test.ListSpaceAreasNotModified(rest.T(), rest.svcSpaceAreas.Context, rest.svcSpaceAreas, rest.ctrlSpaceAreas, parentArea.SpaceID, nil, &ifNoneMatch)
 	// then
 	assertResponseHeaders(rest.T(), res)
 }

--- a/controller/space_codebases_test.go
+++ b/controller/space_codebases_test.go
@@ -83,7 +83,7 @@ func (rest *TestSpaceCodebaseREST) TestSuccessCreateCodebase() {
 		return nil
 	})
 	svc, ctrl := rest.SecuredController()
-	_, c := test.CreateSpaceCodebasesCreated(t, svc.Context, svc, ctrl, p.ID.String(), ci)
+	_, c := test.CreateSpaceCodebasesCreated(t, svc.Context, svc, ctrl, p.ID, ci)
 	require.NotNil(t, c.Data.ID)
 	require.NotNil(t, c.Data.Relationships.Space)
 	assert.Equal(t, p.ID.String(), *c.Data.Relationships.Space.Data.ID)
@@ -127,7 +127,7 @@ func (rest *TestSpaceCodebaseREST) TestListCodebase() {
 	for i := 0; i < 3; i++ {
 		repoURL := strings.Replace(repo, "core", "core"+strconv.Itoa(i), -1)
 		spaceCodebaseContext := createSpaceCodebase(repoURL)
-		_, c := test.CreateSpaceCodebasesCreated(t, svc.Context, svc, ctrl, spaceId.String(), spaceCodebaseContext)
+		_, c := test.CreateSpaceCodebasesCreated(t, svc.Context, svc, ctrl, spaceId, spaceCodebaseContext)
 		require.NotNil(t, c.Data.ID)
 		require.NotNil(t, c.Data.Relationships.Space)
 		createdSpacesUuids1 = append(createdSpacesUuids1, *c.Data.ID)
@@ -135,20 +135,20 @@ func (rest *TestSpaceCodebaseREST) TestListCodebase() {
 
 	otherRepo := "https://github.com/fabric8io/fabric8-planner.git"
 	anotherSpaceCodebaseContext := createSpaceCodebase(otherRepo)
-	_, createdCodebase := test.CreateSpaceCodebasesCreated(t, svc.Context, svc, ctrl, anotherSpaceId.String(), anotherSpaceCodebaseContext)
+	_, createdCodebase := test.CreateSpaceCodebasesCreated(t, svc.Context, svc, ctrl, anotherSpaceId, anotherSpaceCodebaseContext)
 	require.NotNil(t, createdCodebase)
 
 	offset := "0"
 	limit := 100
 
 	svc, ctrl = rest.UnSecuredController()
-	_, codebaseList := test.ListSpaceCodebasesOK(t, svc.Context, svc, ctrl, spaceId.String(), &limit, &offset)
+	_, codebaseList := test.ListSpaceCodebasesOK(t, svc.Context, svc, ctrl, spaceId, &limit, &offset)
 	assert.Len(t, codebaseList.Data, 3)
 	for i := 0; i < len(createdSpacesUuids1); i++ {
 		assert.NotNil(t, searchInCodebaseSlice(createdSpacesUuids1[i], codebaseList))
 	}
 
-	_, anotherCodebaseList := test.ListSpaceCodebasesOK(t, svc.Context, svc, ctrl, anotherSpaceId.String(), &limit, &offset)
+	_, anotherCodebaseList := test.ListSpaceCodebasesOK(t, svc.Context, svc, ctrl, anotherSpaceId, &limit, &offset)
 	require.Len(t, anotherCodebaseList.Data, 1)
 	assert.Equal(t, anotherCodebaseList.Data[0].ID, createdCodebase.Data.ID)
 
@@ -161,7 +161,7 @@ func (rest *TestSpaceCodebaseREST) TestCreateCodebaseMissingSpace() {
 	ci := createSpaceCodebase("https://github.com/fabric8io/fabric8-planner.git")
 
 	svc, ctrl := rest.SecuredController()
-	test.CreateSpaceCodebasesNotFound(t, svc.Context, svc, ctrl, uuid.NewV4().String(), ci)
+	test.CreateSpaceCodebasesNotFound(t, svc.Context, svc, ctrl, uuid.NewV4(), ci)
 }
 
 func (rest *TestSpaceCodebaseREST) TestFailCreateCodebaseNotAuthorized() {
@@ -171,7 +171,7 @@ func (rest *TestSpaceCodebaseREST) TestFailCreateCodebaseNotAuthorized() {
 	ci := createSpaceCodebase("https://github.com/fabric8io/fabric8-planner.git")
 
 	svc, ctrl := rest.UnSecuredController()
-	test.CreateSpaceCodebasesUnauthorized(t, svc.Context, svc, ctrl, uuid.NewV4().String(), ci)
+	test.CreateSpaceCodebasesUnauthorized(t, svc.Context, svc, ctrl, uuid.NewV4(), ci)
 }
 
 func (rest *TestSpaceCodebaseREST) TestFailListCodebaseByMissingSpace() {
@@ -182,7 +182,7 @@ func (rest *TestSpaceCodebaseREST) TestFailListCodebaseByMissingSpace() {
 	limit := 100
 
 	svc, ctrl := rest.UnSecuredController()
-	test.ListSpaceCodebasesNotFound(t, svc.Context, svc, ctrl, uuid.NewV4().String(), &limit, &offset)
+	test.ListSpaceCodebasesNotFound(t, svc.Context, svc, ctrl, uuid.NewV4(), &limit, &offset)
 }
 
 func searchInCodebaseSlice(searchKey uuid.UUID, codebaseList *app.CodebaseList) *app.Codebase {

--- a/controller/space_iterations.go
+++ b/controller/space_iterations.go
@@ -12,7 +12,6 @@ import (
 	"github.com/almighty/almighty-core/workitem"
 
 	"github.com/goadesign/goa"
-	uuid "github.com/satori/go.uuid"
 )
 
 // SpaceIterationsControllerConfiguration configuration for the SpaceIterationsController
@@ -39,11 +38,6 @@ func (c *SpaceIterationsController) Create(ctx *app.CreateSpaceIterationsContext
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrUnauthorized(err.Error()))
 	}
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
-	}
-
 	// Validate Request
 	if ctx.Payload.Data == nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("data", nil).Expected("not nil"))
@@ -54,18 +48,18 @@ func (c *SpaceIterationsController) Create(ctx *app.CreateSpaceIterationsContext
 	}
 
 	return application.Transactional(c.db, func(appl application.Application) error {
-		_, err = appl.Spaces().Load(ctx, spaceID)
+		_, err = appl.Spaces().Load(ctx, ctx.SpaceID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
 		}
 		// Put iteration under root iteration
-		rootIteration, err := appl.Iterations().Root(ctx, spaceID)
+		rootIteration, err := appl.Iterations().Root(ctx, ctx.SpaceID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
 		}
 		childPath := append(rootIteration.Path, rootIteration.ID)
 		newItr := iteration.Iteration{
-			SpaceID: spaceID,
+			SpaceID: ctx.SpaceID,
 			Name:    *reqIter.Attributes.Name,
 			StartAt: reqIter.Attributes.StartAt,
 			EndAt:   reqIter.Attributes.EndAt,
@@ -111,18 +105,12 @@ func (c *SpaceIterationsController) Create(ctx *app.CreateSpaceIterationsContext
 
 // List runs the list action.
 func (c *SpaceIterationsController) List(ctx *app.ListSpaceIterationsContext) error {
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
-	}
-
 	return application.Transactional(c.db, func(appl application.Application) error {
-
-		_, err = appl.Spaces().Load(ctx, spaceID)
+		_, err := appl.Spaces().Load(ctx, ctx.SpaceID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, goa.ErrNotFound(err.Error()))
 		}
-		iterations, err := appl.Iterations().List(ctx, spaceID)
+		iterations, err := appl.Iterations().List(ctx, ctx.SpaceID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
@@ -132,11 +120,11 @@ func (c *SpaceIterationsController) List(ctx *app.ListSpaceIterationsContext) er
 				itrMap[itr.ID] = itr
 			}
 			// fetch extra information(counts of WI in each iteration of the space) to be added in response
-			wiCounts, err := appl.WorkItems().GetCountsPerIteration(ctx, spaceID)
+			wiCounts, err := appl.WorkItems().GetCountsPerIteration(ctx, ctx.SpaceID)
 			log.Info(ctx, map[string]interface{}{
-				"space_id": spaceID,
+				"space_id": ctx.SpaceID.String(),
 				"wiCounts": wiCounts,
-			}, "Retrieving wicounts for spaceID %s -> %v", spaceID, wiCounts)
+			}, "Retrieving wicounts for spaceID %s -> %v", ctx.SpaceID.String(), wiCounts)
 
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)

--- a/controller/space_iterations_test.go
+++ b/controller/space_iterations_test.go
@@ -110,7 +110,7 @@ func (rest *TestSpaceIterationREST) TestSuccessCreateIteration() {
 	require.Nil(rest.T(), err)
 	svc, ctrl := rest.SecuredController()
 	// when
-	_, c := test.CreateSpaceIterationsCreated(rest.T(), svc.Context, svc, ctrl, p.ID.String(), ci)
+	_, c := test.CreateSpaceIterationsCreated(rest.T(), svc.Context, svc, ctrl, p.ID, ci)
 	// then
 	require.NotNil(rest.T(), c.Data.ID)
 	require.NotNil(rest.T(), c.Data.Relationships.Space)
@@ -147,7 +147,7 @@ func (rest *TestSpaceIterationREST) TestSuccessCreateIterationWithOptionalValues
 	})
 	svc, ctrl := rest.SecuredController()
 	// when
-	_, c := test.CreateSpaceIterationsCreated(rest.T(), svc.Context, svc, ctrl, p.ID.String(), ci)
+	_, c := test.CreateSpaceIterationsCreated(rest.T(), svc.Context, svc, ctrl, p.ID, ci)
 	// then
 	assert.NotNil(rest.T(), c.Data.ID)
 	assert.NotNil(rest.T(), c.Data.Relationships.Space)
@@ -158,7 +158,7 @@ func (rest *TestSpaceIterationREST) TestSuccessCreateIterationWithOptionalValues
 	// create another Iteration with nil description
 	iterationName2 := "Sprint #23"
 	ci = createSpaceIteration(iterationName2, nil)
-	_, c = test.CreateSpaceIterationsCreated(rest.T(), svc.Context, svc, ctrl, p.ID.String(), ci)
+	_, c = test.CreateSpaceIterationsCreated(rest.T(), svc.Context, svc, ctrl, p.ID, ci)
 	assert.Equal(rest.T(), *c.Data.Attributes.Name, iterationName2)
 	assert.Nil(rest.T(), c.Data.Attributes.Description)
 }
@@ -168,7 +168,7 @@ func (rest *TestSpaceIterationREST) TestListIterationsBySpaceOK() {
 	spaceID, fatherIteration, childIteration, grandChildIteration := rest.createIterations()
 	svc, ctrl := rest.UnSecuredController()
 	// when
-	_, cs := test.ListSpaceIterationsOK(rest.T(), svc.Context, svc, ctrl, spaceID.String(), nil, nil)
+	_, cs := test.ListSpaceIterationsOK(rest.T(), svc.Context, svc, ctrl, spaceID, nil, nil)
 	// then
 	assertIterations(rest.T(), cs.Data, fatherIteration, childIteration, grandChildIteration)
 }
@@ -179,7 +179,7 @@ func (rest *TestSpaceIterationREST) TestListIterationsBySpaceOKUsingExpiredIfMod
 	svc, ctrl := rest.UnSecuredController()
 	// when
 	idModifiedSince := app.ToHTTPTime(fatherIteration.UpdatedAt.Add(-1 * time.Hour))
-	_, cs := test.ListSpaceIterationsOK(rest.T(), svc.Context, svc, ctrl, spaceID.String(), &idModifiedSince, nil)
+	_, cs := test.ListSpaceIterationsOK(rest.T(), svc.Context, svc, ctrl, spaceID, &idModifiedSince, nil)
 	// then
 	assertIterations(rest.T(), cs.Data, fatherIteration, childIteration, grandChildIteration)
 }
@@ -190,7 +190,7 @@ func (rest *TestSpaceIterationREST) TestListIterationsBySpaceOKUsingExpiredIfNon
 	svc, ctrl := rest.UnSecuredController()
 	// when
 	idNoneMatch := "foo"
-	_, cs := test.ListSpaceIterationsOK(rest.T(), svc.Context, svc, ctrl, spaceID.String(), nil, &idNoneMatch)
+	_, cs := test.ListSpaceIterationsOK(rest.T(), svc.Context, svc, ctrl, spaceID, nil, &idNoneMatch)
 	// then
 	assertIterations(rest.T(), cs.Data, fatherIteration, childIteration, grandChildIteration)
 }
@@ -201,7 +201,7 @@ func (rest *TestSpaceIterationREST) TestListIterationsBySpaceNotModifiedUsingIfM
 	svc, ctrl := rest.UnSecuredController()
 	// when/then
 	idModifiedSince := app.ToHTTPTime(grandChildIteration.UpdatedAt)
-	test.ListSpaceIterationsNotModified(rest.T(), svc.Context, svc, ctrl, spaceID.String(), &idModifiedSince, nil)
+	test.ListSpaceIterationsNotModified(rest.T(), svc.Context, svc, ctrl, spaceID, &idModifiedSince, nil)
 }
 
 func (rest *TestSpaceIterationREST) TestListIterationsBySpaceNotModifiedUsingIfNoneMatchSinceHeader() {
@@ -209,10 +209,10 @@ func (rest *TestSpaceIterationREST) TestListIterationsBySpaceNotModifiedUsingIfN
 	spaceID, _, _, _ := rest.createIterations()
 	svc, ctrl := rest.UnSecuredController()
 	// here we need to get all iterations for the spaceId
-	_, iterations := test.ListSpaceIterationsOK(rest.T(), svc.Context, svc, ctrl, spaceID.String(), nil, nil)
+	_, iterations := test.ListSpaceIterationsOK(rest.T(), svc.Context, svc, ctrl, spaceID, nil, nil)
 	// when/then
 	idNoneMatch := generateIterationsTag(*iterations)
-	test.ListSpaceIterationsNotModified(rest.T(), svc.Context, svc, ctrl, spaceID.String(), nil, &idNoneMatch)
+	test.ListSpaceIterationsNotModified(rest.T(), svc.Context, svc, ctrl, spaceID, nil, &idNoneMatch)
 }
 
 func (rest *TestSpaceIterationREST) TestCreateIterationMissingSpace() {
@@ -220,7 +220,7 @@ func (rest *TestSpaceIterationREST) TestCreateIterationMissingSpace() {
 	ci := createSpaceIteration("Sprint #21", nil)
 	svc, ctrl := rest.SecuredController()
 	// when/then
-	test.CreateSpaceIterationsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4().String(), ci)
+	test.CreateSpaceIterationsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4(), ci)
 }
 
 func (rest *TestSpaceIterationREST) TestFailCreateIterationNotAuthorized() {
@@ -228,14 +228,14 @@ func (rest *TestSpaceIterationREST) TestFailCreateIterationNotAuthorized() {
 	ci := createSpaceIteration("Sprint #21", nil)
 	svc, ctrl := rest.UnSecuredController()
 	// when/then
-	test.CreateSpaceIterationsUnauthorized(rest.T(), svc.Context, svc, ctrl, uuid.NewV4().String(), ci)
+	test.CreateSpaceIterationsUnauthorized(rest.T(), svc.Context, svc, ctrl, uuid.NewV4(), ci)
 }
 
 func (rest *TestSpaceIterationREST) TestFailListIterationsByMissingSpace() {
 	// given
 	svc, ctrl := rest.UnSecuredController()
 	// when/then
-	test.ListSpaceIterationsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4().String(), nil, nil)
+	test.ListSpaceIterationsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4(), nil, nil)
 }
 
 func (rest *TestSpaceIterationREST) TestWICountsWithIterationListBySpace() {
@@ -291,7 +291,7 @@ func (rest *TestSpaceIterationREST) TestWICountsWithIterationListBySpace() {
 	}
 	svc, ctrl := rest.UnSecuredController()
 	// when
-	_, cs := test.ListSpaceIterationsOK(rest.T(), svc.Context, svc, ctrl, spaceInstance.ID.String(), nil, nil)
+	_, cs := test.ListSpaceIterationsOK(rest.T(), svc.Context, svc, ctrl, spaceInstance.ID, nil, nil)
 	// then
 	require.Len(rest.T(), cs.Data, 2)
 	for _, iterationItem := range cs.Data {
@@ -315,7 +315,7 @@ func (rest *TestSpaceIterationREST) TestWICountsWithIterationListBySpace() {
 		require.Nil(rest.T(), err)
 	}
 	// when
-	_, cs = test.ListSpaceIterationsOK(rest.T(), svc.Context, svc, ctrl, spaceInstance.ID.String(), nil, nil)
+	_, cs = test.ListSpaceIterationsOK(rest.T(), svc.Context, svc, ctrl, spaceInstance.ID, nil, nil)
 	// then
 	require.Len(rest.T(), cs.Data, 2)
 	for _, iterationItem := range cs.Data {

--- a/controller/space_test.go
+++ b/controller/space_test.go
@@ -156,8 +156,7 @@ func (rest *TestSpaceREST) TestSuccessCreateSpaceAndDefaultArea() {
 	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
 	require.NotNil(rest.T(), created.Data)
 	spaceAreaSvc, spaceAreaCtrl := rest.SecuredSpaceAreaController(testsupport.TestIdentity)
-	createdID := created.Data.ID.String()
-	_, areaList := test.ListSpaceAreasOK(rest.T(), spaceAreaSvc.Context, spaceAreaSvc, spaceAreaCtrl, createdID, nil, nil)
+	_, areaList := test.ListSpaceAreasOK(rest.T(), spaceAreaSvc.Context, spaceAreaSvc, spaceAreaCtrl, *created.Data.ID, nil, nil)
 	// then
 	// only 1 default gets created.
 	assert.Len(rest.T(), areaList.Data, 1)
@@ -165,7 +164,7 @@ func (rest *TestSpaceREST) TestSuccessCreateSpaceAndDefaultArea() {
 
 	// verify if root iteration is created or not
 	spaceIterationSvc, spaceIterationCtrl := rest.SecuredSpaceIterationController(testsupport.TestIdentity)
-	_, iterationList := test.ListSpaceIterationsOK(rest.T(), spaceIterationSvc.Context, spaceIterationSvc, spaceIterationCtrl, createdID, nil, nil)
+	_, iterationList := test.ListSpaceIterationsOK(rest.T(), spaceIterationSvc.Context, spaceIterationSvc, spaceIterationCtrl, *created.Data.ID, nil, nil)
 	require.Len(rest.T(), iterationList.Data, 1)
 	assert.Equal(rest.T(), name, *iterationList.Data[0].Attributes.Name)
 
@@ -205,7 +204,7 @@ func (rest *TestSpaceREST) TestFailDeleteSpaceDifferentOwner() {
 	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
 	// when
 	svc2, ctrl2 := rest.SecuredController(testsupport.TestIdentity2)
-	_, errors := test.DeleteSpaceForbidden(rest.T(), svc2.Context, svc2, ctrl2, created.Data.ID.String())
+	_, errors := test.DeleteSpaceForbidden(rest.T(), svc2.Context, svc2, ctrl2, *created.Data.ID)
 	// then
 	assert.NotEmpty(rest.T(), errors.Errors)
 	assert.Contains(rest.T(), errors.Errors[0].Detail, "user is not the space owner")
@@ -222,7 +221,7 @@ func (rest *TestSpaceREST) TestSuccessDeleteSpaceSameOwner() {
 	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
 	// when
 	svc2, ctrl2 := rest.SecuredController(testsupport.TestIdentity)
-	test.DeleteSpaceOK(rest.T(), svc2.Context, svc2, ctrl2, created.Data.ID.String())
+	test.DeleteSpaceOK(rest.T(), svc2.Context, svc2, ctrl2, *created.Data.ID)
 }
 
 func (rest *TestSpaceREST) TestSuccessUpdateSpace() {
@@ -242,7 +241,7 @@ func (rest *TestSpaceREST) TestSuccessUpdateSpace() {
 	u.Data.Attributes.Name = &newName
 	u.Data.Attributes.Description = &newDescription
 	// when
-	_, updated := test.UpdateSpaceOK(rest.T(), svc.Context, svc, ctrl, created.Data.ID.String(), u)
+	_, updated := test.UpdateSpaceOK(rest.T(), svc.Context, svc, ctrl, *created.Data.ID, u)
 	// then
 	assert.Equal(rest.T(), newName, *updated.Data.Attributes.Name)
 	assert.Equal(rest.T(), newDescription, *updated.Data.Attributes.Description)
@@ -262,7 +261,7 @@ func (rest *TestSpaceREST) TestFailUpdateSpaceNameLength() {
 	p.Data.Attributes.Name = &testOversizedSpaceName
 	svc2, ctrl2 := rest.SecuredController(testsupport.TestIdentity2)
 
-	test.UpdateSpaceBadRequest(rest.T(), svc2.Context, svc2, ctrl2, created.Data.ID.String(), u)
+	test.UpdateSpaceBadRequest(rest.T(), svc2.Context, svc2, ctrl2, *created.Data.ID, u)
 }
 
 func (rest *TestSpaceREST) TestFailUpdateSpaceDifferentOwner() {
@@ -283,7 +282,7 @@ func (rest *TestSpaceREST) TestFailUpdateSpaceDifferentOwner() {
 	u.Data.Attributes.Name = &newName
 	u.Data.Attributes.Description = &newDescription
 	svc2, ctrl2 := rest.SecuredController(testsupport.TestIdentity2)
-	_, errors := test.UpdateSpaceForbidden(rest.T(), svc2.Context, svc2, ctrl2, created.Data.ID.String(), u)
+	_, errors := test.UpdateSpaceForbidden(rest.T(), svc2.Context, svc2, ctrl2, *created.Data.ID, u)
 	// then
 	assert.NotEmpty(rest.T(), errors.Errors)
 	assert.Contains(rest.T(), errors.Errors[0].Detail, "User is not the space owner")
@@ -294,7 +293,7 @@ func (rest *TestSpaceREST) TestFailUpdateSpaceUnSecure() {
 	u := minimumRequiredUpdateSpace()
 	svc, ctrl := rest.UnSecuredController()
 	// when/then
-	test.UpdateSpaceUnauthorized(rest.T(), svc.Context, svc, ctrl, uuid.NewV4().String(), u)
+	test.UpdateSpaceUnauthorized(rest.T(), svc.Context, svc, ctrl, uuid.NewV4(), u)
 }
 
 func (rest *TestSpaceREST) TestFailUpdateSpaceNotFound() {
@@ -308,7 +307,7 @@ func (rest *TestSpaceREST) TestFailUpdateSpaceNotFound() {
 	u.Data.ID = &id
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
 	// when/then
-	test.UpdateSpaceNotFound(rest.T(), svc.Context, svc, ctrl, id.String(), u)
+	test.UpdateSpaceNotFound(rest.T(), svc.Context, svc, ctrl, id, u)
 }
 
 func (rest *TestSpaceREST) TestFailUpdateSpaceMissingName() {
@@ -322,7 +321,7 @@ func (rest *TestSpaceREST) TestFailUpdateSpaceMissingName() {
 	u.Data.ID = created.Data.ID
 	u.Data.Attributes.Version = created.Data.Attributes.Version
 	// when/then
-	test.UpdateSpaceBadRequest(rest.T(), svc.Context, svc, ctrl, created.Data.ID.String(), u)
+	test.UpdateSpaceBadRequest(rest.T(), svc.Context, svc, ctrl, *created.Data.ID, u)
 }
 
 func (rest *TestSpaceREST) TestFailUpdateSpaceMissingVersion() {
@@ -337,7 +336,7 @@ func (rest *TestSpaceREST) TestFailUpdateSpaceMissingVersion() {
 	u.Data.ID = created.Data.ID
 	u.Data.Attributes.Name = &newName
 	// when/then
-	test.UpdateSpaceBadRequest(rest.T(), svc.Context, svc, ctrl, created.Data.ID.String(), u)
+	test.UpdateSpaceBadRequest(rest.T(), svc.Context, svc, ctrl, *created.Data.ID, u)
 }
 
 func (rest *TestSpaceREST) TestShowSpaceOK() {
@@ -350,7 +349,7 @@ func (rest *TestSpaceREST) TestShowSpaceOK() {
 	svc, ctrl := rest.SecuredController(testsupport.TestIdentity)
 	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
 	// when
-	res, fetched := test.ShowSpaceOK(rest.T(), svc.Context, svc, ctrl, created.Data.ID.String(), nil, nil)
+	res, fetched := test.ShowSpaceOK(rest.T(), svc.Context, svc, ctrl, *created.Data.ID, nil, nil)
 	// then
 	assert.Equal(rest.T(), created.Data.ID, fetched.Data.ID)
 	assert.Equal(rest.T(), *created.Data.Attributes.Name, *fetched.Data.Attributes.Name)
@@ -385,7 +384,7 @@ func (rest *TestSpaceREST) TestShowSpaceOKUsingExpiredIfModifiedSinceHeader() {
 	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
 	// when
 	ifModifiedSince := app.ToHTTPTime(created.Data.Attributes.UpdatedAt.Add(-1 * time.Hour))
-	res, fetched := test.ShowSpaceOK(rest.T(), svc.Context, svc, ctrl, created.Data.ID.String(), &ifModifiedSince, nil)
+	res, fetched := test.ShowSpaceOK(rest.T(), svc.Context, svc, ctrl, *created.Data.ID, &ifModifiedSince, nil)
 	// then
 	assert.Equal(rest.T(), created.Data.ID, fetched.Data.ID)
 	assert.Equal(rest.T(), *created.Data.Attributes.Name, *fetched.Data.Attributes.Name)
@@ -410,7 +409,7 @@ func (rest *TestSpaceREST) TestShowSpaceOKUsingExpiredIfNoneMatchHeader() {
 	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
 	// when
 	ifNoneMatch := "foo_etag"
-	res, fetched := test.ShowSpaceOK(rest.T(), svc.Context, svc, ctrl, created.Data.ID.String(), nil, &ifNoneMatch)
+	res, fetched := test.ShowSpaceOK(rest.T(), svc.Context, svc, ctrl, *created.Data.ID, nil, &ifNoneMatch)
 	// then
 	assert.Equal(rest.T(), created.Data.ID, fetched.Data.ID)
 	assert.Equal(rest.T(), *created.Data.Attributes.Name, *fetched.Data.Attributes.Name)
@@ -435,7 +434,7 @@ func (rest *TestSpaceREST) TestShowSpaceNotModifiedUsingIfModifiedSinceHeader() 
 	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
 	// when/then
 	ifModifiedSince := app.ToHTTPTime(getSpaceUpdatedAt(*created))
-	test.ShowSpaceNotModified(rest.T(), svc.Context, svc, ctrl, created.Data.ID.String(), &ifModifiedSince, nil)
+	test.ShowSpaceNotModified(rest.T(), svc.Context, svc, ctrl, *created.Data.ID, &ifModifiedSince, nil)
 }
 
 func (rest *TestSpaceREST) TestShowSpaceNotModifiedUsingIfNoneMatchHeader() {
@@ -449,11 +448,10 @@ func (rest *TestSpaceREST) TestShowSpaceNotModifiedUsingIfNoneMatchHeader() {
 	_, created := test.CreateSpaceCreated(rest.T(), svc.Context, svc, ctrl, p)
 	// when/then
 	ifNoneMatch := generateSpaceTag(*created)
-	// test.ShowSpaceNotModified(rest.T(), svc.Context, svc, ctrl, created.Data.ID.String(), nil, &ifNoneMatch)
-	test.ShowSpaceNotModified(rest.T(), svc.Context, svc, ctrl, created.Data.ID.String(), nil, &ifNoneMatch)
+	test.ShowSpaceNotModified(rest.T(), svc.Context, svc, ctrl, *created.Data.ID, nil, &ifNoneMatch)
 
 	t := rest.T()
-	_, fetched := test.ShowSpaceOK(t, svc.Context, svc, ctrl, created.Data.ID.String(), nil, nil)
+	_, fetched := test.ShowSpaceOK(t, svc.Context, svc, ctrl, *created.Data.ID, nil, nil)
 	assert.Equal(t, created.Data.ID, fetched.Data.ID)
 	assert.Equal(t, *created.Data.Attributes.Name, *fetched.Data.Attributes.Name)
 	assert.Equal(t, *created.Data.Attributes.Description, *fetched.Data.Attributes.Description)
@@ -494,14 +492,7 @@ func (rest *TestSpaceREST) TestFailShowSpaceNotFound() {
 	// given
 	svc, ctrl := rest.UnSecuredController()
 	// when/then
-	test.ShowSpaceNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4().String(), nil, nil)
-}
-
-func (rest *TestSpaceREST) TestFailShowSpaceNotFoundBadID() {
-	// given
-	svc, ctrl := rest.UnSecuredController()
-	// when/then
-	test.ShowSpaceNotFound(rest.T(), svc.Context, svc, ctrl, "asfasfsaf", nil, nil)
+	test.ShowSpaceNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4(), nil, nil)
 }
 
 func (rest *TestSpaceREST) TestListSpacesOK() {

--- a/controller/work_item_children_blackbox_test.go
+++ b/controller/work_item_children_blackbox_test.go
@@ -137,7 +137,7 @@ func (s *workItemChildSuite) SetupTest() {
 
 	// Create 3 work items (bug1, bug2, and bug3)
 	bug1Payload := CreateWorkItem(s.userSpaceID, workitem.SystemBug, "bug1")
-	_, bug1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), bug1Payload)
+	_, bug1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID, bug1Payload)
 	require.NotNil(s.T(), bug1)
 	checkChildrenRelationship(s.T(), bug1.Data, &hasNoChildren)
 
@@ -147,7 +147,7 @@ func (s *workItemChildSuite) SetupTest() {
 	s.T().Logf("Created bug1 with ID: %s\n", *bug1.Data.ID)
 
 	bug2Payload := CreateWorkItem(s.userSpaceID, workitem.SystemBug, "bug2")
-	_, bug2 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), bug2Payload)
+	_, bug2 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID, bug2Payload)
 	require.NotNil(s.T(), bug2)
 	checkChildrenRelationship(s.T(), bug2.Data, &hasNoChildren)
 
@@ -156,7 +156,7 @@ func (s *workItemChildSuite) SetupTest() {
 	s.T().Logf("Created bug2 with ID: %s\n", *bug2.Data.ID)
 
 	bug3Payload := CreateWorkItem(s.userSpaceID, workitem.SystemBug, "bug3")
-	_, bug3 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), bug3Payload)
+	_, bug3 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID, bug3Payload)
 	require.NotNil(s.T(), bug3)
 	checkChildrenRelationship(s.T(), bug3.Data, &hasNoChildren)
 
@@ -174,7 +174,7 @@ func (s *workItemChildSuite) SetupTest() {
 
 	// Create work item link type payload
 	createLinkTypePayload := createParentChildWorkItemLinkType("test-bug-blocker", workitem.SystemBug, workitem.SystemBug, userLinkCategoryID, s.userSpaceID)
-	_, workItemLinkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.workItemLinkTypeCtrl, s.userSpaceID.String(), createLinkTypePayload)
+	_, workItemLinkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.workItemLinkTypeCtrl, s.userSpaceID, createLinkTypePayload)
 	require.NotNil(s.T(), workItemLinkType)
 	bugBlockerLinkTypeID := *workItemLinkType.Data.ID
 	s.T().Logf("Created link type with ID: %s\n", *workItemLinkType.Data.ID)
@@ -183,7 +183,7 @@ func (s *workItemChildSuite) SetupTest() {
 	_, workItemLink := test.CreateWorkItemLinkCreated(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, createPayload)
 	require.NotNil(s.T(), workItemLink)
 	// Check that the bug1 now hasChildren
-	_, workItemAfterLinked := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), *bug1.Data.ID, nil, nil)
+	_, workItemAfterLinked := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID, *bug1.Data.ID, nil, nil)
 	checkChildrenRelationship(s.T(), workItemAfterLinked.Data, &hasChildren)
 
 	createPayload2 := CreateWorkItemLink(s.bug1ID, bug3ID, bugBlockerLinkTypeID)
@@ -270,16 +270,16 @@ func (s *workItemChildSuite) TestChildren() {
 	hasNoChildren := false
 
 	s.T().Run("show action has children", func(t *testing.T) {
-		_, workItem := test.ShowWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), *s.bug1.Data.ID, nil, nil)
+		_, workItem := test.ShowWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID, *s.bug1.Data.ID, nil, nil)
 		checkChildrenRelationship(t, workItem.Data, &hasChildren)
 	})
 	s.T().Run("show action has no children", func(t *testing.T) {
-		_, workItem := test.ShowWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), *s.bug3.Data.ID, nil, nil)
+		_, workItem := test.ShowWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID, *s.bug3.Data.ID, nil, nil)
 		checkChildrenRelationship(t, workItem.Data, &hasNoChildren)
 	})
 	s.T().Run("list ok", func(t *testing.T) {
 		// when
-		res, workItemList := test.ListChildrenWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, nil)
+		res, workItemList := test.ListChildrenWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID, workItemID1, nil, nil)
 		// then
 		assertWorkItemList(t, workItemList)
 		assertResponseHeaders(t, res)
@@ -287,7 +287,7 @@ func (s *workItemChildSuite) TestChildren() {
 	s.T().Run("using expired if modified since header", func(t *testing.T) {
 		// when
 		ifModifiedSince := app.ToHTTPTime(s.bug1.Data.Attributes[workitem.SystemUpdatedAt].(time.Time).Add(-1 * time.Hour))
-		res, workItemList := test.ListChildrenWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, &ifModifiedSince, nil)
+		res, workItemList := test.ListChildrenWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID, workItemID1, &ifModifiedSince, nil)
 		// then
 		assertWorkItemList(t, workItemList)
 		assertResponseHeaders(t, res)
@@ -295,7 +295,7 @@ func (s *workItemChildSuite) TestChildren() {
 	s.T().Run("using expired if none match header", func(t *testing.T) {
 		// when
 		ifNoneMatch := "foo"
-		res, workItemList := test.ListChildrenWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, &ifNoneMatch)
+		res, workItemList := test.ListChildrenWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID, workItemID1, nil, &ifNoneMatch)
 		// then
 		assertWorkItemList(t, workItemList)
 		assertResponseHeaders(t, res)
@@ -303,15 +303,15 @@ func (s *workItemChildSuite) TestChildren() {
 	s.T().Run("not modified using if modified since header", func(t *testing.T) {
 		// when
 		ifModifiedSince := app.ToHTTPTime(s.bug3.Data.Attributes[workitem.SystemUpdatedAt].(time.Time))
-		res := test.ListChildrenWorkitemNotModified(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, &ifModifiedSince, nil)
+		res := test.ListChildrenWorkitemNotModified(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID, workItemID1, &ifModifiedSince, nil)
 		// then
 		assertResponseHeaders(t, res)
 	})
 	s.T().Run("not modified using if none match header", func(t *testing.T) {
-		_, workItemList := test.ListChildrenWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, nil)
+		_, workItemList := test.ListChildrenWorkitemOK(s.T(), s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID, workItemID1, nil, nil)
 		// when
 		ifNoneMatch := generateWorkitemsTag(workItemList)
-		res := test.ListChildrenWorkitemNotModified(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID.String(), workItemID1, nil, &ifNoneMatch)
+		res := test.ListChildrenWorkitemNotModified(t, s.svc.Context, s.svc, s.workItemCtrl, s.userSpaceID, workItemID1, nil, &ifNoneMatch)
 		// then
 		assertResponseHeaders(t, res)
 	})

--- a/controller/work_item_comments_blackbox_test.go
+++ b/controller/work_item_comments_blackbox_test.go
@@ -24,9 +24,9 @@ import (
 	testsupport "github.com/almighty/almighty-core/test"
 	almtoken "github.com/almighty/almighty-core/token"
 	"github.com/almighty/almighty-core/workitem"
-
 	"github.com/goadesign/goa"
 	"github.com/pkg/errors"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -132,7 +132,7 @@ func (rest *TestCommentREST) TestSuccessCreateSingleCommentWithMarkup() {
 	markup := rendering.SystemMarkupMarkdown
 	p := rest.newCreateWorkItemCommentsPayload("Test", &markup)
 	svc, ctrl := rest.SecuredController()
-	_, c := test.CreateWorkItemCommentsOK(rest.T(), svc.Context, svc, ctrl, wi.SpaceID.String(), wi.ID, p)
+	_, c := test.CreateWorkItemCommentsOK(rest.T(), svc.Context, svc, ctrl, wi.SpaceID, wi.ID, p)
 	// then
 	assertComment(rest.T(), c.Data, rest.testIdentity, "Test", markup)
 }
@@ -143,7 +143,7 @@ func (rest *TestCommentREST) TestSuccessCreateSingleCommentWithDefaultMarkup() {
 	// when
 	p := rest.newCreateWorkItemCommentsPayload("Test", nil)
 	svc, ctrl := rest.SecuredController()
-	_, c := test.CreateWorkItemCommentsOK(rest.T(), svc.Context, svc, ctrl, wi.SpaceID.String(), wi.ID, p)
+	_, c := test.CreateWorkItemCommentsOK(rest.T(), svc.Context, svc, ctrl, wi.SpaceID, wi.ID, p)
 	// then
 	assertComment(rest.T(), c.Data, rest.testIdentity, "Test", rendering.SystemMarkupDefault)
 }
@@ -177,7 +177,7 @@ func (rest *TestCommentREST) TestListCommentsByParentWorkItemOK() {
 	svc, ctrl := rest.UnSecuredController()
 	offset := "0"
 	limit := 3
-	res, cs := test.ListWorkItemCommentsOK(rest.T(), svc.Context, svc, ctrl, wi.SpaceID.String(), wi.ID, &limit, &offset, nil, nil)
+	res, cs := test.ListWorkItemCommentsOK(rest.T(), svc.Context, svc, ctrl, wi.SpaceID, wi.ID, &limit, &offset, nil, nil)
 	// then
 	assertComments(rest.T(), rest.testIdentity, cs)
 	assertResponseHeaders(rest.T(), res)
@@ -191,7 +191,7 @@ func (rest *TestCommentREST) TestListCommentsByParentWorkItemOKUsingExpiredIfMod
 	offset := "0"
 	limit := 3
 	ifModifiedSince := app.ToHTTPTime(comments[3].UpdatedAt.Add(-1 * time.Hour))
-	res, cs := test.ListWorkItemCommentsOK(rest.T(), svc.Context, svc, ctrl, wi.SpaceID.String(), wi.ID, &limit, &offset, &ifModifiedSince, nil)
+	res, cs := test.ListWorkItemCommentsOK(rest.T(), svc.Context, svc, ctrl, wi.SpaceID, wi.ID, &limit, &offset, &ifModifiedSince, nil)
 	// then
 	assertComments(rest.T(), rest.testIdentity, cs)
 	assertResponseHeaders(rest.T(), res)
@@ -205,7 +205,7 @@ func (rest *TestCommentREST) TestListCommentsByParentWorkItemOKUsingExpiredIfNon
 	offset := "0"
 	limit := 3
 	ifNoneMatch := "foo"
-	res, cs := test.ListWorkItemCommentsOK(rest.T(), svc.Context, svc, ctrl, wi.SpaceID.String(), wi.ID, &limit, &offset, nil, &ifNoneMatch)
+	res, cs := test.ListWorkItemCommentsOK(rest.T(), svc.Context, svc, ctrl, wi.SpaceID, wi.ID, &limit, &offset, nil, &ifNoneMatch)
 	// then
 	assertComments(rest.T(), rest.testIdentity, cs)
 	assertResponseHeaders(rest.T(), res)
@@ -219,7 +219,7 @@ func (rest *TestCommentREST) TestListCommentsByParentWorkItemNotModifiedUsingIfM
 	offset := "0"
 	limit := 3
 	ifModifiedSince := app.ToHTTPTime(comments[3].UpdatedAt)
-	res := test.ListWorkItemCommentsNotModified(rest.T(), svc.Context, svc, ctrl, wi.SpaceID.String(), wi.ID, &limit, &offset, &ifModifiedSince, nil)
+	res := test.ListWorkItemCommentsNotModified(rest.T(), svc.Context, svc, ctrl, wi.SpaceID, wi.ID, &limit, &offset, &ifModifiedSince, nil)
 	// then
 	assertResponseHeaders(rest.T(), res)
 }
@@ -236,7 +236,7 @@ func (rest *TestCommentREST) TestListCommentsByParentWorkItemNotModifiedUsingIfN
 		comments[1],
 		comments[0],
 	})
-	res := test.ListWorkItemCommentsNotModified(rest.T(), svc.Context, svc, ctrl, wi.SpaceID.String(), wi.ID, &limit, &offset, nil, &ifNoneMatch)
+	res := test.ListWorkItemCommentsNotModified(rest.T(), svc.Context, svc, ctrl, wi.SpaceID, wi.ID, &limit, &offset, nil, &ifNoneMatch)
 	// then
 	assertResponseHeaders(rest.T(), res)
 }
@@ -248,7 +248,7 @@ func (rest *TestCommentREST) TestEmptyListCommentsByParentWorkItem() {
 	svc, ctrl := rest.UnSecuredController()
 	offset := "0"
 	limit := 1
-	_, cs := test.ListWorkItemCommentsOK(rest.T(), svc.Context, svc, ctrl, wi.SpaceID.String(), wi.ID, &limit, &offset, nil, nil)
+	_, cs := test.ListWorkItemCommentsOK(rest.T(), svc.Context, svc, ctrl, wi.SpaceID, wi.ID, &limit, &offset, nil, nil)
 	// then
 	assert.Equal(rest.T(), 0, len(cs.Data))
 }
@@ -258,7 +258,7 @@ func (rest *TestCommentREST) TestCreateSingleCommentMissingWorkItem() {
 	p := rest.newCreateWorkItemCommentsPayload("Test", nil)
 	// when/then
 	svc, ctrl := rest.SecuredController()
-	test.CreateWorkItemCommentsNotFound(rest.T(), svc.Context, svc, ctrl, "0000000", "0000000", p)
+	test.CreateWorkItemCommentsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4(), "0000000", p)
 }
 
 func (rest *TestCommentREST) TestCreateSingleNoAuthorized() {
@@ -267,7 +267,7 @@ func (rest *TestCommentREST) TestCreateSingleNoAuthorized() {
 	// when/then
 	p := rest.newCreateWorkItemCommentsPayload("Test", nil)
 	svc, ctrl := rest.UnSecuredController()
-	test.CreateWorkItemCommentsUnauthorized(rest.T(), svc.Context, svc, ctrl, wi.SpaceID.String(), wi.ID, p)
+	test.CreateWorkItemCommentsUnauthorized(rest.T(), svc.Context, svc, ctrl, wi.SpaceID, wi.ID, p)
 }
 
 // Can not be tested via normal Goa testing framework as setting empty body on CreateCommentAttributes is
@@ -288,5 +288,5 @@ func (rest *TestCommentREST) TestListCommentsByMissingParentWorkItem() {
 	// when/then
 	offset := "0"
 	limit := 1
-	test.ListWorkItemCommentsNotFound(rest.T(), svc.Context, svc, ctrl, "0000000", "0000000", &limit, &offset, nil, nil)
+	test.ListWorkItemCommentsNotFound(rest.T(), svc.Context, svc, ctrl, uuid.NewV4(), "0000000", &limit, &offset, nil, nil)
 }

--- a/controller/work_item_link_blackbox_test.go
+++ b/controller/work_item_link_blackbox_test.go
@@ -137,35 +137,35 @@ func (s *workItemLinkSuite) SetupTest() {
 	s.T().Logf("Created link space with ID: %s\n", *space.Data.ID)
 
 	payload := CreateWorkItemType(uuid.NewV4(), *space.Data.ID)
-	_, wit := test.CreateWorkitemtypeCreated(s.T(), s.svc.Context, s.svc, s.typeCtrl, s.userSpaceID.String(), &payload)
+	_, wit := test.CreateWorkitemtypeCreated(s.T(), s.svc.Context, s.svc, s.typeCtrl, s.userSpaceID, &payload)
 
 	payload2 := CreateWorkItemType(uuid.NewV4(), *space.Data.ID)
-	_, wit2 := test.CreateWorkitemtypeCreated(s.T(), s.svc.Context, s.svc, s.typeCtrl, s.userSpaceID.String(), &payload2)
+	_, wit2 := test.CreateWorkitemtypeCreated(s.T(), s.svc.Context, s.svc, s.typeCtrl, s.userSpaceID, &payload2)
 
 	// Create 3 work items (bug1, bug2, and feature1)
 	bug1Payload := CreateWorkItem(s.userSpaceID, *wit.Data.ID, "bug1")
-	_, bug1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, bug1Payload.Data.Relationships.Space.Data.ID.String(), bug1Payload)
+	_, bug1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, *bug1Payload.Data.Relationships.Space.Data.ID, bug1Payload)
 	require.NotNil(s.T(), bug1)
 	s.bug1ID, err = strconv.ParseUint(*bug1.Data.ID, 10, 64)
 	require.Nil(s.T(), err)
 	s.T().Logf("Created bug1 with ID: %s\n", *bug1.Data.ID)
 
 	bug2Payload := CreateWorkItem(s.userSpaceID, *wit.Data.ID, "bug2")
-	_, bug2 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, bug2Payload.Data.Relationships.Space.Data.ID.String(), bug2Payload)
+	_, bug2 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, *bug2Payload.Data.Relationships.Space.Data.ID, bug2Payload)
 	require.NotNil(s.T(), bug2)
 	s.bug2ID, err = strconv.ParseUint(*bug2.Data.ID, 10, 64)
 	require.Nil(s.T(), err)
 	s.T().Logf("Created bug2 with ID: %s\n", *bug2.Data.ID)
 
 	bug3Payload := CreateWorkItem(s.userSpaceID, *wit.Data.ID, "bug3")
-	_, bug3 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, bug3Payload.Data.Relationships.Space.Data.ID.String(), bug3Payload)
+	_, bug3 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, *bug3Payload.Data.Relationships.Space.Data.ID, bug3Payload)
 	require.NotNil(s.T(), bug3)
 	s.bug3ID, err = strconv.ParseUint(*bug3.Data.ID, 10, 64)
 	require.Nil(s.T(), err)
 	s.T().Logf("Created bug3 with ID: %s\n", *bug3.Data.ID)
 
 	feature1Payload := CreateWorkItem(s.userSpaceID, *wit2.Data.ID, "feature1")
-	_, feature1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, feature1Payload.Data.Relationships.Space.Data.ID.String(), feature1Payload)
+	_, feature1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.workItemCtrl, *feature1Payload.Data.Relationships.Space.Data.ID, feature1Payload)
 	require.NotNil(s.T(), feature1)
 	s.feature1ID, err = strconv.ParseUint(*feature1.Data.ID, 10, 64)
 	require.Nil(s.T(), err)
@@ -181,7 +181,7 @@ func (s *workItemLinkSuite) SetupTest() {
 
 	// Create work item link type payload
 	createLinkTypePayload := CreateWorkItemLinkType("test-bug-blocker", *wit.Data.ID, *wit.Data.ID, s.userLinkCategoryID, s.userSpaceID)
-	_, workItemLinkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.workItemLinkTypeCtrl, s.userSpaceID.String(), createLinkTypePayload)
+	_, workItemLinkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.workItemLinkTypeCtrl, s.userSpaceID, createLinkTypePayload)
 	require.NotNil(s.T(), workItemLinkType)
 	//s.deleteWorkItemLinkTypes = append(s.deleteWorkItemLinkTypes, *workItemLinkType.Data.ID)
 	s.bugBlockerLinkTypeID = *workItemLinkType.Data.ID
@@ -344,7 +344,7 @@ func (s *workItemLinkSuite) TestCreateAndDeleteWorkItemLinkBadRequestDueToUnique
 // Same for /api/workitems/:id/relationships/links
 func (s *workItemLinkSuite) TestCreateAndDeleteWorkItemRelationshipsLink() {
 	createPayload := CreateWorkItemLink(s.bug1ID, s.bug2ID, s.bugBlockerLinkTypeID)
-	_, workItemLink := test.CreateWorkItemRelationshipsLinksCreated(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.userSpaceID.String(), strconv.FormatUint(s.bug1ID, 10), createPayload)
+	_, workItemLink := test.CreateWorkItemRelationshipsLinksCreated(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.userSpaceID, strconv.FormatUint(s.bug1ID, 10), createPayload)
 	require.NotNil(s.T(), workItemLink)
 }
 
@@ -356,7 +356,7 @@ func (s *workItemLinkSuite) TestCreateWorkItemLinkBadRequestDueToInvalidLinkType
 // Same for /api/workitems/:id/relationships/links
 func (s *workItemLinkSuite) TestCreateWorkItemRelationshipsLinksBadRequestDueToInvalidLinkTypeID() {
 	createPayload := CreateWorkItemLink(s.bug1ID, s.bug2ID, uuid.Nil)
-	_, _ = test.CreateWorkItemRelationshipsLinksBadRequest(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.userSpaceID.String(), strconv.FormatUint(s.bug1ID, 10), createPayload)
+	_, _ = test.CreateWorkItemRelationshipsLinksBadRequest(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.userSpaceID, strconv.FormatUint(s.bug1ID, 10), createPayload)
 }
 
 func (s *workItemLinkSuite) TestCreateWorkItemLinkBadRequestDueToNotFoundLinkType() {
@@ -367,7 +367,7 @@ func (s *workItemLinkSuite) TestCreateWorkItemLinkBadRequestDueToNotFoundLinkTyp
 // Same for /api/workitems/:id/relationships/links
 func (s *workItemLinkSuite) TestCreateWorkItemRelationshipLinksBadRequestDueToNotFoundLinkType() {
 	createPayload := CreateWorkItemLink(s.bug1ID, s.bug2ID, uuid.FromStringOrNil("11122233-871b-43a6-9166-0c4bd573e333"))
-	_, _ = test.CreateWorkItemRelationshipsLinksBadRequest(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.userSpaceID.String(), strconv.FormatUint(s.bug1ID, 10), createPayload)
+	_, _ = test.CreateWorkItemRelationshipsLinksBadRequest(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.userSpaceID, strconv.FormatUint(s.bug1ID, 10), createPayload)
 }
 
 func (s *workItemLinkSuite) TestCreateWorkItemLinkBadRequestDueToNotFoundSource() {
@@ -378,7 +378,7 @@ func (s *workItemLinkSuite) TestCreateWorkItemLinkBadRequestDueToNotFoundSource(
 // Same for /api/workitems/:id/relationships/links
 func (s *workItemLinkSuite) TestCreateWorkItemRelationshipsLinksBadRequestDueToNotFoundSource() {
 	createPayload := CreateWorkItemLink(666666, s.bug2ID, s.bugBlockerLinkTypeID)
-	_, _ = test.CreateWorkItemRelationshipsLinksBadRequest(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.userSpaceID.String(), strconv.FormatUint(s.bug2ID, 10), createPayload)
+	_, _ = test.CreateWorkItemRelationshipsLinksBadRequest(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.userSpaceID, strconv.FormatUint(s.bug2ID, 10), createPayload)
 }
 
 func (s *workItemLinkSuite) TestCreateWorkItemLinkBadRequestDueToNotFoundTarget() {
@@ -389,7 +389,7 @@ func (s *workItemLinkSuite) TestCreateWorkItemLinkBadRequestDueToNotFoundTarget(
 // Same for /api/workitems/:id/relationships/links
 func (s *workItemLinkSuite) TestCreateWorkItemRelationshipsLinksBadRequestDueToNotFoundTarget() {
 	createPayload := CreateWorkItemLink(s.bug1ID, 666666, s.bugBlockerLinkTypeID)
-	_, _ = test.CreateWorkItemRelationshipsLinksBadRequest(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.userSpaceID.String(), strconv.FormatUint(s.bug1ID, 10), createPayload)
+	_, _ = test.CreateWorkItemRelationshipsLinksBadRequest(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.userSpaceID, strconv.FormatUint(s.bug1ID, 10), createPayload)
 }
 
 func (s *workItemLinkSuite) TestCreateWorkItemLinkBadRequestDueToBadSourceType() {
@@ -404,7 +404,7 @@ func (s *workItemLinkSuite) TestCreateWorkItemRelationshipsLinksBadRequestDueToB
 	// Linking a bug and a feature isn't allowed for the bug blocker link type,
 	// thererfore this will cause a bad parameter error (which results in a bad request error).
 	createPayload := CreateWorkItemLink(s.feature1ID, s.bug1ID, s.bugBlockerLinkTypeID)
-	_, _ = test.CreateWorkItemRelationshipsLinksBadRequest(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.userSpaceID.String(), strconv.FormatUint(s.feature1ID, 10), createPayload)
+	_, _ = test.CreateWorkItemRelationshipsLinksBadRequest(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.userSpaceID, strconv.FormatUint(s.feature1ID, 10), createPayload)
 }
 
 func (s *workItemLinkSuite) TestCreateWorkItemLinkBadRequestDueToBadTargetType() {
@@ -419,7 +419,7 @@ func (s *workItemLinkSuite) TestCreateWorkItemRelationshipsLinksBadRequestDueToB
 	// Linking a bug and a feature isn't allowed for the bug blocker link type,
 	// thererfore this will cause a bad parameter error (which results in a bad request error).
 	createPayload := CreateWorkItemLink(s.bug1ID, s.feature1ID, s.bugBlockerLinkTypeID)
-	_, _ = test.CreateWorkItemRelationshipsLinksBadRequest(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.userSpaceID.String(), strconv.FormatUint(s.bug1ID, 10), createPayload)
+	_, _ = test.CreateWorkItemRelationshipsLinksBadRequest(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.userSpaceID, strconv.FormatUint(s.bug1ID, 10), createPayload)
 }
 
 func (s *workItemLinkSuite) TestDeleteWorkItemLinkNotFound() {
@@ -691,19 +691,19 @@ func (s *workItemLinkSuite) TestListWorkItemLinkNotModifiedUsingIfNoneMatchHeade
 func (s *workItemLinkSuite) TestListWorkItemRelationshipsLinksOK() {
 	link1, link2 := s.createSomeLinks()
 	filterByWorkItemID := strconv.FormatUint(s.bug2ID, 10)
-	_, linkCollection := test.ListWorkItemRelationshipsLinksOK(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.userSpaceID.String(), filterByWorkItemID, nil, nil)
+	_, linkCollection := test.ListWorkItemRelationshipsLinksOK(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.userSpaceID, filterByWorkItemID, nil, nil)
 	s.validateSomeLinks(linkCollection, link1, link2)
 }
 
 func (s *workItemLinkSuite) TestListWorkItemRelationshipsLinksNotFound() {
 	filterByWorkItemID := strconv.FormatUint(math.MaxUint32, 10) // not existing bug ID
-	spaceRandomID := strconv.FormatUint(math.MaxUint32, 10)      // not existing space ID
+	spaceRandomID := uuid.NewV4()                                // non-existing space ID
 	_, _ = test.ListWorkItemRelationshipsLinksNotFound(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, spaceRandomID, filterByWorkItemID, nil, nil)
 }
 
 func (s *workItemLinkSuite) TestListWorkItemRelationshipsLinksNotFoundDueToInvalidID() {
 	filterByWorkItemID := "invalid uint64"
-	_, _ = test.ListWorkItemRelationshipsLinksNotFound(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.userSpaceID.String(), filterByWorkItemID, nil, nil)
+	_, _ = test.ListWorkItemRelationshipsLinksNotFound(s.T(), s.svc.Context, s.svc, s.workItemRelsLinksCtrl, s.userSpaceID, filterByWorkItemID, nil, nil)
 }
 
 func (s *workItemLinkSuite) getWorkItemLinkTestDataFunc() func(t *testing.T) []testSecureAPI {

--- a/controller/work_item_link_type.go
+++ b/controller/work_item_link_type.go
@@ -122,10 +122,6 @@ func enrichLinkTypeList(ctx *workItemLinkContext, list *app.WorkItemLinkTypeList
 
 // Create runs the create action.
 func (c *WorkItemLinkTypeController) Create(ctx *app.CreateWorkItemLinkTypeContext) error {
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewNotFoundError("spaceID", ctx.ID))
-	}
 	// WorkItemLinkTypeController_Create: start_implement
 	// Convert payload from app to model representation
 	appLinkType := app.WorkItemLinkTypeSingle{
@@ -134,14 +130,14 @@ func (c *WorkItemLinkTypeController) Create(ctx *app.CreateWorkItemLinkTypeConte
 	// Set the space to the Payload
 	if ctx.Payload.Data != nil && ctx.Payload.Data.Relationships != nil {
 		// We overwrite or use the space ID in the URL to set the space of this WI
-		spaceSelfURL := rest.AbsoluteURL(ctx.RequestData, app.SpaceHref(spaceID.String()))
-		ctx.Payload.Data.Relationships.Space = app.NewSpaceRelation(spaceID, spaceSelfURL)
+		spaceSelfURL := rest.AbsoluteURL(ctx.RequestData, app.SpaceHref(ctx.SpaceID.String()))
+		ctx.Payload.Data.Relationships.Space = app.NewSpaceRelation(ctx.SpaceID, spaceSelfURL)
 	}
 	modelLinkType, err := ConvertWorkItemLinkTypeToModel(appLinkType)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, goa.ErrBadRequest(err.Error()))
 	}
-	modelLinkType.SpaceID = spaceID
+	modelLinkType.SpaceID = ctx.SpaceID
 	currentUserIdentityID, err := login.ContextIdentity(ctx)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
@@ -169,13 +165,9 @@ func (c *WorkItemLinkTypeController) Create(ctx *app.CreateWorkItemLinkTypeConte
 
 // Delete runs the delete action.
 func (c *WorkItemLinkTypeController) Delete(ctx *app.DeleteWorkItemLinkTypeContext) error {
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewNotFoundError("spaceID", ctx.ID))
-	}
 	// WorkItemLinkTypeController_Delete: start_implement
 	return application.Transactional(c.db, func(appl application.Application) error {
-		err := appl.WorkItemLinkTypes().Delete(ctx.Context, spaceID, ctx.WiltID)
+		err := appl.WorkItemLinkTypes().Delete(ctx.Context, ctx.SpaceID, ctx.WiltID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
@@ -186,12 +178,8 @@ func (c *WorkItemLinkTypeController) Delete(ctx *app.DeleteWorkItemLinkTypeConte
 
 // List runs the list action.
 func (c *WorkItemLinkTypeController) List(ctx *app.ListWorkItemLinkTypeContext) error {
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewNotFoundError("spaceID", ctx.ID))
-	}
 	return application.Transactional(c.db, func(appl application.Application) error {
-		modelLinkTypes, err := appl.WorkItemLinkTypes().List(ctx.Context, spaceID)
+		modelLinkTypes, err := appl.WorkItemLinkTypes().List(ctx.Context, ctx.SpaceID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
@@ -210,7 +198,7 @@ func (c *WorkItemLinkTypeController) List(ctx *app.ListWorkItemLinkTypeContext) 
 			}
 			// Enrich
 			hrefFunc := func(obj interface{}) string {
-				return fmt.Sprintf(app.WorkItemLinkTypeHref(spaceID, "%v"), obj)
+				return fmt.Sprintf(app.WorkItemLinkTypeHref(ctx.SpaceID, "%v"), obj)
 			}
 			linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, hrefFunc, nil)
 			err = enrichLinkTypeList(linkCtx, &appLinkTypes)
@@ -224,18 +212,9 @@ func (c *WorkItemLinkTypeController) List(ctx *app.ListWorkItemLinkTypeContext) 
 
 // Show runs the show action.
 func (c *WorkItemLinkTypeController) Show(ctx *app.ShowWorkItemLinkTypeContext) error {
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewNotFoundError("spaceID", ctx.ID))
-	}
 	// WorkItemLinkTypeController_Show: start_implement
 	return application.Transactional(c.db, func(appl application.Application) error {
-		wiltID, err := uuid.FromString(ctx.WiltID)
-		if err != nil {
-			return jsonapi.JSONErrorResponse(ctx, errors.NewNotFoundError("work item link type ID", ctx.WiltID))
-		}
-
-		modelLinkType, err := appl.WorkItemLinkTypes().Load(ctx.Context, wiltID)
+		modelLinkType, err := appl.WorkItemLinkTypes().Load(ctx.Context, ctx.WiltID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
@@ -245,7 +224,7 @@ func (c *WorkItemLinkTypeController) Show(ctx *app.ShowWorkItemLinkTypeContext) 
 
 			// Enrich
 			hrefFunc := func(obj interface{}) string {
-				return fmt.Sprintf(app.WorkItemLinkTypeHref(spaceID, "%v"), obj)
+				return fmt.Sprintf(app.WorkItemLinkTypeHref(ctx.SpaceID, "%v"), obj)
 			}
 			linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, hrefFunc, nil)
 			err = enrichLinkTypeSingle(linkCtx, &appLinkType)
@@ -260,10 +239,6 @@ func (c *WorkItemLinkTypeController) Show(ctx *app.ShowWorkItemLinkTypeContext) 
 
 // Update runs the update action.
 func (c *WorkItemLinkTypeController) Update(ctx *app.UpdateWorkItemLinkTypeContext) error {
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewNotFoundError("spaceID", ctx.ID))
-	}
 	currentUserIdentityID, err := login.ContextIdentity(ctx)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
@@ -288,7 +263,7 @@ func (c *WorkItemLinkTypeController) Update(ctx *app.UpdateWorkItemLinkTypeConte
 
 		// Enrich
 		hrefFunc := func(obj interface{}) string {
-			return fmt.Sprintf(app.WorkItemLinkTypeHref(spaceID, "%v"), obj)
+			return fmt.Sprintf(app.WorkItemLinkTypeHref(ctx.SpaceID, "%v"), obj)
 		}
 		linkTypeCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, hrefFunc, currentUserIdentityID)
 		err = enrichLinkTypeSingle(linkTypeCtx, &appLinkType)

--- a/controller/work_item_link_type_blackbox_test.go
+++ b/controller/work_item_link_type_blackbox_test.go
@@ -140,7 +140,7 @@ func (s *workItemLinkTypeSuite) createDemoLinkType(name string) *app.CreateWorkI
 
 	//	 2. Create at least one work item type
 	workItemTypePayload := CreateWorkItemType(uuid.NewV4(), *space.Data.ID)
-	_, workItemType := test.CreateWorkitemtypeCreated(s.T(), s.svc.Context, s.svc, s.typeCtrl, s.spaceID.String(), &workItemTypePayload)
+	_, workItemType := test.CreateWorkitemtypeCreated(s.T(), s.svc.Context, s.svc, s.typeCtrl, *s.spaceID, &workItemTypePayload)
 	require.NotNil(s.T(), workItemType)
 
 	//   3. Create a work item link category
@@ -173,7 +173,7 @@ func TestNewWorkItemLinkTypeControllerDBNull(t *testing.T) {
 // TestCreateWorkItemLinkType tests if we can create the s.linkTypeName work item link type
 func (s *workItemLinkTypeSuite) TestCreateAndDeleteWorkItemLinkType() {
 	createPayload := s.createDemoLinkType(s.linkTypeName)
-	_, workItemLinkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, createPayload.Data.Relationships.Space.Data.ID.String(), createPayload)
+	_, workItemLinkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, *createPayload.Data.Relationships.Space.Data.ID, createPayload)
 	require.NotNil(s.T(), workItemLinkType)
 
 	// Check that the link category is included in the response in the "included" array
@@ -187,7 +187,7 @@ func (s *workItemLinkTypeSuite) TestCreateAndDeleteWorkItemLinkType() {
 	require.True(s.T(), ok)
 	require.Equal(s.T(), s.spaceName, *spaceData.Attributes.Name, "The work item link type's space should have the name 'test-space'.")
 
-	_ = test.DeleteWorkItemLinkTypeOK(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, workItemLinkType.Data.Relationships.Space.Data.ID.String(), *workItemLinkType.Data.ID)
+	_ = test.DeleteWorkItemLinkTypeOK(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, *workItemLinkType.Data.Relationships.Space.Data.ID, *workItemLinkType.Data.ID)
 }
 
 //func (s *workItemLinkTypeSuite) TestCreateWorkItemLinkTypeBadRequest() {
@@ -210,7 +210,7 @@ func (s *workItemLinkTypeSuite) TestCreateAndDeleteWorkItemLinkType() {
 //}
 
 func (s *workItemLinkTypeSuite) TestDeleteWorkItemLinkTypeNotFound() {
-	test.DeleteWorkItemLinkTypeNotFound(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, space.SystemSpace.String(), uuid.FromStringOrNil("1e9a8b53-73a6-40de-b028-5177add79ffa"))
+	test.DeleteWorkItemLinkTypeNotFound(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, space.SystemSpace, uuid.FromStringOrNil("1e9a8b53-73a6-40de-b028-5177add79ffa"))
 }
 
 func (s *workItemLinkTypeSuite) TestUpdateWorkItemLinkTypeNotFound() {
@@ -221,7 +221,7 @@ func (s *workItemLinkTypeSuite) TestUpdateWorkItemLinkTypeNotFound() {
 	updateLinkTypePayload := &app.UpdateWorkItemLinkTypePayload{
 		Data: createPayload.Data,
 	}
-	test.UpdateWorkItemLinkTypeNotFound(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, updateLinkTypePayload.Data.Relationships.Space.Data.ID.String(), *updateLinkTypePayload.Data.ID, updateLinkTypePayload)
+	test.UpdateWorkItemLinkTypeNotFound(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, *updateLinkTypePayload.Data.Relationships.Space.Data.ID, *updateLinkTypePayload.Data.ID, updateLinkTypePayload)
 }
 
 // func (s *workItemLinkTypeSuite) TestUpdateWorkItemLinkTypeBadRequestDueToBadID() {
@@ -237,7 +237,7 @@ func (s *workItemLinkTypeSuite) TestUpdateWorkItemLinkTypeNotFound() {
 
 func (s *workItemLinkTypeSuite) TestUpdateWorkItemLinkTypeOK() {
 	createPayload := s.createDemoLinkType(s.linkTypeName)
-	_, workItemLinkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, createPayload.Data.Relationships.Space.Data.ID.String(), createPayload)
+	_, workItemLinkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, *createPayload.Data.Relationships.Space.Data.ID, createPayload)
 	require.NotNil(s.T(), workItemLinkType)
 	// Specify new description for link type that we just created
 	// Wrap data portion in an update payload instead of a create payload
@@ -246,7 +246,7 @@ func (s *workItemLinkTypeSuite) TestUpdateWorkItemLinkTypeOK() {
 	}
 	newDescription := "Lalala this is a new description for the work item type"
 	updateLinkTypePayload.Data.Attributes.Description = &newDescription
-	_, lt := test.UpdateWorkItemLinkTypeOK(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, updateLinkTypePayload.Data.Relationships.Space.Data.ID.String(), *updateLinkTypePayload.Data.ID, updateLinkTypePayload)
+	_, lt := test.UpdateWorkItemLinkTypeOK(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, *updateLinkTypePayload.Data.Relationships.Space.Data.ID, *updateLinkTypePayload.Data.ID, updateLinkTypePayload)
 	require.NotNil(s.T(), lt.Data)
 	require.NotNil(s.T(), lt.Data.Attributes)
 	require.NotNil(s.T(), lt.Data.Attributes.Description)
@@ -274,7 +274,7 @@ func (s *workItemLinkTypeSuite) TestUpdateWorkItemLinkTypeOK() {
 
 func (s *workItemLinkTypeSuite) createWorkItemLinkType() *app.WorkItemLinkTypeSingle {
 	createPayload := s.createDemoLinkType(s.linkTypeName)
-	_, workItemLinkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, createPayload.Data.Relationships.Space.Data.ID.String(), createPayload)
+	_, workItemLinkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, *createPayload.Data.Relationships.Space.Data.ID, createPayload)
 	require.NotNil(s.T(), workItemLinkType)
 	return workItemLinkType
 }
@@ -306,7 +306,7 @@ func (s *workItemLinkTypeSuite) TestShowWorkItemLinkTypeOK() {
 	// given
 	createdWorkItemLinkType := s.createWorkItemLinkType()
 	// when
-	res, readWorkItemLinkType := test.ShowWorkItemLinkTypeOK(s.T(), nil, nil, s.linkTypeCtrl, createdWorkItemLinkType.Data.Relationships.Space.Data.ID.String(), createdWorkItemLinkType.Data.ID.String(), nil, nil)
+	res, readWorkItemLinkType := test.ShowWorkItemLinkTypeOK(s.T(), nil, nil, s.linkTypeCtrl, *createdWorkItemLinkType.Data.Relationships.Space.Data.ID, *createdWorkItemLinkType.Data.ID, nil, nil)
 	// then
 	assertWorkItemLinkType(s.T(), createdWorkItemLinkType, s.spaceName, s.categoryName, readWorkItemLinkType)
 	assertResponseHeaders(s.T(), res)
@@ -317,7 +317,7 @@ func (s *workItemLinkTypeSuite) TestShowWorkItemLinkTypeOKUsingExpiredIfModified
 	createdWorkItemLinkType := s.createWorkItemLinkType()
 	// when
 	ifModifiedSinceHeader := app.ToHTTPTime(createdWorkItemLinkType.Data.Attributes.UpdatedAt.Add(-1 * time.Hour))
-	res, readWorkItemLinkType := test.ShowWorkItemLinkTypeOK(s.T(), nil, nil, s.linkTypeCtrl, createdWorkItemLinkType.Data.Relationships.Space.Data.ID.String(), createdWorkItemLinkType.Data.ID.String(), &ifModifiedSinceHeader, nil)
+	res, readWorkItemLinkType := test.ShowWorkItemLinkTypeOK(s.T(), nil, nil, s.linkTypeCtrl, *createdWorkItemLinkType.Data.Relationships.Space.Data.ID, *createdWorkItemLinkType.Data.ID, &ifModifiedSinceHeader, nil)
 	// then
 	assertWorkItemLinkType(s.T(), createdWorkItemLinkType, s.spaceName, s.categoryName, readWorkItemLinkType)
 	assertResponseHeaders(s.T(), res)
@@ -328,7 +328,7 @@ func (s *workItemLinkTypeSuite) TestShowWorkItemLinkTypeOKUsingExpiredIfNoneMatc
 	createdWorkItemLinkType := s.createWorkItemLinkType()
 	// when
 	ifNoneMatch := "foo"
-	res, readWorkItemLinkType := test.ShowWorkItemLinkTypeOK(s.T(), nil, nil, s.linkTypeCtrl, createdWorkItemLinkType.Data.Relationships.Space.Data.ID.String(), createdWorkItemLinkType.Data.ID.String(), nil, &ifNoneMatch)
+	res, readWorkItemLinkType := test.ShowWorkItemLinkTypeOK(s.T(), nil, nil, s.linkTypeCtrl, *createdWorkItemLinkType.Data.Relationships.Space.Data.ID, *createdWorkItemLinkType.Data.ID, nil, &ifNoneMatch)
 	// then
 	assertWorkItemLinkType(s.T(), createdWorkItemLinkType, s.spaceName, s.categoryName, readWorkItemLinkType)
 	assertResponseHeaders(s.T(), res)
@@ -338,7 +338,7 @@ func (s *workItemLinkTypeSuite) TestShowWorkItemLinkTypeNotModifiedUsingIfModifi
 	createdWorkItemLinkType := s.createWorkItemLinkType()
 	// when
 	ifModifiedSinceHeader := app.ToHTTPTime(*createdWorkItemLinkType.Data.Attributes.UpdatedAt)
-	res := test.ShowWorkItemLinkTypeNotModified(s.T(), nil, nil, s.linkTypeCtrl, createdWorkItemLinkType.Data.Relationships.Space.Data.ID.String(), createdWorkItemLinkType.Data.ID.String(), &ifModifiedSinceHeader, nil)
+	res := test.ShowWorkItemLinkTypeNotModified(s.T(), nil, nil, s.linkTypeCtrl, *createdWorkItemLinkType.Data.Relationships.Space.Data.ID, *createdWorkItemLinkType.Data.ID, &ifModifiedSinceHeader, nil)
 	// then
 	assertResponseHeaders(s.T(), res)
 }
@@ -350,26 +350,26 @@ func (s *workItemLinkTypeSuite) TestShowWorkItemLinkTypeNotModifiedUsingIfNoneMa
 	createdWorkItemLinkTypeModel, err := ConvertWorkItemLinkTypeToModel(*createdWorkItemLinkType)
 	require.Nil(s.T(), err)
 	ifNoneMatch := app.GenerateEntityTag(createdWorkItemLinkTypeModel)
-	res := test.ShowWorkItemLinkTypeNotModified(s.T(), nil, nil, s.linkTypeCtrl, createdWorkItemLinkType.Data.Relationships.Space.Data.ID.String(), createdWorkItemLinkType.Data.ID.String(), nil, &ifNoneMatch)
+	res := test.ShowWorkItemLinkTypeNotModified(s.T(), nil, nil, s.linkTypeCtrl, *createdWorkItemLinkType.Data.Relationships.Space.Data.ID, *createdWorkItemLinkType.Data.ID, nil, &ifNoneMatch)
 	// then
 	assertResponseHeaders(s.T(), res)
 }
 
 // TestShowWorkItemLinkTypeNotFound tests if we can fetch a non existing work item link type
 func (s *workItemLinkTypeSuite) TestShowWorkItemLinkTypeNotFound() {
-	test.ShowWorkItemLinkTypeNotFound(s.T(), nil, nil, s.linkTypeCtrl, space.SystemSpace.String(), "88727441-4a21-4b35-aabe-007f8273cd19", nil, nil)
+	test.ShowWorkItemLinkTypeNotFound(s.T(), nil, nil, s.linkTypeCtrl, space.SystemSpace, uuid.NewV4(), nil, nil)
 }
 func (s *workItemLinkTypeSuite) createWorkItemLinkTypes() (*app.WorkItemTypeSingle, *app.WorkItemLinkTypeSingle) {
 	bugBlockerPayload := s.createDemoLinkType(s.linkTypeName)
-	_, bugBlockerType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, bugBlockerPayload.Data.Relationships.Space.Data.ID.String(), bugBlockerPayload)
+	_, bugBlockerType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, *bugBlockerPayload.Data.Relationships.Space.Data.ID, bugBlockerPayload)
 	require.NotNil(s.T(), bugBlockerType)
 
 	workItemTypePayload := CreateWorkItemType(uuid.NewV4(), *s.spaceID)
-	_, workItemType := test.CreateWorkitemtypeCreated(s.T(), s.svc.Context, s.svc, s.typeCtrl, bugBlockerPayload.Data.Relationships.Space.Data.ID.String(), &workItemTypePayload)
+	_, workItemType := test.CreateWorkitemtypeCreated(s.T(), s.svc.Context, s.svc, s.typeCtrl, *bugBlockerPayload.Data.Relationships.Space.Data.ID, &workItemTypePayload)
 	require.NotNil(s.T(), workItemType)
 
 	relatedPayload := CreateWorkItemLinkType(s.linkName, *workItemType.Data.ID, *workItemType.Data.ID, bugBlockerType.Data.Relationships.LinkCategory.Data.ID, *bugBlockerType.Data.Relationships.Space.Data.ID)
-	_, relatedType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, relatedPayload.Data.Relationships.Space.Data.ID.String(), relatedPayload)
+	_, relatedType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, *relatedPayload.Data.Relationships.Space.Data.ID, relatedPayload)
 	require.NotNil(s.T(), relatedType)
 	return workItemType, relatedType
 
@@ -409,7 +409,7 @@ func (s *workItemLinkTypeSuite) TestListWorkItemLinkTypeOK() {
 	// given
 	_, createdWorkItemLinkType := s.createWorkItemLinkTypes()
 	// when fetching all work item link type in a give space
-	res, linkTypes := test.ListWorkItemLinkTypeOK(s.T(), nil, nil, s.linkTypeCtrl, createdWorkItemLinkType.Data.Relationships.Space.Data.ID.String(), nil, nil)
+	res, linkTypes := test.ListWorkItemLinkTypeOK(s.T(), nil, nil, s.linkTypeCtrl, *createdWorkItemLinkType.Data.Relationships.Space.Data.ID, nil, nil)
 	// then
 	assertWorkItemLinkTypes(s.T(), s.spaceName, s.categoryName, s.linkTypeName, s.linkName, linkTypes)
 	assertResponseHeaders(s.T(), res)
@@ -420,7 +420,7 @@ func (s *workItemLinkTypeSuite) TestListWorkItemLinkTypeOKUsingExpiredIfModified
 	_, createdWorkItemLinkType := s.createWorkItemLinkTypes()
 	// when fetching all work item link type in a give space
 	ifModifiedSinceHeader := app.ToHTTPTime(createdWorkItemLinkType.Data.Attributes.UpdatedAt.Add(-1 * time.Hour))
-	res, linkTypes := test.ListWorkItemLinkTypeOK(s.T(), nil, nil, s.linkTypeCtrl, createdWorkItemLinkType.Data.Relationships.Space.Data.ID.String(), &ifModifiedSinceHeader, nil)
+	res, linkTypes := test.ListWorkItemLinkTypeOK(s.T(), nil, nil, s.linkTypeCtrl, *createdWorkItemLinkType.Data.Relationships.Space.Data.ID, &ifModifiedSinceHeader, nil)
 	// then
 	assertWorkItemLinkTypes(s.T(), s.spaceName, s.categoryName, s.linkTypeName, s.linkName, linkTypes)
 	assertResponseHeaders(s.T(), res)
@@ -431,7 +431,7 @@ func (s *workItemLinkTypeSuite) TestListWorkItemLinkTypeOKUsingExpiredIfNoneMatc
 	_, createdWorkItemLinkType := s.createWorkItemLinkTypes()
 	// when fetching all work item link type in a give space
 	ifNoneMatch := "foo"
-	res, linkTypes := test.ListWorkItemLinkTypeOK(s.T(), nil, nil, s.linkTypeCtrl, createdWorkItemLinkType.Data.Relationships.Space.Data.ID.String(), nil, &ifNoneMatch)
+	res, linkTypes := test.ListWorkItemLinkTypeOK(s.T(), nil, nil, s.linkTypeCtrl, *createdWorkItemLinkType.Data.Relationships.Space.Data.ID, nil, &ifNoneMatch)
 	// then
 	assertWorkItemLinkTypes(s.T(), s.spaceName, s.categoryName, s.linkTypeName, s.linkName, linkTypes)
 	assertResponseHeaders(s.T(), res)
@@ -442,7 +442,7 @@ func (s *workItemLinkTypeSuite) TestListWorkItemLinkTypeNotModifiedUsingIfModifi
 	_, workItemLinkType := s.createWorkItemLinkTypes()
 	// when fetching all work item link type in a give space
 	ifModifiedSinceHeader := app.ToHTTPTime(*workItemLinkType.Data.Attributes.UpdatedAt)
-	res := test.ListWorkItemLinkTypeNotModified(s.T(), nil, nil, s.linkTypeCtrl, workItemLinkType.Data.Relationships.Space.Data.ID.String(), &ifModifiedSinceHeader, nil)
+	res := test.ListWorkItemLinkTypeNotModified(s.T(), nil, nil, s.linkTypeCtrl, *workItemLinkType.Data.Relationships.Space.Data.ID, &ifModifiedSinceHeader, nil)
 	// then
 	assertResponseHeaders(s.T(), res)
 }
@@ -450,7 +450,7 @@ func (s *workItemLinkTypeSuite) TestListWorkItemLinkTypeNotModifiedUsingIfModifi
 func (s *workItemLinkTypeSuite) TestListWorkItemLinkTypeNotModifiedUsingIfNoneMatchHeader() {
 	// given
 	_, createdWorkItemLinkType := s.createWorkItemLinkTypes()
-	_, existingLinkTypes := test.ListWorkItemLinkTypeOK(s.T(), nil, nil, s.linkTypeCtrl, createdWorkItemLinkType.Data.Relationships.Space.Data.ID.String(), nil, nil)
+	_, existingLinkTypes := test.ListWorkItemLinkTypeOK(s.T(), nil, nil, s.linkTypeCtrl, *createdWorkItemLinkType.Data.Relationships.Space.Data.ID, nil, nil)
 	// when fetching all work item link type in a give space
 	createdWorkItemLinkTypeModels := make([]app.ConditionalResponseEntity, len(existingLinkTypes.Data))
 	for i, linkTypeData := range existingLinkTypes.Data {
@@ -463,7 +463,7 @@ func (s *workItemLinkTypeSuite) TestListWorkItemLinkTypeNotModifiedUsingIfNoneMa
 		createdWorkItemLinkTypeModels[i] = *createdWorkItemLinkTypeModel
 	}
 	ifNoneMatch := app.GenerateEntitiesTag(createdWorkItemLinkTypeModels)
-	res := test.ListWorkItemLinkTypeNotModified(s.T(), nil, nil, s.linkTypeCtrl, createdWorkItemLinkType.Data.Relationships.Space.Data.ID.String(), nil, &ifNoneMatch)
+	res := test.ListWorkItemLinkTypeNotModified(s.T(), nil, nil, s.linkTypeCtrl, *createdWorkItemLinkType.Data.Relationships.Space.Data.ID, nil, &ifNoneMatch)
 	// then
 	assertResponseHeaders(s.T(), res)
 }

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -62,11 +62,6 @@ func NewWorkitemController(service *goa.Service, db application.DB, config WorkI
 // Prev and Next links will be present only when there actually IS a next or previous page.
 // Last will always be present. Total Item count needs to be computed from the "Last" link.
 func (c *WorkitemController) List(ctx *app.ListWorkitemContext) error {
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return errors.NewNotFoundError("spaceID", ctx.ID)
-	}
-
 	var additionalQuery []string
 	exp, err := query.Parse(ctx.Filter)
 	if err != nil {
@@ -118,7 +113,7 @@ func (c *WorkitemController) List(ctx *app.ListWorkitemContext) error {
 
 	offset, limit := computePagingLimits(ctx.PageOffset, ctx.PageLimit)
 	return application.Transactional(c.db, func(tx application.Application) error {
-		workitems, tc, err := tx.WorkItems().List(ctx.Context, spaceID, exp, ctx.FilterParentexists, &offset, &limit)
+		workitems, tc, err := tx.WorkItems().List(ctx.Context, ctx.SpaceID, exp, ctx.FilterParentexists, &offset, &limit)
 		count := int(tc)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "Error listing work items"))
@@ -155,10 +150,6 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 	if ctx.Payload == nil || ctx.Payload.Data == nil || ctx.Payload.Data.ID == nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("missing data.ID element in request", nil))
 	}
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return errors.NewNotFoundError("spaceID", ctx.ID)
-	}
 	currentUserIdentityID, err := login.ContextIdentity(ctx)
 	if err != nil {
 		jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
@@ -166,7 +157,7 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 
 	var wi *workitem.WorkItem
 	err = application.Transactional(c.db, func(appl application.Application) error {
-		wi, err = appl.WorkItems().Load(ctx, spaceID, *ctx.Payload.Data.ID)
+		wi, err = appl.WorkItems().Load(ctx, ctx.SpaceID, *ctx.Payload.Data.ID)
 		if err != nil {
 			return errs.Wrap(err, fmt.Sprintf("Failed to load work item with id %v", *ctx.Payload.Data.ID))
 		}
@@ -179,7 +170,7 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 	if creator == nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("work item doesn't have creator"))
 	}
-	authorized, err := authorizeWorkitemEditor(ctx, c.db, spaceID, creator.(string), currentUserIdentityID.String())
+	authorized, err := authorizeWorkitemEditor(ctx, c.db, ctx.SpaceID, creator.(string), currentUserIdentityID.String())
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, err)
 	}
@@ -190,12 +181,12 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 		// Type changes of WI are not allowed which is why we overwrite it the
 		// type with the old one after the WI has been converted.
 		oldType := wi.Type
-		err = ConvertJSONAPIToWorkItem(appl, *ctx.Payload.Data, wi, spaceID)
+		err = ConvertJSONAPIToWorkItem(appl, *ctx.Payload.Data, wi, ctx.SpaceID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
 		wi.Type = oldType
-		wi, err = appl.WorkItems().Save(ctx, spaceID, *wi, *currentUserIdentityID)
+		wi, err = appl.WorkItems().Save(ctx, ctx.SpaceID, *wi, *currentUserIdentityID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "Error updating work item"))
 		}
@@ -215,16 +206,11 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 
 // Reorder does PATCH workitem
 func (c *WorkitemController) Reorder(ctx *app.ReorderWorkitemContext) error {
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return errors.NewNotFoundError("spaceID", ctx.ID)
-	}
-
 	currentUserIdentityID, err := login.ContextIdentity(ctx)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
-	authorized, err := authz.Authorize(ctx, ctx.ID)
+	authorized, err := authz.Authorize(ctx, ctx.SpaceID.String())
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
@@ -239,12 +225,12 @@ func (c *WorkitemController) Reorder(ctx *app.ReorderWorkitemContext) error {
 
 		// Reorder workitems in the array one by one
 		for i := 0; i < len(ctx.Payload.Data); i++ {
-			wi, err := appl.WorkItems().Load(ctx, spaceID, *ctx.Payload.Data[i].ID)
+			wi, err := appl.WorkItems().Load(ctx, ctx.SpaceID, *ctx.Payload.Data[i].ID)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "failed to reorder work item"))
 			}
 
-			err = ConvertJSONAPIToWorkItem(appl, *ctx.Payload.Data[i], wi, spaceID)
+			err = ConvertJSONAPIToWorkItem(appl, *ctx.Payload.Data[i], wi, ctx.SpaceID)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "failed to reorder work item"))
 			}
@@ -266,11 +252,6 @@ func (c *WorkitemController) Reorder(ctx *app.ReorderWorkitemContext) error {
 
 // Create does POST workitem
 func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return errors.NewNotFoundError("spaceID", ctx.ID)
-	}
-
 	currentUserIdentityID, err := login.ContextIdentity(ctx)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
@@ -287,8 +268,8 @@ func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
 	// Set the space to the Payload
 	if ctx.Payload.Data != nil && ctx.Payload.Data.Relationships != nil {
 		// We overwrite or use the space ID in the URL to set the space of this WI
-		spaceSelfURL := rest.AbsoluteURL(goa.ContextRequest(ctx), app.SpaceHref(spaceID.String()))
-		ctx.Payload.Data.Relationships.Space = app.NewSpaceRelation(spaceID, spaceSelfURL)
+		spaceSelfURL := rest.AbsoluteURL(goa.ContextRequest(ctx), app.SpaceHref(ctx.SpaceID.String()))
+		ctx.Payload.Data.Relationships.Space = app.NewSpaceRelation(ctx.SpaceID, spaceSelfURL)
 	}
 	wi := workitem.WorkItem{
 		Fields: make(map[string]interface{}),
@@ -296,21 +277,21 @@ func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
 	return application.Transactional(c.db, func(appl application.Application) error {
 		//verify spaceID:
 		// To be removed once we have endpoint like - /api/space/{spaceID}/workitems
-		spaceInstance, spaceLoadErr := appl.Spaces().Load(ctx, spaceID)
+		spaceInstance, spaceLoadErr := appl.Spaces().Load(ctx, ctx.SpaceID)
 		if spaceLoadErr != nil {
 			return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError("space", "string").Expected("valid space ID"))
 		}
 
 		if _, ok := wi.Fields[workitem.SystemArea]; ok == false {
 			// no area assigned yet hence set root area
-			rootArea, err := appl.Areas().Root(ctx, spaceID)
+			rootArea, err := appl.Areas().Root(ctx, ctx.SpaceID)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error fetching root area")))
 			}
 			wi.Fields[workitem.SystemArea] = rootArea.ID.String()
 		}
 
-		err := ConvertJSONAPIToWorkItem(appl, *ctx.Payload.Data, &wi, spaceID)
+		err := ConvertJSONAPIToWorkItem(appl, *ctx.Payload.Data, &wi, ctx.SpaceID)
 		// fetch root iteration for this space and assign it to WI if not present already
 		if _, ok := wi.Fields[workitem.SystemIteration]; ok == false {
 			// no iteration set hence set to root iteration of its space
@@ -323,7 +304,7 @@ func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error creating work item")))
 		}
 
-		wi, err := appl.WorkItems().Create(ctx, spaceID, *wit, wi.Fields, *currentUserIdentityID)
+		wi, err := appl.WorkItems().Create(ctx, ctx.SpaceID, *wit, wi.Fields, *currentUserIdentityID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Error creating work item")))
 		}
@@ -343,15 +324,10 @@ func (c *WorkitemController) Create(ctx *app.CreateWorkitemContext) error {
 
 // Show does GET workitem
 func (c *WorkitemController) Show(ctx *app.ShowWorkitemContext) error {
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return errors.NewNotFoundError("spaceID", ctx.ID)
-	}
-
 	return application.Transactional(c.db, func(appl application.Application) error {
 		comments := workItemIncludeCommentsAndTotal(ctx, c.db, ctx.WiID)
 		hasChildren := workItemIncludeHasChildren(appl, ctx)
-		wi, err := appl.WorkItems().Load(ctx, spaceID, ctx.WiID)
+		wi, err := appl.WorkItems().Load(ctx, ctx.SpaceID, ctx.WiID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Fail to load work item with id %v", ctx.WiID)))
 		}
@@ -373,15 +349,11 @@ func (c *WorkitemController) Delete(ctx *app.DeleteWorkitemContext) error {
 	if true {
 		return ctx.MethodNotAllowed()
 	}
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return errors.NewNotFoundError("spaceID", ctx.ID)
-	}
 	currentUserIdentityID, err := login.ContextIdentity(ctx)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
-	authorized, err := authz.Authorize(ctx, ctx.ID)
+	authorized, err := authz.Authorize(ctx, ctx.SpaceID.String())
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(err.Error()))
 	}
@@ -389,7 +361,7 @@ func (c *WorkitemController) Delete(ctx *app.DeleteWorkitemContext) error {
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("user is not authorized to access the space"))
 	}
 	return application.Transactional(c.db, func(appl application.Application) error {
-		err := appl.WorkItems().Delete(ctx, spaceID, ctx.WiID, *currentUserIdentityID)
+		err := appl.WorkItems().Delete(ctx, ctx.SpaceID, ctx.WiID, *currentUserIdentityID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrapf(err, "error deleting work item %s", ctx.WiID))
 		}

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -392,28 +392,28 @@ func getWorkItemTestDataFunc(config configuration.ConfigurationData) func(t *tes
 			// Create Work Item API with different parameters
 			{
 				method:             http.MethodPost,
-				url:                fmt.Sprintf(endpointWorkItems, "1234"),
+				url:                fmt.Sprintf(endpointWorkItems, "5b5faa94-7478-4a35-9fdd-e1b5278df331"),
 				expectedStatusCode: http.StatusUnauthorized,
 				expectedErrorCode:  jsonapi.ErrorCodeJWTSecurityError,
 				payload:            createWIPayloadString,
 				jwtToken:           getExpiredAuthHeader(t, privatekey),
 			}, {
 				method:             http.MethodPost,
-				url:                fmt.Sprintf(endpointWorkItems, "1234"),
+				url:                fmt.Sprintf(endpointWorkItems, "5b5faa94-7478-4a35-9fdd-e1b5278df331"),
 				expectedStatusCode: http.StatusUnauthorized,
 				expectedErrorCode:  jsonapi.ErrorCodeJWTSecurityError,
 				payload:            createWIPayloadString,
 				jwtToken:           getMalformedAuthHeader(t, privatekey),
 			}, {
 				method:             http.MethodPost,
-				url:                fmt.Sprintf(endpointWorkItems, "1234"),
+				url:                fmt.Sprintf(endpointWorkItems, "5b5faa94-7478-4a35-9fdd-e1b5278df331"),
 				expectedStatusCode: http.StatusUnauthorized,
 				expectedErrorCode:  jsonapi.ErrorCodeJWTSecurityError,
 				payload:            createWIPayloadString,
 				jwtToken:           getValidAuthHeader(t, differentPrivatekey),
 			}, {
 				method:             http.MethodPost,
-				url:                fmt.Sprintf(endpointWorkItems, "1234"),
+				url:                fmt.Sprintf(endpointWorkItems, "5b5faa94-7478-4a35-9fdd-e1b5278df331"),
 				expectedStatusCode: http.StatusUnauthorized,
 				expectedErrorCode:  jsonapi.ErrorCodeJWTSecurityError,
 				payload:            createWIPayloadString,
@@ -422,28 +422,28 @@ func getWorkItemTestDataFunc(config configuration.ConfigurationData) func(t *tes
 			// Update Work Item API with different parameters
 			{
 				method:             http.MethodPatch,
-				url:                fmt.Sprintf(endpointWorkItems, "1234") + "/12345",
+				url:                fmt.Sprintf(endpointWorkItems, "5b5faa94-7478-4a35-9fdd-e1b5278df331") + "/12345",
 				expectedStatusCode: http.StatusUnauthorized,
 				expectedErrorCode:  jsonapi.ErrorCodeJWTSecurityError,
 				payload:            createWIPayloadString,
 				jwtToken:           getExpiredAuthHeader(t, privatekey),
 			}, {
 				method:             http.MethodPatch,
-				url:                fmt.Sprintf(endpointWorkItems, "1234") + "/12345",
+				url:                fmt.Sprintf(endpointWorkItems, "5b5faa94-7478-4a35-9fdd-e1b5278df331") + "/12345",
 				expectedStatusCode: http.StatusUnauthorized,
 				expectedErrorCode:  jsonapi.ErrorCodeJWTSecurityError,
 				payload:            createWIPayloadString,
 				jwtToken:           getMalformedAuthHeader(t, privatekey),
 			}, {
 				method:             http.MethodPatch,
-				url:                fmt.Sprintf(endpointWorkItems, "1234") + "/12345",
+				url:                fmt.Sprintf(endpointWorkItems, "5b5faa94-7478-4a35-9fdd-e1b5278df331") + "/12345",
 				expectedStatusCode: http.StatusUnauthorized,
 				expectedErrorCode:  jsonapi.ErrorCodeJWTSecurityError,
 				payload:            createWIPayloadString,
 				jwtToken:           getValidAuthHeader(t, differentPrivatekey),
 			}, {
 				method:             http.MethodPatch,
-				url:                fmt.Sprintf(endpointWorkItems, "1234") + "/12345",
+				url:                fmt.Sprintf(endpointWorkItems, "5b5faa94-7478-4a35-9fdd-e1b5278df331") + "/12345",
 				expectedStatusCode: http.StatusUnauthorized,
 				expectedErrorCode:  jsonapi.ErrorCodeJWTSecurityError,
 				payload:            createWIPayloadString,
@@ -452,28 +452,28 @@ func getWorkItemTestDataFunc(config configuration.ConfigurationData) func(t *tes
 			// Delete Work Item API with different parameters
 			{
 				method:             http.MethodDelete,
-				url:                fmt.Sprintf(endpointWorkItems, "1234") + "/12345",
+				url:                fmt.Sprintf(endpointWorkItems, "5b5faa94-7478-4a35-9fdd-e1b5278df331") + "/12345",
 				expectedStatusCode: http.StatusUnauthorized,
 				expectedErrorCode:  jsonapi.ErrorCodeJWTSecurityError,
 				payload:            nil,
 				jwtToken:           getExpiredAuthHeader(t, privatekey),
 			}, {
 				method:             http.MethodDelete,
-				url:                fmt.Sprintf(endpointWorkItems, "1234") + "/12345",
+				url:                fmt.Sprintf(endpointWorkItems, "5b5faa94-7478-4a35-9fdd-e1b5278df331") + "/12345",
 				expectedStatusCode: http.StatusUnauthorized,
 				expectedErrorCode:  jsonapi.ErrorCodeJWTSecurityError,
 				payload:            nil,
 				jwtToken:           getMalformedAuthHeader(t, privatekey),
 			}, {
 				method:             http.MethodDelete,
-				url:                fmt.Sprintf(endpointWorkItems, "1234") + "/12345",
+				url:                fmt.Sprintf(endpointWorkItems, "5b5faa94-7478-4a35-9fdd-e1b5278df331") + "/12345",
 				expectedStatusCode: http.StatusUnauthorized,
 				expectedErrorCode:  jsonapi.ErrorCodeJWTSecurityError,
 				payload:            nil,
 				jwtToken:           getValidAuthHeader(t, differentPrivatekey),
 			}, {
 				method:             http.MethodDelete,
-				url:                fmt.Sprintf(endpointWorkItems, "1234") + "/12345",
+				url:                fmt.Sprintf(endpointWorkItems, "5b5faa94-7478-4a35-9fdd-e1b5278df331") + "/12345",
 				expectedStatusCode: http.StatusUnauthorized,
 				expectedErrorCode:  jsonapi.ErrorCodeJWTSecurityError,
 				payload:            nil,
@@ -483,7 +483,7 @@ func getWorkItemTestDataFunc(config configuration.ConfigurationData) func(t *tes
 			// We do not have security on GET hence this should return 404 not found
 			{
 				method:             http.MethodGet,
-				url:                fmt.Sprintf(endpointWorkItems, "1234") + "/088481764871",
+				url:                fmt.Sprintf(endpointWorkItems, "5b5faa94-7478-4a35-9fdd-e1b5278df331") + "/088481764871",
 				expectedStatusCode: http.StatusNotFound,
 				expectedErrorCode:  jsonapi.ErrorCodeNotFound,
 				payload:            nil,

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -94,14 +94,14 @@ func (s *WorkItemSuite) SetupTest() {
 	payload := minimumRequiredCreateWithType(workitem.SystemBug)
 	payload.Data.Attributes[workitem.SystemTitle] = "Test WI"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
 	s.wi = wi.Data
 	s.minimumPayload = getMinimumRequiredUpdatePayload(s.wi)
 }
 
 func (s *WorkItemSuite) TestGetWorkItemWithLegacyDescription() {
 	// given
-	_, wi := test.ShowWorkitemOK(s.T(), nil, nil, s.controller, s.wi.Relationships.Space.Data.ID.String(), *s.wi.ID, nil, nil)
+	_, wi := test.ShowWorkitemOK(s.T(), nil, nil, s.controller, *s.wi.Relationships.Space.Data.ID, *s.wi.ID, nil, nil)
 	require.NotNil(s.T(), wi)
 	assert.Equal(s.T(), s.wi.ID, wi.Data.ID)
 	assert.NotNil(s.T(), wi.Data.Attributes[workitem.SystemCreatedAt])
@@ -113,7 +113,7 @@ func (s *WorkItemSuite) TestGetWorkItemWithLegacyDescription() {
 	payload2 := minimumRequiredUpdatePayload()
 	payload2.Data.ID = wi.Data.ID
 	payload2.Data.Attributes = wi.Data.Attributes
-	_, updated := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.controller, payload2.Data.Relationships.Space.Data.ID.String(), *wi.Data.ID, &payload2)
+	_, updated := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.controller, *payload2.Data.Relationships.Space.Data.ID, *wi.Data.ID, &payload2)
 	// then
 	assert.NotNil(s.T(), updated.Data.Attributes[workitem.SystemCreatedAt])
 	assert.Equal(s.T(), (s.wi.Attributes["version"].(int) + 1), updated.Data.Attributes["version"])
@@ -128,7 +128,7 @@ func (s *WorkItemSuite) TestCreateWI() {
 	payload.Data.Attributes[workitem.SystemTitle] = "Test WI"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	// when
-	_, created := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
+	_, created := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
 	// then
 	require.NotNil(s.T(), created.Data.ID)
 	assert.NotEmpty(s.T(), *created.Data.ID)
@@ -145,10 +145,10 @@ func (s *WorkItemSuite) TestReorderWorkitemAboveOK() {
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateClosed
 
 	// This workitem is created but not used to clearly test that the reorder workitem is moved between **two** workitems i.e. result1 and result2 and not to the **top** of the list
-	test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
+	test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
 
-	_, result2 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
-	_, result3 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
+	_, result2 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
+	_, result3 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
 	payload2 := minimumRequiredReorderPayload()
 
 	var dataArray []*app.WorkItem // dataArray contains the workitem(s) that have to be reordered
@@ -156,7 +156,7 @@ func (s *WorkItemSuite) TestReorderWorkitemAboveOK() {
 	payload2.Data = dataArray
 	payload2.Position.ID = result2.Data.ID // Position.ID specifies the workitem ID above or below which the workitem(s) should be placed
 	payload2.Position.Direction = string(workitem.DirectionAbove)
-	_, reordered1 := test.ReorderWorkitemOK(s.T(), s.svc.Context, s.svc, s.controller, space.SystemSpace.String(), &payload2) // Returns the workitems which are reordered
+	_, reordered1 := test.ReorderWorkitemOK(s.T(), s.svc.Context, s.svc, s.controller, space.SystemSpace, &payload2) // Returns the workitems which are reordered
 
 	require.Len(s.T(), reordered1.Data, 1) // checks the correct number of workitems reordered
 	assert.Equal(s.T(), result3.Data.Attributes["version"].(int)+1, reordered1.Data[0].Attributes["version"])
@@ -170,11 +170,11 @@ func (s *WorkItemSuite) TestReorderWorkitemBelowOK() {
 	payload.Data.Attributes[workitem.SystemTitle] = "Reorder Test WI"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateClosed
 
-	_, result1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
-	_, result2 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
+	_, result1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
+	_, result2 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
 
 	// This workitem is created but not used to clearly demonstrate that the reorder workitem is moved between **two** workitems i.e. result2 and result3 and not to the **bottom** of the list
-	test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
+	test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
 
 	payload2 := minimumRequiredReorderPayload()
 
@@ -184,7 +184,7 @@ func (s *WorkItemSuite) TestReorderWorkitemBelowOK() {
 	payload2.Position.ID = result2.Data.ID // Position.ID specifies the workitem ID above or below which the workitem(s) should be placed
 	payload2.Position.Direction = string(workitem.DirectionBelow)
 
-	_, reordered1 := test.ReorderWorkitemOK(s.T(), s.svc.Context, s.svc, s.controller, space.SystemSpace.String(), &payload2) // Returns the workitems which are reordered
+	_, reordered1 := test.ReorderWorkitemOK(s.T(), s.svc.Context, s.svc, s.controller, space.SystemSpace, &payload2) // Returns the workitems which are reordered
 
 	require.Len(s.T(), reordered1.Data, 1) // checks the correct number of workitems reordered
 	assert.Equal(s.T(), result1.Data.Attributes["version"].(int)+1, reordered1.Data[0].Attributes["version"])
@@ -199,15 +199,15 @@ func (s *WorkItemSuite) TestReorderWorkitemTopOK() {
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateClosed
 	// There are two workitems in the list -> result1 and result2
 	// In this case, we reorder result2 to the top of the list i.e. above result1
-	_, result1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
-	test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
+	_, result1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
+	test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
 	payload2 := minimumRequiredReorderPayload()
 
 	var dataArray []*app.WorkItem // dataArray contains the workitem(s) that have to be reordered
 	dataArray = append(dataArray, result1.Data)
 	payload2.Data = dataArray
 	payload2.Position.Direction = string(workitem.DirectionTop)
-	_, reordered1 := test.ReorderWorkitemOK(s.T(), s.svc.Context, s.svc, s.controller, space.SystemSpace.String(), &payload2) // Returns the workitems which are reordered
+	_, reordered1 := test.ReorderWorkitemOK(s.T(), s.svc.Context, s.svc, s.controller, space.SystemSpace, &payload2) // Returns the workitems which are reordered
 
 	require.Len(s.T(), reordered1.Data, 1) // checks the correct number of workitems reordered
 	assert.Equal(s.T(), result1.Data.Attributes["version"].(int)+1, reordered1.Data[0].Attributes["version"])
@@ -223,8 +223,8 @@ func (s *WorkItemSuite) TestReorderWorkitemBottomOK() {
 
 	// There are two workitems in the list -> result1 and result2
 	// In this case, we reorder result1 to the bottom of the list i.e. below result2
-	test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
-	_, result2 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
+	test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
+	_, result2 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
 	payload2 := minimumRequiredReorderPayload()
 
 	var dataArray []*app.WorkItem // dataArray contains the workitem(s) that have to be reordered
@@ -232,7 +232,7 @@ func (s *WorkItemSuite) TestReorderWorkitemBottomOK() {
 	payload2.Data = dataArray
 	payload2.Position.Direction = string(workitem.DirectionBottom)
 
-	_, reordered1 := test.ReorderWorkitemOK(s.T(), s.svc.Context, s.svc, s.controller, space.SystemSpace.String(), &payload2) // Returns the workitems which are reordered
+	_, reordered1 := test.ReorderWorkitemOK(s.T(), s.svc.Context, s.svc, s.controller, space.SystemSpace, &payload2) // Returns the workitems which are reordered
 
 	require.Len(s.T(), reordered1.Data, 1) // checks the correct number of workitems reordered
 	assert.Equal(s.T(), result2.Data.Attributes["version"].(int)+1, reordered1.Data[0].Attributes["version"])
@@ -246,10 +246,10 @@ func (s *WorkItemSuite) TestReorderMultipleWorkitems() {
 	payload.Data.Attributes[workitem.SystemTitle] = "Reorder Test WI"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateClosed
 
-	test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
-	_, result2 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
-	_, result3 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
-	_, result4 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
+	test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
+	_, result2 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
+	_, result3 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
+	_, result4 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
 	payload2 := minimumRequiredReorderPayload()
 
 	var dataArray []*app.WorkItem // dataArray contains the workitems that have to be reordered
@@ -258,7 +258,7 @@ func (s *WorkItemSuite) TestReorderMultipleWorkitems() {
 	payload2.Position.ID = result2.Data.ID // Position.ID specifies the workitem ID above or below which the workitem(s) should be placed
 	payload2.Position.Direction = string(workitem.DirectionAbove)
 
-	_, reordered1 := test.ReorderWorkitemOK(s.T(), s.svc.Context, s.svc, s.controller, space.SystemSpace.String(), &payload2) // Returns the workitems which are reordered
+	_, reordered1 := test.ReorderWorkitemOK(s.T(), s.svc.Context, s.svc, s.controller, space.SystemSpace, &payload2) // Returns the workitems which are reordered
 
 	require.Len(s.T(), reordered1.Data, 2) // checks the correct number of workitems reordered
 
@@ -274,7 +274,7 @@ func (s *WorkItemSuite) TestReorderWorkitemBadRequestOK() {
 	payload := minimumRequiredCreateWithType(workitem.SystemBug)
 	payload.Data.Attributes[workitem.SystemTitle] = "Reorder Test WI"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateClosed
-	_, result1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
+	_, result1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
 	payload2 := minimumRequiredReorderPayload()
 
 	// This case gives empty dataArray as input
@@ -285,7 +285,7 @@ func (s *WorkItemSuite) TestReorderWorkitemBadRequestOK() {
 	payload2.Data = dataArray
 	payload2.Position.ID = result1.Data.ID
 	payload2.Position.Direction = string(workitem.DirectionAbove)
-	test.ReorderWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.controller, space.SystemSpace.String(), &payload2)
+	test.ReorderWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.controller, space.SystemSpace, &payload2)
 }
 
 // TestReorderWorkitemNotFound is negative test which tests unsuccessful reorder by providing invalid input
@@ -293,7 +293,7 @@ func (s *WorkItemSuite) TestReorderWorkitemNotFoundOK() {
 	payload := minimumRequiredCreateWithType(workitem.SystemBug)
 	payload.Data.Attributes[workitem.SystemTitle] = "Reorder Test WI"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateClosed
-	_, result1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
+	_, result1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
 	payload2 := minimumRequiredReorderPayload()
 
 	// This case gives id of workitem in position.ID which is not present in db as input
@@ -306,7 +306,7 @@ func (s *WorkItemSuite) TestReorderWorkitemNotFoundOK() {
 	randomID := "78"
 	payload2.Position.ID = &randomID
 	payload2.Position.Direction = string(workitem.DirectionAbove)
-	test.ReorderWorkitemNotFound(s.T(), s.svc.Context, s.svc, s.controller, space.SystemSpace.String(), &payload2)
+	test.ReorderWorkitemNotFound(s.T(), s.svc.Context, s.svc, s.controller, space.SystemSpace, &payload2)
 }
 
 // TestUpdateWorkitemWithoutReorder tests that when workitem is updated, execution order of workitem doesnot change.
@@ -316,14 +316,14 @@ func (s *WorkItemSuite) TestUpdateWorkitemWithoutReorder() {
 	payload := minimumRequiredCreateWithType(workitem.SystemBug)
 	payload.Data.Attributes[workitem.SystemTitle] = "Test WI"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
 
 	// Update the workitem
 	wi.Data.Attributes[workitem.SystemTitle] = "Updated Test WI"
 	payload2 := minimumRequiredUpdatePayload()
 	payload2.Data.ID = wi.Data.ID
 	payload2.Data.Attributes = wi.Data.Attributes
-	_, updated := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), *wi.Data.ID, &payload2)
+	_, updated := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, *wi.Data.ID, &payload2)
 
 	assert.Equal(s.T(), *wi.Data.ID, *updated.Data.ID)
 	assert.Equal(s.T(), (s.wi.Attributes["version"].(int) + 1), updated.Data.Attributes["version"])
@@ -340,7 +340,7 @@ func (s *WorkItemSuite) TestCreateWorkItemWithoutContext() {
 	payload.Data.Attributes[workitem.SystemTitle] = "Test WI"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	// when/then
-	test.CreateWorkitemUnauthorized(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
+	test.CreateWorkitemUnauthorized(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
 }
 
 func (s *WorkItemSuite) TestListByFields() {
@@ -348,19 +348,19 @@ func (s *WorkItemSuite) TestListByFields() {
 	payload := minimumRequiredCreateWithType(workitem.SystemBug)
 	payload.Data.Attributes[workitem.SystemTitle] = "run integration test"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateClosed
-	test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &payload)
+	test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.controller, *payload.Data.Relationships.Space.Data.ID, &payload)
 	// when
 	filter := "{\"system.title\":\"run integration test\"}"
 	offset := "0"
 	limit := 1
-	_, result := test.ListWorkitemOK(s.T(), nil, nil, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &filter, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result := test.ListWorkitemOK(s.T(), nil, nil, s.controller, *payload.Data.Relationships.Space.Data.ID, &filter, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	// then
 	require.NotNil(s.T(), result)
 	require.Equal(s.T(), 1, len(result.Data))
 	// when
 	filter = fmt.Sprintf("{\"system.creator\":\"%s\"}", s.testIdentity.ID.String())
 	// then
-	_, result = test.ListWorkitemOK(s.T(), nil, nil, s.controller, payload.Data.Relationships.Space.Data.ID.String(), &filter, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result = test.ListWorkitemOK(s.T(), nil, nil, s.controller, *payload.Data.Relationships.Space.Data.ID, &filter, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	require.NotNil(s.T(), result)
 	require.Equal(s.T(), 1, len(result.Data))
 }
@@ -504,7 +504,7 @@ func (s *WorkItemSuite) TestUnauthorizeWorkItemCUD() {
 	})
 }
 
-func createPagingTest(t *testing.T, ctx context.Context, controller *WorkitemController, repo *testsupport.WorkItemRepository, spaceID string, totalCount int) func(start int, limit int, first string, last string, prev string, next string) {
+func createPagingTest(t *testing.T, ctx context.Context, controller *WorkitemController, repo *testsupport.WorkItemRepository, spaceID uuid.UUID, totalCount int) func(start int, limit int, first string, last string, prev string, next string) {
 	return func(start int, limit int, first string, last string, prev string, next string) {
 		count := computeCount(totalCount, int(start), int(limit))
 		repo.ListReturns(makeWorkItems(count), uint64(totalCount), nil)
@@ -772,7 +772,7 @@ func (s *WorkItem2Suite) SetupTest() {
 	payload.Data.Attributes[workitem.SystemTitle] = "Test WI"
 	payload.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	s.T().Log("Creating default WI in space#", payload.Data.Relationships.Space.Data.ID.String())
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wiCtrl, payload.Data.Relationships.Space.Data.ID.String(), &payload)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wiCtrl, *payload.Data.Relationships.Space.Data.ID, &payload)
 	s.T().Log("Done creating default WI")
 	s.wi = wi.Data
 	s.minimumPayload = getMinimumRequiredUpdatePayload(s.wi)
@@ -787,10 +787,10 @@ func (s *WorkItem2Suite) TearDownTest() {
 func (s *WorkItem2Suite) TestWI2UpdateOnlyState() {
 	s.minimumPayload.Data.Attributes[workitem.SystemTitle] = "Test title"
 	s.minimumPayload.Data.Attributes["system.state"] = "invalid_value"
-	test.UpdateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, s.wi.Relationships.Space.Data.ID.String(), *s.wi.ID, s.minimumPayload)
+	test.UpdateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.Relationships.Space.Data.ID, *s.wi.ID, s.minimumPayload)
 	newStateValue := "closed"
 	s.minimumPayload.Data.Attributes[workitem.SystemState] = newStateValue
-	_, updatedWI := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, s.wi.Relationships.Space.Data.ID.String(), *s.wi.ID, s.minimumPayload)
+	_, updatedWI := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.Relationships.Space.Data.ID, *s.wi.ID, s.minimumPayload)
 	require.NotNil(s.T(), updatedWI)
 	assert.Equal(s.T(), updatedWI.Data.Attributes[workitem.SystemState], newStateValue)
 }
@@ -798,16 +798,16 @@ func (s *WorkItem2Suite) TestWI2UpdateOnlyState() {
 func (s *WorkItem2Suite) TestWI2UpdateVersionConflict() {
 	// given
 	s.minimumPayload.Data.Attributes[workitem.SystemTitle] = "Test title"
-	test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, s.wi.Relationships.Space.Data.ID.String(), *s.wi.ID, s.minimumPayload)
+	test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.Relationships.Space.Data.ID, *s.wi.ID, s.minimumPayload)
 	s.minimumPayload.Data.Attributes["version"] = 2398475203
 	// when/then
-	test.UpdateWorkitemConflict(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, s.wi.Relationships.Space.Data.ID.String(), *s.wi.ID, s.minimumPayload)
+	test.UpdateWorkitemConflict(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.Relationships.Space.Data.ID, *s.wi.ID, s.minimumPayload)
 }
 
 func (s *WorkItem2Suite) TestWI2UpdateWithNonExistentID() {
 	id := "2398475203"
 	s.minimumPayload.Data.ID = &id
-	test.UpdateWorkitemNotFound(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, s.minimumPayload.Data.Relationships.Space.Data.ID.String(), id, s.minimumPayload)
+	test.UpdateWorkitemNotFound(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.minimumPayload.Data.Relationships.Space.Data.ID, id, s.minimumPayload)
 }
 
 func (s *WorkItem2Suite) TestWI2UpdateWithInvalidID() {
@@ -815,7 +815,7 @@ func (s *WorkItem2Suite) TestWI2UpdateWithInvalidID() {
 	s.minimumPayload.Data.ID = &id
 	// pass*s.wi.ID below, because that creates a route to the controller
 	// if do not pass*s.wi.ID then we will be testing goa's code and not ours
-	test.UpdateWorkitemNotFound(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, s.minimumPayload.Data.Relationships.Space.Data.ID.String(), *s.wi.ID, s.minimumPayload)
+	test.UpdateWorkitemNotFound(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.minimumPayload.Data.Relationships.Space.Data.ID, *s.wi.ID, s.minimumPayload)
 }
 
 func (s *WorkItem2Suite) TestWI2UpdateSetBaseType() {
@@ -823,7 +823,7 @@ func (s *WorkItem2Suite) TestWI2UpdateSetBaseType() {
 	c.Data.Attributes[workitem.SystemTitle] = "Test title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 
-	_, created := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, created := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	assert.Equal(s.T(), created.Data.Relationships.BaseType.Data.ID, workitem.SystemBug)
 
 	u := minimumRequiredUpdatePayload()
@@ -834,7 +834,7 @@ func (s *WorkItem2Suite) TestWI2UpdateSetBaseType() {
 		BaseType: newRelationBaseType(space.SystemSpace, workitem.SystemExperience),
 	}
 
-	_, newWi := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, s.wi.Relationships.Space.Data.ID.String(), *s.wi.ID, &u)
+	_, newWi := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.Relationships.Space.Data.ID, *s.wi.ID, &u)
 
 	// Ensure the type wasn't updated
 	require.Equal(s.T(), workitem.SystemBug, newWi.Data.Relationships.BaseType.Data.ID)
@@ -847,7 +847,7 @@ func (s *WorkItem2Suite) TestWI2UpdateOnlyLegacyDescription() {
 	expectedRenderedDescription := "Only Description is modified"
 	s.minimumPayload.Data.Attributes[workitem.SystemDescription] = modifiedDescription
 
-	_, updatedWI := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, s.wi.Relationships.Space.Data.ID.String(), *s.wi.ID, s.minimumPayload)
+	_, updatedWI := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.Relationships.Space.Data.ID, *s.wi.ID, s.minimumPayload)
 	require.NotNil(s.T(), updatedWI)
 	assert.Equal(s.T(), expectedDescription, updatedWI.Data.Attributes[workitem.SystemDescription])
 	assert.Equal(s.T(), expectedRenderedDescription, updatedWI.Data.Attributes[workitem.SystemDescriptionRendered])
@@ -865,7 +865,7 @@ func (s *WorkItem2Suite) TestWI2UpdateDescriptionAndMarkup() {
 	s.minimumPayload.Data.Attributes[workitem.SystemDescription] = modifiedDescription
 	s.minimumPayload.Data.Attributes[workitem.SystemDescriptionMarkup] = modifiedMarkup
 
-	_, updatedWI := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, s.wi.Relationships.Space.Data.ID.String(), *s.wi.ID, s.minimumPayload)
+	_, updatedWI := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.Relationships.Space.Data.ID, *s.wi.ID, s.minimumPayload)
 	require.NotNil(s.T(), updatedWI)
 	assert.Equal(s.T(), expectedDescription, updatedWI.Data.Attributes[workitem.SystemDescription])
 	assert.Equal(s.T(), expectedRenderedDescription, updatedWI.Data.Attributes[workitem.SystemDescriptionRendered])
@@ -878,7 +878,7 @@ func (s *WorkItem2Suite) TestWI2UpdateOnlyMarkupDescriptionWithoutMarkup() {
 	expectedDescription := "Only Description is modified"
 	expectedRenderedDescription := "Only Description is modified"
 	s.minimumPayload.Data.Attributes[workitem.SystemDescription] = modifiedDescription.ToMap()
-	_, updatedWI := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, s.wi.Relationships.Space.Data.ID.String(), *s.wi.ID, s.minimumPayload)
+	_, updatedWI := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.Relationships.Space.Data.ID, *s.wi.ID, s.minimumPayload)
 	require.NotNil(s.T(), updatedWI)
 	assert.Equal(s.T(), expectedDescription, updatedWI.Data.Attributes[workitem.SystemDescription])
 	assert.Equal(s.T(), expectedRenderedDescription, updatedWI.Data.Attributes[workitem.SystemDescriptionRendered])
@@ -892,7 +892,7 @@ func (s *WorkItem2Suite) TestWI2UpdateOnlyMarkupDescriptionWithMarkup() {
 	expectedRenderedDescription := "<p>Only Description is modified</p>\n"
 	s.minimumPayload.Data.Attributes[workitem.SystemDescription] = modifiedDescription.ToMap()
 
-	_, updatedWI := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, s.wi.Relationships.Space.Data.ID.String(), *s.wi.ID, s.minimumPayload)
+	_, updatedWI := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.Relationships.Space.Data.ID, *s.wi.ID, s.minimumPayload)
 	require.NotNil(s.T(), updatedWI)
 	assert.Equal(s.T(), expectedDescription, updatedWI.Data.Attributes[workitem.SystemDescription])
 	assert.Equal(s.T(), expectedRenderedDescription, updatedWI.Data.Attributes[workitem.SystemDescriptionRendered])
@@ -905,7 +905,7 @@ func (s *WorkItem2Suite) TestWI2UpdateMultipleScenarios() {
 	modifiedTitle := "Is the model updated?"
 	s.minimumPayload.Data.Attributes[workitem.SystemTitle] = modifiedTitle
 
-	_, updatedWI := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, s.wi.Relationships.Space.Data.ID.String(), *s.wi.ID, s.minimumPayload)
+	_, updatedWI := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.Relationships.Space.Data.ID, *s.wi.ID, s.minimumPayload)
 	require.NotNil(s.T(), updatedWI)
 	assert.Equal(s.T(), updatedWI.Data.Attributes[workitem.SystemTitle], modifiedTitle)
 
@@ -938,7 +938,7 @@ func (s *WorkItem2Suite) TestWI2UpdateMultipleScenarios() {
 				Type: &userType,
 			}},
 	}
-	test.UpdateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, s.wi.Relationships.Space.Data.ID.String(), *s.wi.ID, s.minimumPayload)
+	test.UpdateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.Relationships.Space.Data.ID, *s.wi.ID, s.minimumPayload)
 
 	s.minimumPayload.Data.Relationships.Assignees = &app.RelationGenericList{
 		Data: []*app.GenericData{
@@ -948,19 +948,19 @@ func (s *WorkItem2Suite) TestWI2UpdateMultipleScenarios() {
 			}},
 	}
 
-	_, updatedWI = test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, s.wi.Relationships.Space.Data.ID.String(), *s.wi.ID, s.minimumPayload)
+	_, updatedWI = test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.Relationships.Space.Data.ID, *s.wi.ID, s.minimumPayload)
 	require.NotNil(s.T(), updatedWI)
 	assert.Equal(s.T(), *updatedWI.Data.Relationships.Assignees.Data[0].ID, newUser.ID.String())
 
 	// update to wrong version
 	correctVersion := updatedWI.Data.Attributes["version"]
 	s.minimumPayload.Data.Attributes["version"] = 12453972348
-	test.UpdateWorkitemConflict(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, s.wi.Relationships.Space.Data.ID.String(), *s.wi.ID, s.minimumPayload)
+	test.UpdateWorkitemConflict(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.Relationships.Space.Data.ID, *s.wi.ID, s.minimumPayload)
 	s.minimumPayload.Data.Attributes["version"] = correctVersion
 
 	// Add test to remove assignee for WI
 	s.minimumPayload.Data.Relationships.Assignees.Data = nil
-	_, updatedWI = test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, s.wi.Relationships.Space.Data.ID.String(), *s.wi.ID, s.minimumPayload)
+	_, updatedWI = test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *s.wi.Relationships.Space.Data.ID, *s.wi.ID, s.minimumPayload)
 	require.NotNil(s.T(), updatedWI)
 	require.Len(s.T(), updatedWI.Data.Relationships.Assignees.Data, 0)
 	// need to do in order to keep object future usage
@@ -975,7 +975,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWorkItem() {
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
 
 	// when
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// then
 	assert.NotNil(s.T(), wi.Data)
 	assert.NotNil(s.T(), wi.Data.ID)
@@ -999,7 +999,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWorkItemWithoutDescription() {
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
 
 	// when
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// then
 	require.NotNil(s.T(), wi.Data)
 	require.NotNil(s.T(), wi.Data.Attributes)
@@ -1019,7 +1019,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWorkItemWithLegacyDescription() {
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
 
 	// when
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// then
 	require.NotNil(s.T(), wi.Data)
 	require.NotNil(s.T(), wi.Data.Attributes)
@@ -1040,7 +1040,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWorkItemWithDescriptionAndMarkup() 
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
 
 	// when
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// then
 	require.NotNil(s.T(), wi.Data)
 	require.NotNil(s.T(), wi.Data.Attributes)
@@ -1061,7 +1061,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWorkItemWithDescriptionAndNoMarkup(
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
 
 	// when
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// then
 	require.NotNil(s.T(), wi.Data)
 	require.NotNil(s.T(), wi.Data.Attributes)
@@ -1082,7 +1082,7 @@ func (s *WorkItem2Suite) TestWI2FailCreateWorkItemWithDescriptionAndUnsupportedM
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
 
 	// when/then
-	test.CreateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	test.CreateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 }
 
 func (s *WorkItem2Suite) TestWI2FailCreateMissingBaseType() {
@@ -1091,7 +1091,7 @@ func (s *WorkItem2Suite) TestWI2FailCreateMissingBaseType() {
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	// when/then
-	test.CreateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	test.CreateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 }
 
 func (s *WorkItem2Suite) TestWI2FailCreateWithAssigneeAsField() {
@@ -1104,7 +1104,7 @@ func (s *WorkItem2Suite) TestWI2FailCreateWithAssigneeAsField() {
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
 
 	// when
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// then
 	assert.NotNil(s.T(), wi.Data)
 	assert.NotNil(s.T(), wi.Data.ID)
@@ -1120,7 +1120,7 @@ func (s *WorkItem2Suite) TestWI2FailCreateWithMissingTitle() {
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
 
 	// when/then
-	test.CreateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	test.CreateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 }
 
 func (s *WorkItem2Suite) TestWI2FailCreateWithEmptyTitle() {
@@ -1130,7 +1130,7 @@ func (s *WorkItem2Suite) TestWI2FailCreateWithEmptyTitle() {
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
 	// when/then
-	test.CreateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	test.CreateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 }
 
 func (s *WorkItem2Suite) TestWI2SuccessCreateWithAssigneeRelation() {
@@ -1150,7 +1150,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWithAssigneeRelation() {
 			}},
 	}
 	// when
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// then
 	assert.NotNil(s.T(), wi.Data)
 	assert.NotNil(s.T(), wi.Data.ID)
@@ -1175,7 +1175,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWithAssigneesRelation() {
 		},
 	}
 	// when
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// then
 	assert.NotNil(s.T(), wi.Data)
 	assert.NotNil(s.T(), wi.Data.ID)
@@ -1198,7 +1198,7 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateWithAssigneesRelation() {
 		},
 		Space: spaceRelation,
 	}
-	_, wiu := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, wi.Data.Relationships.Space.Data.ID.String(), *wi.Data.ID, &update)
+	_, wiu := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *wi.Data.Relationships.Space.Data.ID, *wi.Data.ID, &update)
 	assert.Len(s.T(), wiu.Data.Relationships.Assignees.Data, 2)
 	assert.Equal(s.T(), newUser2.ID.String(), *wiu.Data.Relationships.Assignees.Data[0].ID)
 	assert.Equal(s.T(), newUser3.ID.String(), *wiu.Data.Relationships.Assignees.Data[1].ID)
@@ -1217,7 +1217,7 @@ func (s *WorkItem2Suite) TestWI2ListByAssigneeFilter() {
 		},
 	}
 	// when
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// then
 	assert.NotNil(s.T(), wi.Data)
 	assert.NotNil(s.T(), wi.Data.ID)
@@ -1226,7 +1226,7 @@ func (s *WorkItem2Suite) TestWI2ListByAssigneeFilter() {
 	assert.Len(s.T(), wi.Data.Relationships.Assignees.Data, 1)
 	assert.Equal(s.T(), newUser.ID.String(), *wi.Data.Relationships.Assignees.Data[0].ID)
 	newUserID := newUser.ID.String()
-	_, list := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), nil, nil, &newUserID, nil, nil, nil, nil, nil, nil, nil, nil)
+	_, list := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, nil, nil, &newUserID, nil, nil, nil, nil, nil, nil, nil, nil)
 	assert.Len(s.T(), list.Data, 1)
 	assert.Equal(s.T(), newUser.ID.String(), *list.Data[0].Relationships.Assignees.Data[0].ID)
 	assert.True(s.T(), strings.Contains(*list.Links.First, "filter[assignee]"))
@@ -1251,14 +1251,14 @@ func (s *WorkItem2Suite) TestWI2ListByNoAssigneeFilter() {
 	assignee := none
 
 	s.T().Run("default work item created in fixture", func(t *testing.T) {
-		_, list0 := test.ListWorkitemOK(t, s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), nil, nil, &assignee, nil, nil, nil, nil, nil, nil, nil, nil)
+		_, list0 := test.ListWorkitemOK(t, s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, nil, nil, &assignee, nil, nil, nil, nil, nil, nil, nil, nil)
 		// data coming from test fixture
 		assert.Len(t, list0.Data, 1)
 		assert.True(t, strings.Contains(*list0.Links.First, "filter[assignee]=none"))
 	})
 
 	s.T().Run("work item with assignee", func(t *testing.T) {
-		_, wi := test.CreateWorkitemCreated(t, s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+		_, wi := test.CreateWorkitemCreated(t, s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 		assert.NotNil(t, wi.Data)
 		assert.NotNil(t, wi.Data.ID)
 		assert.NotNil(t, wi.Data.Type)
@@ -1266,7 +1266,7 @@ func (s *WorkItem2Suite) TestWI2ListByNoAssigneeFilter() {
 		assert.NotNil(t, wi.Data.Relationships.Assignees.Data)
 		assert.NotNil(t, wi.Data.Relationships.Assignees.Data[0].ID)
 
-		_, list := test.ListWorkitemOK(t, s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), nil, nil, &newUserID, nil, nil, nil, nil, nil, nil, nil, nil)
+		_, list := test.ListWorkitemOK(t, s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, nil, nil, &newUserID, nil, nil, nil, nil, nil, nil, nil, nil)
 		assert.Len(t, list.Data, 1)
 		require.NotNil(t, *list.Data[0].Relationships.Assignees.Data[0])
 		assert.Equal(t, newUser.ID.String(), *list.Data[0].Relationships.Assignees.Data[0].ID)
@@ -1274,13 +1274,13 @@ func (s *WorkItem2Suite) TestWI2ListByNoAssigneeFilter() {
 	})
 
 	s.T().Run("work item with assignee value as none", func(t *testing.T) {
-		_, list2 := test.ListWorkitemOK(t, s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), nil, nil, &assignee, nil, nil, nil, nil, nil, nil, nil, nil)
+		_, list2 := test.ListWorkitemOK(t, s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, nil, nil, &assignee, nil, nil, nil, nil, nil, nil, nil, nil)
 		assert.Len(t, list2.Data, 1)
 		assert.True(t, strings.Contains(*list2.Links.First, "filter[assignee]=none"))
 	})
 
 	s.T().Run("work item without specifying assignee", func(t *testing.T) {
-		_, list3 := test.ListWorkitemOK(t, s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		_, list3 := test.ListWorkitemOK(t, s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		assert.Len(t, list3.Data, 2)
 		assert.False(t, strings.Contains(*list3.Links.First, "filter[assignee]=none"))
 	})
@@ -1293,12 +1293,12 @@ func (s *WorkItem2Suite) TestWI2ListByTypeFilter() {
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
 	// when
-	_, expected := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, expected := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// then
 	assert.NotNil(s.T(), expected.Data)
 	require.NotNil(s.T(), expected.Data.ID)
 	require.NotNil(s.T(), expected.Data.Type)
-	_, actual := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, &workitem.SystemBug, nil, nil, nil, nil)
+	_, actual := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace, nil, nil, nil, nil, nil, nil, &workitem.SystemBug, nil, nil, nil, nil)
 	require.NotNil(s.T(), actual)
 	require.True(s.T(), len(actual.Data) > 1)
 	assert.Contains(s.T(), *actual.Links.First, fmt.Sprintf("filter[workitemtype]=%s", workitem.SystemBug))
@@ -1313,7 +1313,7 @@ func (s *WorkItem2Suite) createWorkItem(title, state string) app.WorkItemSingle 
 	c.Data.Attributes[workitem.SystemTitle] = title
 	c.Data.Attributes[workitem.SystemState] = state
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	require.NotNil(s.T(), wi.Data)
 	require.NotNil(s.T(), wi.Data.ID)
 	require.NotNil(s.T(), wi.Data.Type)
@@ -1327,7 +1327,7 @@ func (s *WorkItem2Suite) TestWI2ListByStateFilterOK() {
 	inprogressWI := s.createWorkItem("title", workitem.SystemStateInProgress)
 	// when
 	stateNew := workitem.SystemStateNew
-	_, actualWIs := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), nil, nil, nil, nil, nil, &stateNew, nil, nil, nil, nil, nil)
+	_, actualWIs := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace, nil, nil, nil, nil, nil, &stateNew, nil, nil, nil, nil, nil)
 	// then
 	require.NotNil(s.T(), actualWIs)
 	require.True(s.T(), len(actualWIs.Data) > 1)
@@ -1346,7 +1346,7 @@ func (s *WorkItem2Suite) TestWI2ListByStateFilterNotModifiedUsingIfNoneMatchIfMo
 	inprogressWI := s.createWorkItem("title", workitem.SystemStateInProgress)
 	// when
 	stateNew := workitem.SystemStateNew
-	res, actualWIs := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), nil, nil, nil, nil, nil, &stateNew, nil, nil, nil, nil, nil)
+	res, actualWIs := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace, nil, nil, nil, nil, nil, &stateNew, nil, nil, nil, nil, nil)
 	// then
 	require.NotNil(s.T(), actualWIs)
 	require.True(s.T(), len(actualWIs.Data) > 1)
@@ -1359,7 +1359,7 @@ func (s *WorkItem2Suite) TestWI2ListByStateFilterNotModifiedUsingIfNoneMatchIfMo
 	// retain conditional headers in response and submit the request again
 	etag, lastModified, _ := assertResponseHeaders(s.T(), res)
 	// when calling again
-	res = test.ListWorkitemNotModified(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), nil, nil, nil, nil, nil, &stateNew, nil, nil, nil, &lastModified, &etag)
+	res = test.ListWorkitemNotModified(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace, nil, nil, nil, nil, nil, &stateNew, nil, nil, nil, &lastModified, &etag)
 	// then
 	assertResponseHeaders(s.T(), res)
 }
@@ -1371,7 +1371,7 @@ func (s *WorkItem2Suite) TestWI2ListByStateFilterOKModifiedUsingIfNoneMatchIfMod
 	inprogressWI := s.createWorkItem("title", workitem.SystemStateInProgress)
 	// when
 	stateNew := workitem.SystemStateNew
-	res, actualWIs := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), nil, nil, nil, nil, nil, &stateNew, nil, nil, nil, nil, nil)
+	res, actualWIs := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace, nil, nil, nil, nil, nil, &stateNew, nil, nil, nil, nil, nil)
 	// then
 	require.NotNil(s.T(), actualWIs)
 	require.True(s.T(), len(actualWIs.Data) > 1)
@@ -1390,9 +1390,9 @@ func (s *WorkItem2Suite) TestWI2ListByStateFilterOKModifiedUsingIfNoneMatchIfMod
 	update.Data.Attributes[workitem.SystemTitle] = inprogressWI.Data.Attributes[workitem.SystemTitle]
 	update.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	update.Data.Attributes["version"] = inprogressWI.Data.Attributes["version"]
-	test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), *inprogressWI.Data.ID, &update)
+	test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace, *inprogressWI.Data.ID, &update)
 	// when calling again (with expired validation headers)
-	res, actualWIs = test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), nil, nil, nil, nil, nil, &stateNew, nil, nil, nil, &lastModified, &etag)
+	res, actualWIs = test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace, nil, nil, nil, nil, nil, &stateNew, nil, nil, nil, &lastModified, &etag)
 	// then expect the new data
 	assertResponseHeaders(s.T(), res)
 	require.NotNil(s.T(), actualWIs)
@@ -1404,7 +1404,7 @@ func (s *WorkItem2Suite) TestWI2ListByStateFilterOKModifiedUsingIfNoneMatchIfMod
 	}
 }
 
-func (s *WorkItem2Suite) setupAreaWorkItem(createWorkItem bool) (string, string, *app.WorkItemSingle) {
+func (s *WorkItem2Suite) setupAreaWorkItem(createWorkItem bool) (uuid.UUID, string, *app.WorkItemSingle) {
 	tempArea := createOneRandomArea(s.svc.Context, s.DB, "TestWI2ListByAreaFilter")
 	require.NotNil(s.T(), tempArea)
 	areaID := tempArea.ID.String()
@@ -1418,7 +1418,7 @@ func (s *WorkItem2Suite) setupAreaWorkItem(createWorkItem bool) (string, string,
 		},
 	}
 	if createWorkItem {
-		_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+		_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 		require.NotNil(s.T(), wi)
 		require.NotNil(s.T(), wi.Data)
 		require.NotNil(s.T(), wi.Data.ID)
@@ -1426,9 +1426,9 @@ func (s *WorkItem2Suite) setupAreaWorkItem(createWorkItem bool) (string, string,
 		require.NotNil(s.T(), wi.Data.Attributes)
 		require.NotNil(s.T(), wi.Data.Relationships.Area)
 		assert.Equal(s.T(), areaID, *wi.Data.Relationships.Area.Data.ID)
-		return c.Data.Relationships.Space.Data.ID.String(), areaID, wi
+		return *c.Data.Relationships.Space.Data.ID, areaID, wi
 	}
-	return c.Data.Relationships.Space.Data.ID.String(), areaID, nil
+	return *c.Data.Relationships.Space.Data.ID, areaID, nil
 }
 
 func assertAreaWorkItems(t *testing.T, areaID string, workitems *app.WorkItemList) {
@@ -1520,7 +1520,7 @@ func (s *WorkItem2Suite) TestWI2ListByIterationFilter() {
 			ID: &iterationID,
 		},
 	}
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	require.NotNil(s.T(), wi.Data)
 	require.NotNil(s.T(), wi.Data.ID)
 	require.NotNil(s.T(), wi.Data.Type)
@@ -1528,7 +1528,7 @@ func (s *WorkItem2Suite) TestWI2ListByIterationFilter() {
 	require.NotNil(s.T(), wi.Data.Relationships.Iteration)
 	assert.Equal(s.T(), iterationID, *wi.Data.Relationships.Iteration.Data.ID)
 
-	_, list := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), nil, nil, nil, &iterationID, nil, nil, nil, nil, nil, nil, nil)
+	_, list := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, nil, nil, nil, &iterationID, nil, nil, nil, nil, nil, nil, nil)
 	require.Len(s.T(), list.Data, 1)
 	assert.Equal(s.T(), iterationID, *list.Data[0].Relationships.Iteration.Data.ID)
 	assert.True(s.T(), strings.Contains(*list.Links.First, "filter[iteration]"))
@@ -1546,7 +1546,7 @@ func (s *WorkItem2Suite) TestWI2FailCreateInvalidAssignees() {
 		},
 	}
 	// when/then
-	test.CreateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	test.CreateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 }
 
 func (s *WorkItem2Suite) TestWI2FailUpdateInvalidAssignees() {
@@ -1560,7 +1560,7 @@ func (s *WorkItem2Suite) TestWI2FailUpdateInvalidAssignees() {
 			ident(newUser.ID),
 		},
 	}
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 
 	update := minimumRequiredUpdatePayload()
 	update.Data.ID = wi.Data.ID
@@ -1573,7 +1573,7 @@ func (s *WorkItem2Suite) TestWI2FailUpdateInvalidAssignees() {
 			},
 		},
 	}
-	test.UpdateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, wi.Data.Relationships.Space.Data.ID.String(), *wi.Data.ID, &update)
+	test.UpdateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *wi.Data.Relationships.Space.Data.ID, *wi.Data.ID, &update)
 }
 
 func (s *WorkItem2Suite) TestWI2SuccessUpdateWithAssigneesRelation() {
@@ -1589,7 +1589,7 @@ func (s *WorkItem2Suite) TestWI2SuccessUpdateWithAssigneesRelation() {
 			ident(newUser2.ID),
 		},
 	}
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	assert.NotNil(s.T(), wi.Data)
 	assert.NotNil(s.T(), wi.Data.ID)
 	assert.NotNil(s.T(), wi.Data.Type)
@@ -1603,9 +1603,9 @@ func (s *WorkItem2Suite) TestWI2ShowOK() {
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
-	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// when
-	res, fetchedWI := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, createdWI.Data.Relationships.Space.Data.ID.String(), *createdWI.Data.ID, nil, nil)
+	res, fetchedWI := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWI.Data.Relationships.Space.Data.ID, *createdWI.Data.ID, nil, nil)
 	// then
 	assertSingleWorkItem(s.T(), *createdWI, *fetchedWI)
 	assertResponseHeaders(s.T(), res)
@@ -1617,10 +1617,10 @@ func (s *WorkItem2Suite) TestWI2ShowOKUsingExpiredIfModifiedSinceHeader() {
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
-	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// when
 	ifModifiedSince := app.ToHTTPTime(createdWI.Data.Attributes[workitem.SystemUpdatedAt].(time.Time).Add(-10 * time.Hour))
-	res, fetchedWI := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, createdWI.Data.Relationships.Space.Data.ID.String(), *createdWI.Data.ID, &ifModifiedSince, nil)
+	res, fetchedWI := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWI.Data.Relationships.Space.Data.ID, *createdWI.Data.ID, &ifModifiedSince, nil)
 	// then
 	assertSingleWorkItem(s.T(), *createdWI, *fetchedWI)
 	assertResponseHeaders(s.T(), res)
@@ -1632,10 +1632,10 @@ func (s *WorkItem2Suite) TestWI2ShowOKUsingExpiredIfNoneMatchHeader() {
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
-	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// when
 	ifNoneMatch := "foo"
-	res, fetchedWI := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, createdWI.Data.Relationships.Space.Data.ID.String(), *createdWI.Data.ID, nil, &ifNoneMatch)
+	res, fetchedWI := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWI.Data.Relationships.Space.Data.ID, *createdWI.Data.ID, nil, &ifNoneMatch)
 	// then
 	assertSingleWorkItem(s.T(), *createdWI, *fetchedWI)
 	assertResponseHeaders(s.T(), res)
@@ -1647,10 +1647,10 @@ func (s *WorkItem2Suite) TestWI2ShowNotModifiedUsingIfModifiedSinceHeader() {
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
-	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// when
 	ifModifiedSince := app.ToHTTPTime(createdWI.Data.Attributes[workitem.SystemUpdatedAt].(time.Time))
-	res := test.ShowWorkitemNotModified(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, createdWI.Data.Relationships.Space.Data.ID.String(), *createdWI.Data.ID, &ifModifiedSince, nil)
+	res := test.ShowWorkitemNotModified(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWI.Data.Relationships.Space.Data.ID, *createdWI.Data.ID, &ifModifiedSince, nil)
 	// then
 	assertResponseHeaders(s.T(), res)
 }
@@ -1661,10 +1661,10 @@ func (s *WorkItem2Suite) TestWI2ShowNotModifiedUsingIfNoneMatchHeader() {
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
-	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// when
 	ifNoneMatch := app.GenerateEntityTag(convertWorkItemToConditionalResponseEntity(*createdWI))
-	res := test.ShowWorkitemNotModified(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, createdWI.Data.Relationships.Space.Data.ID.String(), *createdWI.Data.ID, nil, &ifNoneMatch)
+	res := test.ShowWorkitemNotModified(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWI.Data.Relationships.Space.Data.ID, *createdWI.Data.ID, nil, &ifNoneMatch)
 	// then
 	assertResponseHeaders(s.T(), res)
 }
@@ -1692,7 +1692,7 @@ func assertResponseHeaders(t *testing.T, res http.ResponseWriter) (string, strin
 
 // Temporarly disabled, See https://github.com/almighty/almighty-core/issues/1036
 func (s *WorkItem2Suite) xTestWI2FailShowMissing() {
-	test.ShowWorkitemNotFound(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), "00000000", nil, nil)
+	test.ShowWorkitemNotFound(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace, "00000000", nil, nil)
 }
 
 // Temporarly disabled, See https://github.com/almighty/almighty-core/issues/1036
@@ -1702,9 +1702,9 @@ func (s *WorkItem2Suite) TestWI2FailOnDelete() {
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
 
-	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
-	test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, createdWI.Data.Relationships.Space.Data.ID.String(), *createdWI.Data.ID, nil, nil)
-	test.DeleteWorkitemMethodNotAllowed(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), *createdWI.Data.ID)
+	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
+	test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWI.Data.Relationships.Space.Data.ID, *createdWI.Data.ID, nil, nil)
+	test.DeleteWorkitemMethodNotAllowed(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, *createdWI.Data.ID)
 }
 
 // Temporarly disabled, See https://github.com/almighty/almighty-core/issues/1036
@@ -1714,10 +1714,10 @@ func (s *WorkItem2Suite) xTestWI2SuccessDelete() {
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
 
-	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
-	test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, createdWI.Data.Relationships.Space.Data.ID.String(), *createdWI.Data.ID, nil, nil)
-	test.DeleteWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), *createdWI.Data.ID)
-	test.ShowWorkitemNotFound(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, createdWI.Data.Relationships.Space.Data.ID.String(), *createdWI.Data.ID, nil, nil)
+	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
+	test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWI.Data.Relationships.Space.Data.ID, *createdWI.Data.ID, nil, nil)
+	test.DeleteWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, *createdWI.Data.ID)
+	test.ShowWorkitemNotFound(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWI.Data.Relationships.Space.Data.ID, *createdWI.Data.ID, nil, nil)
 }
 
 // TestWI2DeleteLinksOnWIDeletionOK creates two work items (WI1 and WI2) and
@@ -1730,10 +1730,10 @@ func (s *WorkItem2Suite) xTestWI2DeleteLinksOnWIDeletionOK() {
 	c.Data.Attributes[workitem.SystemTitle] = "WI1"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
-	_, wi1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi1 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	require.NotNil(s.T(), wi1)
 	c.Data.Attributes[workitem.SystemTitle] = "WI2"
-	_, wi2 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi2 := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	require.NotNil(s.T(), wi2)
 
 	// Create link category
@@ -1747,7 +1747,7 @@ func (s *WorkItem2Suite) xTestWI2DeleteLinksOnWIDeletionOK() {
 
 	// Create work item link type payload
 	linkTypePayload := CreateWorkItemLinkType("MyLinkType", workitem.SystemBug, workitem.SystemBug, *linkCat.Data.ID, *space.Data.ID)
-	_, linkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, space.Data.ID.String(), linkTypePayload)
+	_, linkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, *space.Data.ID, linkTypePayload)
 	require.NotNil(s.T(), linkType)
 
 	// Create link between wi1 and wi2
@@ -1760,18 +1760,18 @@ func (s *WorkItem2Suite) xTestWI2DeleteLinksOnWIDeletionOK() {
 	require.NotNil(s.T(), workItemLink)
 
 	// Delete work item wi1
-	test.DeleteWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, wi1.Data.Relationships.Space.Data.ID.String(), *wi1.Data.ID)
+	test.DeleteWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *wi1.Data.Relationships.Space.Data.ID, *wi1.Data.ID)
 
 	// Check that the link was deleted by deleting wi1
 	test.ShowWorkItemLinkNotFound(s.T(), s.svc.Context, s.svc, s.linkCtrl, *workItemLink.Data.ID, nil, nil)
 
 	// Check that we can query for wi2 without problems
-	test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, wi2.Data.Relationships.Space.Data.ID.String(), *wi2.Data.ID, nil, nil)
+	test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *wi2.Data.Relationships.Space.Data.ID, *wi2.Data.ID, nil, nil)
 }
 
 // Temporarly disabled, See https://github.com/almighty/almighty-core/issues/1036
 func (s *WorkItem2Suite) xTestWI2FailMissingDelete() {
-	test.DeleteWorkitemNotFound(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), "00000000")
+	test.DeleteWorkitemNotFound(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace, "00000000")
 }
 
 func (s *WorkItem2Suite) TestWI2CreateWithArea() {
@@ -1796,7 +1796,7 @@ func (s *WorkItem2Suite) TestWI2CreateWithArea() {
 			},
 		},
 	}
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// then
 	require.NotNil(s.T(), wi.Data.Relationships.Area)
 	assert.Equal(s.T(), areaID, *wi.Data.Relationships.Area.Data.ID)
@@ -1816,7 +1816,7 @@ func (s *WorkItem2Suite) TestWI2UpdateWithArea() {
 			ID:   workitem.SystemBug,
 		},
 	}
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	require.NotNil(s.T(), wi.Data.Relationships.Area)
 	require.NotNil(s.T(), wi.Data.Relationships.Area.Data.ID)
 	// should get root area's id for that space
@@ -1840,7 +1840,7 @@ func (s *WorkItem2Suite) TestWI2UpdateWithArea() {
 			},
 		},
 	}
-	_, wiu := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, wi.Data.Relationships.Space.Data.ID.String(), *wi.Data.ID, &u)
+	_, wiu := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *wi.Data.Relationships.Space.Data.ID, *wi.Data.ID, &u)
 	// then
 	require.NotNil(s.T(), wiu.Data.Relationships.Area)
 	require.NotNil(s.T(), wiu.Data.Relationships.Area.Data)
@@ -1890,7 +1890,7 @@ func (s *WorkItem2Suite) TestWI2UpdateWithRootAreaIfMissing() {
 		},
 	}
 	s.T().Log("Space ID:", testSpace.ID.String())
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, testSpace.ID.String(), &payload)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, testSpace.ID, &payload)
 	require.NotNil(s.T(), wi.Data.Relationships.Space)
 	require.NotNil(s.T(), wi.Data.Relationships.Space.Data.ID)
 	require.NotNil(s.T(), wi.Data.Relationships.Area)
@@ -1903,7 +1903,7 @@ func (s *WorkItem2Suite) TestWI2UpdateWithRootAreaIfMissing() {
 	u.Data.Relationships = &app.WorkItemRelationships{
 		Area: &app.RelationGeneric{},
 	}
-	_, wiu := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, wi.Data.Relationships.Space.Data.ID.String(), *wi.Data.ID, &u)
+	_, wiu := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *wi.Data.Relationships.Space.Data.ID, *wi.Data.ID, &u)
 	// then
 	require.NotNil(s.T(), wiu.Data.Relationships.Space)
 	require.NotNil(s.T(), wiu.Data.Relationships.Space.Data)
@@ -1930,7 +1930,7 @@ func (s *WorkItem2Suite) TestWI2CreateUnknownArea() {
 		},
 	}
 	// when/then
-	test.CreateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	test.CreateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 }
 
 func (s *WorkItem2Suite) TestWI2CreateWithIteration() {
@@ -1955,7 +1955,7 @@ func (s *WorkItem2Suite) TestWI2CreateWithIteration() {
 			},
 		},
 	}
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// then
 	require.NotNil(s.T(), wi.Data.Relationships.Iteration)
 	assert.Equal(s.T(), iterationID, *wi.Data.Relationships.Iteration.Data.ID)
@@ -1970,7 +1970,7 @@ func (s *WorkItem2Suite) TestWI2UpdateWithIteration() {
 	c.Data.Attributes[workitem.SystemTitle] = "Title"
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	assert.NotNil(s.T(), wi.Data.Relationships.Iteration)
 	// should get root iteration's id for that space
 	spaceRepo := space.NewRepository(s.DB)
@@ -1990,7 +1990,7 @@ func (s *WorkItem2Suite) TestWI2UpdateWithIteration() {
 			ID:   &iterationID,
 		},
 	}
-	_, wiu := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, wi.Data.Relationships.Space.Data.ID.String(), *wi.Data.ID, &u)
+	_, wiu := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *wi.Data.Relationships.Space.Data.ID, *wi.Data.ID, &u)
 	// then
 	require.NotNil(s.T(), wiu.Data.Relationships.Iteration)
 	require.NotNil(s.T(), wiu.Data.Relationships.Iteration.Data)
@@ -2030,7 +2030,7 @@ func (s *WorkItem2Suite) TestWI2UpdateWithRootIterationIfMissing() {
 		},
 	}
 	s.T().Log("Space ID:", testSpace.ID.String())
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, testSpace.ID.String(), &payload)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, testSpace.ID, &payload)
 	require.NotNil(s.T(), wi.Data.Relationships.Space)
 	require.NotNil(s.T(), wi.Data.Relationships.Space.Data.ID)
 	require.NotNil(s.T(), wi.Data.Relationships.Iteration)
@@ -2043,7 +2043,7 @@ func (s *WorkItem2Suite) TestWI2UpdateWithRootIterationIfMissing() {
 	u.Data.Relationships = &app.WorkItemRelationships{
 		Iteration: &app.RelationGeneric{},
 	}
-	_, wiu := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, wi.Data.Relationships.Space.Data.ID.String(), *wi.Data.ID, &u)
+	_, wiu := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *wi.Data.Relationships.Space.Data.ID, *wi.Data.ID, &u)
 	// then
 	require.NotNil(s.T(), wiu.Data.Relationships.Space)
 	require.NotNil(s.T(), wiu.Data.Relationships.Space.Data)
@@ -2072,7 +2072,7 @@ func (s *WorkItem2Suite) TestWI2UpdateRemoveIteration() {
 			ID:   &iterationID,
 		},
 	}
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	assert.NotNil(s.T(), wi.Data.Relationships.Iteration)
 	assert.NotNil(s.T(), wi.Data.Relationships.Iteration.Data)
 	u := minimumRequiredUpdatePayload()
@@ -2081,7 +2081,7 @@ func (s *WorkItem2Suite) TestWI2UpdateRemoveIteration() {
 	u.Data.Relationships.Iteration = &app.RelationGeneric{
 		Data: nil,
 	}
-	_, wiu := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, wi.Data.Relationships.Space.Data.ID.String(), *wi.Data.ID, &u)
+	_, wiu := test.UpdateWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *wi.Data.Relationships.Space.Data.ID, *wi.Data.ID, &u)
 	// then
 	require.NotNil(s.T(), wiu.Data.Relationships.Iteration)
 	assert.Nil(s.T(), wiu.Data.Relationships.Iteration.Data)
@@ -2102,7 +2102,7 @@ func (s *WorkItem2Suite) TestWI2CreateUnknownIteration() {
 		},
 	}
 	// when/then
-	test.CreateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	test.CreateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 }
 
 func (s *WorkItem2Suite) TestWI2SuccessCreateAndPreventJavascriptInjectionWithLegacyDescription() {
@@ -2114,9 +2114,9 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateAndPreventJavascriptInjectionWithLe
 	c.Data.Attributes[workitem.SystemDescription] = description
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
-	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// when
-	_, fetchedWI := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, createdWI.Data.Relationships.Space.Data.ID.String(), *createdWI.Data.ID, nil, nil)
+	_, fetchedWI := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWI.Data.Relationships.Space.Data.ID, *createdWI.Data.ID, nil, nil)
 	// then
 	require.NotNil(s.T(), fetchedWI.Data)
 	require.NotNil(s.T(), fetchedWI.Data.Attributes)
@@ -2133,9 +2133,9 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateAndPreventJavascriptInjectionWithPl
 	c.Data.Attributes[workitem.SystemDescription] = description
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
-	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// when
-	_, fetchedWI := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, createdWI.Data.Relationships.Space.Data.ID.String(), *createdWI.Data.ID, nil, nil)
+	_, fetchedWI := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWI.Data.Relationships.Space.Data.ID, *createdWI.Data.ID, nil, nil)
 	// then
 	require.NotNil(s.T(), fetchedWI.Data)
 	require.NotNil(s.T(), fetchedWI.Data.Attributes)
@@ -2152,9 +2152,9 @@ func (s *WorkItem2Suite) TestWI2SuccessCreateAndPreventJavascriptInjectionWithMa
 	c.Data.Attributes[workitem.SystemDescription] = description
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	c.Data.Relationships.BaseType = newRelationBaseType(space.SystemSpace, workitem.SystemBug)
-	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// when
-	_, fetchedWI := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, createdWI.Data.Relationships.Space.Data.ID.String(), *createdWI.Data.ID, nil, nil)
+	_, fetchedWI := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWI.Data.Relationships.Space.Data.ID, *createdWI.Data.ID, nil, nil)
 	// then
 	require.NotNil(s.T(), fetchedWI.Data)
 	require.NotNil(s.T(), fetchedWI.Data.Attributes)
@@ -2180,10 +2180,10 @@ func (s *WorkItem2Suite) TestCreateWIWithCodebase() {
 		LineNumber: line,
 	}
 	c.Data.Attributes[workitem.SystemCodebase] = cbase.ToMap()
-	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, createdWI := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	require.NotNil(s.T(), createdWI)
 	// when
-	_, fetchedWI := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, createdWI.Data.Relationships.Space.Data.ID.String(), *createdWI.Data.ID, nil, nil)
+	_, fetchedWI := test.ShowWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *createdWI.Data.Relationships.Space.Data.ID, *createdWI.Data.ID, nil, nil)
 	// then
 	require.NotNil(s.T(), fetchedWI.Data)
 	require.NotNil(s.T(), fetchedWI.Data.Attributes)
@@ -2214,7 +2214,7 @@ func (s *WorkItem2Suite) TestFailToCreateWIWithCodebase() {
 	}
 	c.Data.Attributes[workitem.SystemCodebase] = cbase.ToMap()
 	// when/then
-	test.CreateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	test.CreateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 }
 
 func (s *WorkItem2Suite) TestCreateWorkItemWithInferredSpace() {
@@ -2224,7 +2224,7 @@ func (s *WorkItem2Suite) TestCreateWorkItemWithInferredSpace() {
 	c.Data.Attributes[workitem.SystemTitle] = title
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	// remove Space relation and see if WI gets the space out of the space URL.
-	spaceID := c.Data.Relationships.Space.Data.ID.String()
+	spaceID := *c.Data.Relationships.Space.Data.ID
 	c.Data.Relationships.Space = nil
 	// when
 	_, item := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, spaceID, &c)
@@ -2258,7 +2258,7 @@ func (s *WorkItem2Suite) TestCreateWorkItemWithCustomSpace() {
 	// set custom space and see if WI gets custom space
 	c.Data.Relationships.Space.Data.ID = customSpace.Data.ID
 	// when
-	_, item := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, item := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// then
 	require.NotNil(s.T(), item)
 	assert.Equal(s.T(), title, item.Data.Attributes[workitem.SystemTitle])
@@ -2279,7 +2279,7 @@ func (s *WorkItem2Suite) TestCreateWorkItemWithInvalidSpace() {
 	fakeSpaceID := uuid.NewV4()
 	c.Data.Relationships.Space.Data.ID = &fakeSpaceID
 	// when/then
-	test.CreateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	test.CreateWorkitemBadRequest(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 }
 
 func (s *WorkItem2Suite) TestDefaultSpaceAndIterationRelations() {
@@ -2289,7 +2289,7 @@ func (s *WorkItem2Suite) TestDefaultSpaceAndIterationRelations() {
 	c.Data.Attributes[workitem.SystemTitle] = title
 	c.Data.Attributes[workitem.SystemState] = workitem.SystemStateNew
 	// when
-	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	// then
 	require.NotNil(s.T(), wi)
 	require.NotNil(s.T(), wi.Data.Relationships)
@@ -2312,7 +2312,7 @@ func (s *WorkItem2Suite) xTestWI2IfModifiedSince() {
 	c.Data.Relationships = &app.WorkItemRelationships{
 		BaseType: newRelationBaseType(space.SystemSpace, workitem.SystemBug),
 	}
-	resp, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+	resp, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 	lastMod := resp.Header().Get("Last-Modified")
 	s.svc.Use(func(handler goa.Handler) goa.Handler {
 		return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) (err error) {
@@ -2321,7 +2321,7 @@ func (s *WorkItem2Suite) xTestWI2IfModifiedSince() {
 		}
 	})
 	// when/then
-	test.ShowWorkitemNotModified(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, wi.Data.Relationships.Space.Data.ID.String(), *wi.Data.ID, nil, nil)
+	test.ShowWorkitemNotModified(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *wi.Data.Relationships.Space.Data.ID, *wi.Data.ID, nil, nil)
 }
 
 func (s *WorkItem2Suite) TestWI2ListForChildIteration() {
@@ -2346,7 +2346,7 @@ func (s *WorkItem2Suite) TestWI2ListForChildIteration() {
 				ID: &grandParentIterationID,
 			},
 		}
-		_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+		_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 		require.NotNil(s.T(), wi.Data)
 		require.NotNil(s.T(), wi.Data.ID)
 		require.NotNil(s.T(), wi.Data.Relationships.Iteration)
@@ -2365,7 +2365,7 @@ func (s *WorkItem2Suite) TestWI2ListForChildIteration() {
 				ID: &parentIterationID,
 			},
 		}
-		_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+		_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 		require.NotNil(s.T(), wi.Data)
 		require.NotNil(s.T(), wi.Data.ID)
 		require.NotNil(s.T(), wi.Data.Relationships.Iteration)
@@ -2384,7 +2384,7 @@ func (s *WorkItem2Suite) TestWI2ListForChildIteration() {
 				ID: &childIteraitonID,
 			},
 		}
-		_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, c.Data.Relationships.Space.Data.ID.String(), &c)
+		_, wi := test.CreateWorkitemCreated(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, *c.Data.Relationships.Space.Data.ID, &c)
 		require.NotNil(s.T(), wi.Data)
 		require.NotNil(s.T(), wi.Data.ID)
 		require.NotNil(s.T(), wi.Data.Relationships.Iteration)
@@ -2392,15 +2392,15 @@ func (s *WorkItem2Suite) TestWI2ListForChildIteration() {
 	}
 
 	// list workitems for grandParentIteration
-	_, list := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), nil, nil, nil, &grandParentIterationID, nil, nil, nil, nil, nil, nil, nil)
+	_, list := test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace, nil, nil, nil, &grandParentIterationID, nil, nil, nil, nil, nil, nil, nil)
 	require.Len(s.T(), list.Data, 7)
 
 	// list workitems for parentIteration
-	_, list = test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), nil, nil, nil, &parentIterationID, nil, nil, nil, nil, nil, nil, nil)
+	_, list = test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace, nil, nil, nil, &parentIterationID, nil, nil, nil, nil, nil, nil, nil)
 	require.Len(s.T(), list.Data, 4)
 
 	// list workitems for childIteraiton
-	_, list = test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace.String(), nil, nil, nil, &childIteraitonID, nil, nil, nil, nil, nil, nil, nil)
+	_, list = test.ListWorkitemOK(s.T(), s.svc.Context, s.svc, s.wi2Ctrl, space.SystemSpace, nil, nil, nil, &childIteraitonID, nil, nil, nil, nil, nil, nil, nil)
 	require.Len(s.T(), list.Data, 2)
 }
 
@@ -2457,15 +2457,15 @@ func (s *WorkItemSuite) TestUpdateWorkitemForSpaceCollaborator() {
 	svcNotAuthrized := testsupport.ServiceAsSpaceUser("Collaborators-Service", almtoken.NewManagerWithPrivateKey(priv), testIdentity2, &TestSpaceAuthzService{testIdentity})
 	ctrlNotAuthrize := NewWorkitemController(svcNotAuthrized, gormapplication.NewGormDB(s.DB), s.Configuration)
 
-	_, wi := test.CreateWorkitemCreated(s.T(), svc.Context, svc, ctrl, payload.Data.Relationships.Space.Data.ID.String(), &payload)
-	_, wi2 := test.CreateWorkitemCreated(s.T(), svcNotAuthrized.Context, svcNotAuthrized, ctrlNotAuthrize, payload.Data.Relationships.Space.Data.ID.String(), &payload)
+	_, wi := test.CreateWorkitemCreated(s.T(), svc.Context, svc, ctrl, *payload.Data.Relationships.Space.Data.ID, &payload)
+	_, wi2 := test.CreateWorkitemCreated(s.T(), svcNotAuthrized.Context, svcNotAuthrized, ctrlNotAuthrize, *payload.Data.Relationships.Space.Data.ID, &payload)
 
 	// Update the workitem by space collaborator
 	wi.Data.Attributes[workitem.SystemTitle] = "Updated Test WI"
 	payload2 := minimumRequiredUpdatePayloadWithSpace(*space.ID)
 	payload2.Data.ID = wi.Data.ID
 	payload2.Data.Attributes = wi.Data.Attributes
-	_, updated := test.UpdateWorkitemOK(s.T(), svc.Context, svc, ctrl, payload.Data.Relationships.Space.Data.ID.String(), *wi.Data.ID, &payload2)
+	_, updated := test.UpdateWorkitemOK(s.T(), svc.Context, svc, ctrl, *payload.Data.Relationships.Space.Data.ID, *wi.Data.ID, &payload2)
 
 	assert.Equal(s.T(), *wi.Data.ID, *updated.Data.ID)
 	assert.Equal(s.T(), (s.wi.Attributes["version"].(int) + 1), updated.Data.Attributes["version"])
@@ -2476,7 +2476,7 @@ func (s *WorkItemSuite) TestUpdateWorkitemForSpaceCollaborator() {
 	payload3 := minimumRequiredUpdatePayloadWithSpace(*space.ID)
 	payload3.Data.ID = wi2.Data.ID
 	payload3.Data.Attributes = wi2.Data.Attributes
-	_, updated = test.UpdateWorkitemOK(s.T(), svcNotAuthrized.Context, svcNotAuthrized, ctrlNotAuthrize, payload.Data.Relationships.Space.Data.ID.String(), *wi2.Data.ID, &payload3)
+	_, updated = test.UpdateWorkitemOK(s.T(), svcNotAuthrized.Context, svcNotAuthrized, ctrlNotAuthrize, *payload.Data.Relationships.Space.Data.ID, *wi2.Data.ID, &payload3)
 
 	assert.Equal(s.T(), *wi2.Data.ID, *updated.Data.ID)
 	assert.Equal(s.T(), (s.wi.Attributes["version"].(int) + 1), updated.Data.Attributes["version"])
@@ -2486,17 +2486,17 @@ func (s *WorkItemSuite) TestUpdateWorkitemForSpaceCollaborator() {
 	assert.Equal(s.T(), wi2.Data.Attributes[workitem.SystemOrder], updated.Data.Attributes[workitem.SystemOrder])
 
 	// Not a space collaborator is not authorized to update
-	test.UpdateWorkitemUnauthorized(s.T(), svcNotAuthrized.Context, svcNotAuthrized, ctrlNotAuthrize, payload.Data.Relationships.Space.Data.ID.String(), *wi.Data.ID, &payload2)
+	test.UpdateWorkitemUnauthorized(s.T(), svcNotAuthrized.Context, svcNotAuthrized, ctrlNotAuthrize, *payload.Data.Relationships.Space.Data.ID, *wi.Data.ID, &payload2)
 	// Not a space collaborator is not authorized to delete
 	// Temporarly disabled, See https://github.com/almighty/almighty-core/issues/1036
-	// test.DeleteWorkitemUnauthorized(s.T(), svcNotAuthrized.Context, svcNotAuthrized, ctrlNotAuthrize, payload.Data.Relationships.Space.Data.ID.String(), *wi.Data.ID)
+	// test.DeleteWorkitemUnauthorized(s.T(), svcNotAuthrized.Context, svcNotAuthrized, ctrlNotAuthrize, *payload.Data.Relationships.Space.Data.ID, *wi.Data.ID)
 	// Not a space collaborator is not authorized to reoder
 	payload4 := minimumRequiredReorderPayload()
 	var dataArray []*app.WorkItem // dataArray contains the workitem(s) that have to be reordered
 	dataArray = append(dataArray, wi.Data)
 	payload4.Data = dataArray
 	payload4.Position.Direction = string(workitem.DirectionTop)
-	test.ReorderWorkitemUnauthorized(s.T(), svcNotAuthrized.Context, svcNotAuthrized, ctrlNotAuthrize, space.ID.String(), &payload4)
+	test.ReorderWorkitemUnauthorized(s.T(), svcNotAuthrized.Context, svcNotAuthrized, ctrlNotAuthrize, *space.ID, &payload4)
 }
 
 func convertWorkItemToConditionalResponseEntity(appWI app.WorkItemSingle) app.ConditionalResponseEntity {
@@ -2514,7 +2514,7 @@ func (s *workItemChildSuite) TestWorkItemListFilterByNoParents() {
 		// given
 		var pe *bool
 		// when
-		_, result := test.ListWorkitemOK(t, nil, nil, s.workItemCtrl, s.userSpaceID.String(), nil, nil, nil, nil, pe, nil, nil, nil, nil, nil, nil)
+		_, result := test.ListWorkitemOK(t, nil, nil, s.workItemCtrl, s.userSpaceID, nil, nil, nil, nil, pe, nil, nil, nil, nil, nil, nil)
 		// then
 		assert.Len(t, result.Data, 3)
 	})
@@ -2523,7 +2523,7 @@ func (s *workItemChildSuite) TestWorkItemListFilterByNoParents() {
 		// given
 		pe := false
 		// when
-		_, result2 := test.ListWorkitemOK(t, nil, nil, s.workItemCtrl, s.userSpaceID.String(), nil, nil, nil, nil, &pe, nil, nil, nil, nil, nil, nil)
+		_, result2 := test.ListWorkitemOK(t, nil, nil, s.workItemCtrl, s.userSpaceID, nil, nil, nil, nil, &pe, nil, nil, nil, nil, nil, nil)
 		// then
 		assert.Len(t, result2.Data, 1)
 	})
@@ -2532,7 +2532,7 @@ func (s *workItemChildSuite) TestWorkItemListFilterByNoParents() {
 		// given
 		pe := true
 		// when
-		_, result2 := test.ListWorkitemOK(t, nil, nil, s.workItemCtrl, s.userSpaceID.String(), nil, nil, nil, nil, &pe, nil, nil, nil, nil, nil, nil)
+		_, result2 := test.ListWorkitemOK(t, nil, nil, s.workItemCtrl, s.userSpaceID, nil, nil, nil, nil, &pe, nil, nil, nil, nil, nil, nil)
 		// then
 		assert.Len(t, result2.Data, 3)
 	})

--- a/controller/workitem_test.go
+++ b/controller/workitem_test.go
@@ -43,7 +43,7 @@ func (s *TestPagingSuite) SetupSuite() {
 }
 
 func (s *TestPagingSuite) TestPagingLinks() {
-	pagingTest := createPagingTest(s.T(), s.svc.Context, s.controller, s.repo, space.SystemSpace.String(), 13)
+	pagingTest := createPagingTest(s.T(), s.svc.Context, s.controller, s.repo, space.SystemSpace, 13)
 	pagingTest(2, 5, "page[offset]=0&page[limit]=2", "page[offset]=12&page[limit]=5", "page[offset]=0&page[limit]=2", "page[offset]=7&page[limit]=5")
 	pagingTest(10, 3, "page[offset]=0&page[limit]=1", "page[offset]=10&page[limit]=3", "page[offset]=7&page[limit]=3", "")
 	pagingTest(0, 4, "page[offset]=0&page[limit]=4", "page[offset]=12&page[limit]=4", "", "page[offset]=4&page[limit]=4")
@@ -55,7 +55,7 @@ func (s *TestPagingSuite) TestPagingLinks() {
 	pagingTest(3, 50, "page[offset]=0&page[limit]=3", "page[offset]=3&page[limit]=50", "page[offset]=0&page[limit]=3", "")
 	pagingTest(0, 50, "page[offset]=0&page[limit]=50", "page[offset]=0&page[limit]=50", "", "")
 
-	pagingTest = createPagingTest(s.T(), s.svc.Context, s.controller, s.repo, space.SystemSpace.String(), 0)
+	pagingTest = createPagingTest(s.T(), s.svc.Context, s.controller, s.repo, space.SystemSpace, 0)
 	pagingTest(2, 5, "page[offset]=0&page[limit]=2", "page[offset]=0&page[limit]=2", "", "")
 }
 
@@ -64,28 +64,28 @@ func (s *TestPagingSuite) TestPagingErrors() {
 
 	var offset string = "-1"
 	var limit int = 2
-	_, result := test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result := test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace, nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	if !strings.Contains(*result.Links.First, "page[offset]=0") {
 		assert.Fail(s.T(), "Offset is negative", "Expected offset to be %d, but was %s", 0, *result.Links.First)
 	}
 
 	offset = "0"
 	limit = 0
-	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace, nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	if !strings.Contains(*result.Links.First, "page[limit]=20") {
 		assert.Fail(s.T(), "Limit is 0", "Expected limit to be default size %d, but was %s", 20, *result.Links.First)
 	}
 
 	offset = "0"
 	limit = -1
-	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace, nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	if !strings.Contains(*result.Links.First, "page[limit]=20") {
 		assert.Fail(s.T(), "Limit is negative", "Expected limit to be default size %d, but was %s", 20, *result.Links.First)
 	}
 
 	offset = "-3"
 	limit = -1
-	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace, nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	if !strings.Contains(*result.Links.First, "page[limit]=20") {
 		assert.Fail(s.T(), "Limit is negative", "Expected limit to be default size %d, but was %s", 20, *result.Links.First)
 	}
@@ -95,7 +95,7 @@ func (s *TestPagingSuite) TestPagingErrors() {
 
 	offset = "ALPHA"
 	limit = 40
-	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace, nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	if !strings.Contains(*result.Links.First, "page[limit]=40") {
 		assert.Fail(s.T(), "Limit is within range", "Expected limit to be size %d, but was %s", 40, *result.Links.First)
 	}
@@ -110,7 +110,7 @@ func (s *TestPagingSuite) TestPagingLinksHasAbsoluteURL() {
 	limit := 10
 	s.repo.ListReturns(makeWorkItems(10), uint64(100), nil)
 	// when
-	_, result := test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result := test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace, nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	// then
 	if !strings.HasPrefix(*result.Links.First, "http://") {
 		assert.Fail(s.T(), "Not Absolute URL", "Expected link %s to contain absolute URL but was %s", "First", *result.Links.First)
@@ -132,21 +132,21 @@ func (s *TestPagingSuite) TestPagingDefaultAndMaxSize() {
 	var limit int
 	s.repo.ListReturns(makeWorkItems(10), uint64(100), nil)
 	// when
-	_, result := test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, nil, nil, &offset, nil, nil)
+	_, result := test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace, nil, nil, nil, nil, nil, nil, nil, nil, &offset, nil, nil)
 	// then
 	if !strings.Contains(*result.Links.First, "page[limit]=20") {
 		assert.Fail(s.T(), "Limit is nil", "Expected limit to be default size %d, got %v", 20, *result.Links.First)
 	}
 	// when
 	limit = 1000
-	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace, nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	// then
 	if !strings.Contains(*result.Links.First, "page[limit]=100") {
 		assert.Fail(s.T(), "Limit is more than max", "Expected limit to be %d, got %v", 100, *result.Links.First)
 	}
 	// when
 	limit = 50
-	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace.String(), nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
+	_, result = test.ListWorkitemOK(s.T(), context.Background(), nil, s.controller, space.SystemSpace, nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil)
 	// then
 	if !strings.Contains(*result.Links.First, "page[limit]=50") {
 		assert.Fail(s.T(), "Limit is within range", "Expected limit to be %d, got %v", 50, *result.Links.First)

--- a/controller/workitemtype.go
+++ b/controller/workitemtype.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
-	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/log"
 	"github.com/almighty/almighty-core/rest"
@@ -14,7 +13,6 @@ import (
 
 	"github.com/goadesign/goa"
 	errs "github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
 )
 
 const (
@@ -44,13 +42,8 @@ func NewWorkitemtypeController(service *goa.Service, db application.DB, config W
 
 // Show runs the show action.
 func (c *WorkitemtypeController) Show(ctx *app.ShowWorkitemtypeContext) error {
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return errors.NewNotFoundError("spaceID", ctx.ID)
-	}
-
 	return application.Transactional(c.db, func(appl application.Application) error {
-		witModel, err := appl.WorkItemTypes().Load(ctx.Context, spaceID, ctx.WitID)
+		witModel, err := appl.WorkItemTypes().Load(ctx.Context, ctx.SpaceID, ctx.WitID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
@@ -64,11 +57,6 @@ func (c *WorkitemtypeController) Show(ctx *app.ShowWorkitemtypeContext) error {
 
 // Create runs the create action.
 func (c *WorkitemtypeController) Create(ctx *app.CreateWorkitemtypeContext) error {
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return errors.NewNotFoundError("spaceID", ctx.ID)
-	}
-
 	return application.Transactional(c.db, func(appl application.Application) error {
 		var fields = map[string]app.FieldDefinition{}
 		for key, fd := range ctx.Payload.Data.Attributes.Fields {
@@ -77,8 +65,8 @@ func (c *WorkitemtypeController) Create(ctx *app.CreateWorkitemtypeContext) erro
 		// Set the space to the Payload
 		if ctx.Payload.Data != nil && ctx.Payload.Data.Relationships != nil {
 			// We overwrite or use the space ID in the URL to set the space of this WI
-			spaceSelfURL := rest.AbsoluteURL(ctx.RequestData, app.SpaceHref(spaceID.String()))
-			ctx.Payload.Data.Relationships.Space = app.NewSpaceRelation(spaceID, spaceSelfURL)
+			spaceSelfURL := rest.AbsoluteURL(ctx.RequestData, app.SpaceHref(ctx.SpaceID.String()))
+			ctx.Payload.Data.Relationships.Space = app.NewSpaceRelation(ctx.SpaceID, spaceSelfURL)
 		}
 		modelFields, err := ConvertFieldDefinitionsToModel(fields)
 		if err != nil {
@@ -105,17 +93,13 @@ func (c *WorkitemtypeController) Create(ctx *app.CreateWorkitemtypeContext) erro
 
 // List runs the list action
 func (c *WorkitemtypeController) List(ctx *app.ListWorkitemtypeContext) error {
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return errors.NewNotFoundError("spaceID", ctx.ID)
-	}
-	log.Info(ctx, map[string]interface{}{"space_id": spaceID}, "Listing work item types per space")
+	log.Debug(ctx, map[string]interface{}{"space_id": ctx.SpaceID}, "Listing work item types per space")
 	start, limit, err := parseLimit(ctx.Page)
 	if err != nil {
 		return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "Could not parse paging"))
 	}
 	return application.Transactional(c.db, func(appl application.Application) error {
-		witModelsOrig, err := appl.WorkItemTypes().List(ctx.Context, spaceID, start, &limit)
+		witModelsOrig, err := appl.WorkItemTypes().List(ctx.Context, ctx.SpaceID, start, &limit)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, "Error listing work item types"))
 		}
@@ -149,14 +133,9 @@ func (c *WorkitemtypeController) List(ctx *app.ListWorkitemtypeContext) error {
 
 // ListSourceLinkTypes runs the list-source-link-types action.
 func (c *WorkitemtypeController) ListSourceLinkTypes(ctx *app.ListSourceLinkTypesWorkitemtypeContext) error {
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return errors.NewNotFoundError("spaceID", ctx.ID)
-	}
-
 	return application.Transactional(c.db, func(appl application.Application) error {
 		// Test that work item type exists
-		_, err := appl.WorkItemTypes().Load(ctx.Context, spaceID, ctx.WitID)
+		_, err := appl.WorkItemTypes().Load(ctx.Context, ctx.SpaceID, ctx.WitID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
@@ -174,7 +153,7 @@ func (c *WorkitemtypeController) ListSourceLinkTypes(ctx *app.ListSourceLinkType
 			}
 			// Enrich link types
 			hrefFunc := func(obj interface{}) string {
-				return fmt.Sprintf(app.WorkItemLinkTypeHref(spaceID, "%v"), obj)
+				return fmt.Sprintf(app.WorkItemLinkTypeHref(ctx.SpaceID, "%v"), obj)
 			}
 			linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, hrefFunc, nil)
 			err = enrichLinkTypeList(linkCtx, appLinkTypes)
@@ -188,14 +167,9 @@ func (c *WorkitemtypeController) ListSourceLinkTypes(ctx *app.ListSourceLinkType
 
 // ListTargetLinkTypes runs the list-target-link-types action.
 func (c *WorkitemtypeController) ListTargetLinkTypes(ctx *app.ListTargetLinkTypesWorkitemtypeContext) error {
-	spaceID, err := uuid.FromString(ctx.ID)
-	if err != nil {
-		return errors.NewNotFoundError("spaceID", ctx.ID)
-	}
-
 	return application.Transactional(c.db, func(appl application.Application) error {
 		// Test that work item type exists
-		_, err := appl.WorkItemTypes().Load(ctx.Context, spaceID, ctx.WitID)
+		_, err := appl.WorkItemTypes().Load(ctx.Context, ctx.SpaceID, ctx.WitID)
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
@@ -212,7 +186,7 @@ func (c *WorkitemtypeController) ListTargetLinkTypes(ctx *app.ListTargetLinkType
 			}
 			// Enrich link types
 			hrefFunc := func(obj interface{}) string {
-				return fmt.Sprintf(app.WorkItemLinkTypeHref(spaceID, "%v"), obj)
+				return fmt.Sprintf(app.WorkItemLinkTypeHref(ctx.SpaceID, "%v"), obj)
 			}
 			linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, hrefFunc, nil)
 			err = enrichLinkTypeList(linkCtx, appLinkTypes)

--- a/controller/workitemtype_blackbox_test.go
+++ b/controller/workitemtype_blackbox_test.go
@@ -152,7 +152,7 @@ func (s *workItemTypeSuite) createWorkItemTypeAnimal() (http.ResponseWriter, *ap
 	}
 
 	s.T().Log("Creating 'animal' work item type...")
-	responseWriter, wi := test.CreateWorkitemtypeCreated(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), &payload)
+	responseWriter, wi := test.CreateWorkitemtypeCreated(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, &payload)
 	require.NotNil(s.T(), wi)
 	require.NotNil(s.T(), wi.Data)
 	require.NotNil(s.T(), wi.Data.ID)
@@ -197,7 +197,7 @@ func (s *workItemTypeSuite) createWorkItemTypePerson() (http.ResponseWriter, *ap
 		},
 	}
 
-	responseWriter, wi := test.CreateWorkitemtypeCreated(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), &payload)
+	responseWriter, wi := test.CreateWorkitemtypeCreated(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, &payload)
 	require.NotNil(s.T(), wi)
 	require.NotNil(s.T(), wi.Data)
 	require.NotNil(s.T(), wi.Data.ID)
@@ -279,7 +279,7 @@ func (s *workItemTypeSuite) TestShowWorkItemType200OK() {
 	require.NotNil(s.T(), wit.Data)
 	require.NotNil(s.T(), wit.Data.ID)
 	// when
-	res, wit2 := test.ShowWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, wit.Data.Relationships.Space.Data.ID.String(), *wit.Data.ID, nil, nil)
+	res, wit2 := test.ShowWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, *wit.Data.Relationships.Space.Data.ID, *wit.Data.ID, nil, nil)
 	// then
 	require.NotNil(s.T(), wit2)
 	assert.EqualValues(s.T(), wit, wit2)
@@ -302,7 +302,7 @@ func (s *workItemTypeSuite) TestShowWorkItemType200UsingExpiredLastModifiedHeade
 	require.NotNil(s.T(), wit.Data.ID)
 	// when
 	lastModified := app.ToHTTPTime(time.Now().Add(-1 * time.Hour))
-	res, wit2 := test.ShowWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), *wit.Data.ID, &lastModified, nil)
+	res, wit2 := test.ShowWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, *wit.Data.ID, &lastModified, nil)
 	// then
 	require.NotNil(s.T(), wit2)
 	assert.EqualValues(s.T(), wit, wit2)
@@ -325,7 +325,7 @@ func (s *workItemTypeSuite) TestShowWorkItemType200UsingExpiredETagHeader() {
 	require.NotNil(s.T(), wit.Data.ID)
 	// when
 	etag := "foo"
-	res, wit2 := test.ShowWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, wit.Data.Relationships.Space.Data.ID.String(), *wit.Data.ID, nil, &etag)
+	res, wit2 := test.ShowWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, *wit.Data.Relationships.Space.Data.ID, *wit.Data.ID, nil, &etag)
 	// then
 	require.NotNil(s.T(), wit2)
 	assert.EqualValues(s.T(), wit, wit2)
@@ -348,7 +348,7 @@ func (s *workItemTypeSuite) TestShowWorkItemType304UsingIfModifiedSinceHeader() 
 	require.NotNil(s.T(), wit.Data.ID)
 	// when/then
 	lastModified := app.ToHTTPTime(wit.Data.Attributes.UpdatedAt.Add(1 * time.Second))
-	test.ShowWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, wit.Data.Relationships.Space.Data.ID.String(), *wit.Data.ID, &lastModified, nil)
+	test.ShowWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, *wit.Data.Relationships.Space.Data.ID, *wit.Data.ID, &lastModified, nil)
 }
 
 // TestShowWorkItemType304UsingIfNoneMatchHeader tests
@@ -362,7 +362,7 @@ func (s *workItemTypeSuite) TestShowWorkItemType304UsingIfNoneMatchHeader() {
 	require.NotNil(s.T(), wit.Data.ID)
 	// when/then
 	etag := generateWorkItemTypeTag(*wit)
-	test.ShowWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, wit.Data.Relationships.Space.Data.ID.String(), *wit.Data.ID, nil, &etag)
+	test.ShowWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, *wit.Data.Relationships.Space.Data.ID, *wit.Data.ID, nil, &etag)
 }
 
 // TestListWorkItemTypeOK200 tests if we can find the work item types
@@ -378,7 +378,7 @@ func (s *workItemTypeSuite) TestListWorkItemType200OK() {
 	// Fetch a single work item type
 	// Paging in the format <start>,<limit>"
 	page := "0,-1"
-	res, witCollection := test.ListWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), &page, nil, nil)
+	res, witCollection := test.ListWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, &page, nil, nil)
 	// then
 	require.NotNil(s.T(), witCollection)
 	require.Nil(s.T(), witCollection.Validate())
@@ -407,7 +407,7 @@ func (s *workItemTypeSuite) TestListWorkItemType200UsingExpiredIfModifiedSinceHe
 	// Paging in the format <start>,<limit>"
 	lastModified := app.ToHTTPTime(time.Now().Add(-1 * time.Hour))
 	page := "0,-1"
-	res, witCollection := test.ListWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), &page, &lastModified, nil)
+	res, witCollection := test.ListWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, &page, &lastModified, nil)
 	// then
 	require.NotNil(s.T(), witCollection)
 	require.Nil(s.T(), witCollection.Validate())
@@ -435,7 +435,7 @@ func (s *workItemTypeSuite) TestListWorkItemType200UsingExpiredIfNoneMatchHeader
 	// Paging in the format <start>,<limit>"
 	etag := "foo"
 	page := "0,-1"
-	res, witCollection := test.ListWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), &page, nil, &etag)
+	res, witCollection := test.ListWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, &page, nil, &etag)
 	// then
 	require.NotNil(s.T(), witCollection)
 	require.Nil(s.T(), witCollection.Validate())
@@ -463,7 +463,7 @@ func (s *workItemTypeSuite) TestListWorkItemType304UsingIfModifiedSinceHeader() 
 	// Paging in the format <start>,<limit>"
 	lastModified := app.ToHTTPTime(getWorkItemTypeUpdatedAt(*witPerson))
 	page := "0,-1"
-	test.ListWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), &page, &lastModified, nil)
+	test.ListWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, &page, &lastModified, nil)
 }
 
 // TestListWorkItemType304UsingIfNoneMatchHeader tests if we can find the work item types
@@ -477,12 +477,12 @@ func (s *workItemTypeSuite) TestListWorkItemType304UsingIfNoneMatchHeader() {
 	require.NotNil(s.T(), witPerson)
 	// Paging in the format <start>,<limit>"
 	page := "0,-1"
-	_, witCollection := test.ListWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), &page, nil, nil)
+	_, witCollection := test.ListWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, &page, nil, nil)
 	require.NotNil(s.T(), witCollection)
 	// when/then
 	// Fetch a single work item type
 	ifNoneMatch := generateWorkItemTypesTag(*witCollection)
-	test.ListWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), &page, nil, &ifNoneMatch)
+	test.ListWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, &page, nil, &ifNoneMatch)
 }
 
 //-----------------------------------------------------------------------------
@@ -512,12 +512,12 @@ func (s *workItemTypeSuite) createWorkitemtypeLinks() (app.WorkItemLinkTypeSingl
 	s.T().Log("Created space")
 	// Create work item link type
 	linkTypePayload := CreateWorkItemLinkType(animalLinksToBugStr, animalID, workitem.SystemBug, *linkCat.Data.ID, *sp.Data.ID)
-	_, sourceLinkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, sp.Data.ID.String(), linkTypePayload)
+	_, sourceLinkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, *sp.Data.ID, linkTypePayload)
 	require.NotNil(s.T(), sourceLinkType)
 	s.T().Log("Created work item source link")
 	// Create another work item link type
 	linkTypePayload = CreateWorkItemLinkType(bugLinksToAnimalStr, workitem.SystemBug, animalID, *linkCat.Data.ID, *sp.Data.ID)
-	_, targetLinkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, sp.Data.ID.String(), linkTypePayload)
+	_, targetLinkType := test.CreateWorkItemLinkTypeCreated(s.T(), s.svc.Context, s.svc, s.linkTypeCtrl, *sp.Data.ID, linkTypePayload)
 	require.NotNil(s.T(), targetLinkType)
 	s.T().Log("Created work item target link")
 	return *sourceLinkType, *targetLinkType
@@ -529,7 +529,7 @@ func (s *workItemTypeSuite) TestListWorkItemLinkTypeSources200OK() {
 	// given
 	sourceLinkType, _ := s.createWorkitemtypeLinks()
 	// when fetch source link types
-	res, wiltCollection := test.ListSourceLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), animalID, nil, nil)
+	res, wiltCollection := test.ListSourceLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, animalID, nil, nil)
 	require.NotNil(s.T(), wiltCollection)
 	assert.Nil(s.T(), wiltCollection.Validate())
 	// then check the number of found work item link types
@@ -549,7 +549,7 @@ func (s *workItemTypeSuite) TestListWorkItemLinkTypeTargets200OK() {
 	// given
 	_, targetLinkType := s.createWorkitemtypeLinks()
 	// When fetch target link types
-	res, wiltCollection := test.ListTargetLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), animalID, nil, nil)
+	res, wiltCollection := test.ListTargetLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, animalID, nil, nil)
 	require.NotNil(s.T(), wiltCollection)
 	assert.Nil(s.T(), wiltCollection.Validate())
 	// Then check the number of found work item link types
@@ -570,7 +570,7 @@ func (s *workItemTypeSuite) TestListSourceLinkTypes200UsingExpiredIfModifiedSinc
 	sourceLinkType, _ := s.createWorkitemtypeLinks()
 	// when fetch source link types
 	ifModifiedSince := app.ToHTTPTime(sourceLinkType.Data.Attributes.UpdatedAt.Add(-1 * time.Hour))
-	res, wiltCollection := test.ListSourceLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), animalID, &ifModifiedSince, nil)
+	res, wiltCollection := test.ListSourceLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, animalID, &ifModifiedSince, nil)
 	require.NotNil(s.T(), wiltCollection)
 	assert.Nil(s.T(), wiltCollection.Validate())
 	// then check the number of found work item link types
@@ -591,7 +591,7 @@ func (s *workItemTypeSuite) TestListTargetLinkTypes200UsingExpiredIfModifiedSinc
 	_, targetLinkType := s.createWorkitemtypeLinks()
 	// When fetch target link types
 	ifModifiedSince := app.ToHTTPTime(targetLinkType.Data.Attributes.UpdatedAt.Add(-1 * time.Hour))
-	res, wiltCollection := test.ListTargetLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), animalID, &ifModifiedSince, nil)
+	res, wiltCollection := test.ListTargetLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, animalID, &ifModifiedSince, nil)
 	require.NotNil(s.T(), wiltCollection)
 	assert.Nil(s.T(), wiltCollection.Validate())
 	// Then check the number of found work item link types
@@ -612,7 +612,7 @@ func (s *workItemTypeSuite) TestListSourceLinkTypes200UsingExpiredIfNoneMatchHea
 	sourceLinkType, _ := s.createWorkitemtypeLinks()
 	// when fetch source link types
 	ifNoneMatch := "foo"
-	res, wiltCollection := test.ListSourceLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), animalID, nil, &ifNoneMatch)
+	res, wiltCollection := test.ListSourceLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, animalID, nil, &ifNoneMatch)
 	require.NotNil(s.T(), wiltCollection)
 	assert.Nil(s.T(), wiltCollection.Validate())
 	// then check the number of found work item link types
@@ -633,7 +633,7 @@ func (s *workItemTypeSuite) TestListTargetLinkTypes200UsingExpiredIfNoneMatchHea
 	_, targetLinkType := s.createWorkitemtypeLinks()
 	// When fetch target link types
 	ifNoneMatch := "foo"
-	res, wiltCollection := test.ListTargetLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), animalID, nil, &ifNoneMatch)
+	res, wiltCollection := test.ListTargetLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, animalID, nil, &ifNoneMatch)
 	require.NotNil(s.T(), wiltCollection)
 	assert.Nil(s.T(), wiltCollection.Validate())
 	// Then check the number of found work item link types
@@ -654,7 +654,7 @@ func (s *workItemTypeSuite) TestListSourceLinkTypes304UsingIfModifiedSinceHeader
 	sourceLinkType, _ := s.createWorkitemtypeLinks()
 	// when/then
 	ifModifiedSince := app.ToHTTPTime(getWorkItemLinkTypeUpdatedAt(sourceLinkType))
-	test.ListSourceLinkTypesWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), animalID, &ifModifiedSince, nil)
+	test.ListSourceLinkTypesWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, animalID, &ifModifiedSince, nil)
 }
 
 // TestListTargetLinkTypes200UsingExpiredIfModifiedSinceHeader tests if we can find the work item link
@@ -664,7 +664,7 @@ func (s *workItemTypeSuite) TestListTargetLinkTypes304UsingIfModifiedSinceHeader
 	_, targetLinkType := s.createWorkitemtypeLinks()
 	// When fetch target link types
 	ifModifiedSince := app.ToHTTPTime(getWorkItemLinkTypeUpdatedAt(targetLinkType))
-	test.ListTargetLinkTypesWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), animalID, &ifModifiedSince, nil)
+	test.ListTargetLinkTypesWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, animalID, &ifModifiedSince, nil)
 }
 
 // TestListSourceLinkTypes200UsingExpiredIfNoneMatchHeader tests if we can find the work item link
@@ -674,7 +674,7 @@ func (s *workItemTypeSuite) TestListSourceLinkTypes304UsingIfNoneMatchHeader() {
 	sourceLinkType, _ := s.createWorkitemtypeLinks()
 	// when fetch source link types
 	ifNoneMatch := generateWorkItemLinkTypeTag(sourceLinkType)
-	test.ListSourceLinkTypesWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), animalID, nil, &ifNoneMatch)
+	test.ListSourceLinkTypesWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, animalID, nil, &ifNoneMatch)
 }
 
 // TestListTargetLinkTypes304UsingIfNoneMatchHeader tests if we can find the work item link
@@ -684,7 +684,7 @@ func (s *workItemTypeSuite) TestListTargetLinkTypes304UsingIfNoneMatchHeader() {
 	_, targetLinkType := s.createWorkitemtypeLinks()
 	// When fetch target link types
 	ifNoneMatch := generateWorkItemLinkTypeTag(targetLinkType)
-	test.ListTargetLinkTypesWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), animalID, nil, &ifNoneMatch)
+	test.ListTargetLinkTypesWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, animalID, nil, &ifNoneMatch)
 }
 
 // TestListSourceAndTargetLinkTypesEmpty tests that no link type is returned for
@@ -693,12 +693,12 @@ func (s *workItemTypeSuite) TestListSourceAndTargetLinkTypesEmpty() {
 	_, witPerson := s.createWorkItemTypePerson()
 	require.NotNil(s.T(), witPerson)
 
-	_, wiltCollection := test.ListSourceLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), personID, nil, nil)
+	_, wiltCollection := test.ListSourceLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, personID, nil, nil)
 	require.NotNil(s.T(), wiltCollection)
 	require.Nil(s.T(), wiltCollection.Validate())
 	require.Len(s.T(), wiltCollection.Data, 0)
 
-	_, wiltCollection = test.ListTargetLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), personID, nil, nil)
+	_, wiltCollection = test.ListTargetLinkTypesWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, personID, nil, nil)
 	require.NotNil(s.T(), wiltCollection)
 	require.Nil(s.T(), wiltCollection.Validate())
 	require.Len(s.T(), wiltCollection.Data, 0)
@@ -707,10 +707,10 @@ func (s *workItemTypeSuite) TestListSourceAndTargetLinkTypesEmpty() {
 // TestListSourceAndTargetLinkTypesNotFound tests that a NotFound error is
 // returned when you query a non existing WIT.
 func (s *workItemTypeSuite) TestListSourceAndTargetLinkTypesNotFound() {
-	_, jerrors := test.ListSourceLinkTypesWorkitemtypeNotFound(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), uuid.Nil, nil, nil)
+	_, jerrors := test.ListSourceLinkTypesWorkitemtypeNotFound(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, uuid.Nil, nil, nil)
 	require.NotNil(s.T(), jerrors)
 
-	_, jerrors = test.ListTargetLinkTypesWorkitemtypeNotFound(s.T(), nil, nil, s.typeCtrl, space.SystemSpace.String(), uuid.Nil, nil, nil)
+	_, jerrors = test.ListTargetLinkTypesWorkitemtypeNotFound(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, uuid.Nil, nil, nil)
 	require.NotNil(s.T(), jerrors)
 }
 
@@ -832,14 +832,14 @@ func (s *workItemTypeSuite) getWorkItemTypeTestDataFunc() func(*testing.T) []tes
 				jwtToken:           "",
 			}, {
 				method:             http.MethodGet,
-				url:                fmt.Sprintf(endpointWorkItemTypesSourceLinkTypes, space.SystemSpace.String(), "2e889d4e-49a9-463b-8cd4-6a3a95155103"),
+				url:                fmt.Sprintf(endpointWorkItemTypesSourceLinkTypes, space.SystemSpace, "2e889d4e-49a9-463b-8cd4-6a3a95155103"),
 				expectedStatusCode: http.StatusNotFound,
 				expectedErrorCode:  jsonapi.ErrorCodeNotFound,
 				payload:            nil,
 				jwtToken:           "",
 			}, {
 				method:             http.MethodGet,
-				url:                fmt.Sprintf(endpointWorkItemTypesTargetLinkTypes, space.SystemSpace.String(), "2e889d4e-49a9-463b-8cd4-6a3a95155103"),
+				url:                fmt.Sprintf(endpointWorkItemTypesTargetLinkTypes, space.SystemSpace, "2e889d4e-49a9-463b-8cd4-6a3a95155103"),
 				expectedStatusCode: http.StatusNotFound,
 				expectedErrorCode:  jsonapi.ErrorCodeNotFound,
 				payload:            nil,

--- a/design/spaces.go
+++ b/design/spaces.go
@@ -115,11 +115,11 @@ var _ = a.Resource("space", func() {
 
 	a.Action("show", func() {
 		a.Routing(
-			a.GET("/:id"),
+			a.GET("/:spaceID"),
 		)
 		a.Description("Retrieve space (as JSONAPI) for the given ID.")
 		a.Params(func() {
-			a.Param("id", d.String, "ID of the space")
+			a.Param("spaceID", d.UUID, "ID of the space")
 		})
 		a.UseTrait("conditional")
 		a.Response(d.OK, spaceSingle)
@@ -163,11 +163,11 @@ var _ = a.Resource("space", func() {
 	a.Action("delete", func() {
 		a.Security("jwt")
 		a.Routing(
-			a.DELETE("/:id"),
+			a.DELETE("/:spaceID"),
 		)
-		a.Description("Delete a space with given id.")
+		a.Description("Delete a space with the given ID.")
 		a.Params(func() {
-			a.Param("id", d.String, "id")
+			a.Param("spaceID", d.UUID, "ID of the space to delete")
 		})
 		a.Response(d.OK)
 		a.Response(d.BadRequest, JSONAPIErrors)
@@ -179,11 +179,11 @@ var _ = a.Resource("space", func() {
 	a.Action("update", func() {
 		a.Security("jwt")
 		a.Routing(
-			a.PATCH("/:id"),
+			a.PATCH("/:spaceID"),
 		)
-		a.Description("Update the space with given id.")
+		a.Description("Update the space with the given ID.")
 		a.Params(func() {
-			a.Param("id", d.String, "id")
+			a.Param("spaceID", d.UUID, "ID of the space to update")
 		})
 		a.Payload(spaceSingle)
 		a.Response(d.OK, func() {

--- a/design/work_item_link_type.go
+++ b/design/work_item_link_type.go
@@ -155,11 +155,11 @@ var _ = a.Resource("work_item_link_type", func() {
 
 	a.Action("show", func() {
 		a.Routing(
-			a.GET("/:wiltId"),
+			a.GET("/:wiltID"),
 		)
 		a.Description("Retrieve work item link type (as JSONAPI) for the given link ID.")
 		a.Params(func() {
-			a.Param("id", d.UUID, "ID of the work item link type")
+			a.Param("wiltID", d.UUID, "ID of the work item link type")
 		})
 		a.UseTrait("conditional")
 		a.Response(d.OK, workItemLinkType)
@@ -199,11 +199,11 @@ var _ = a.Resource("work_item_link_type", func() {
 	a.Action("delete", func() {
 		a.Security("jwt")
 		a.Routing(
-			a.DELETE("/:wiltId"),
+			a.DELETE("/:wiltID"),
 		)
 		a.Description("Delete work item link type with given id.")
 		a.Params(func() {
-			a.Param("wiltId", d.UUID, "wiltId")
+			a.Param("wiltID", d.UUID, "wiltID")
 		})
 		a.Response(d.OK)
 		a.Response(d.BadRequest, JSONAPIErrors)
@@ -215,11 +215,11 @@ var _ = a.Resource("work_item_link_type", func() {
 	a.Action("update", func() {
 		a.Security("jwt")
 		a.Routing(
-			a.PATCH("/:wiltId"),
+			a.PATCH("/:wiltID"),
 		)
 		a.Description("Update the given work item link type with given id.")
 		a.Params(func() {
-			a.Param("wiltId", d.UUID, "wiltId")
+			a.Param("wiltID", d.UUID, "wiltID")
 		})
 		a.Payload(updateWorkItemLinkTypePayload)
 		a.Response(d.OK, workItemLinkType)
@@ -235,10 +235,10 @@ var _ = a.Resource("redirect_work_item_link_type", func() {
 
 	a.Action("show", func() {
 		a.Routing(
-			a.GET("/:wiltId"),
+			a.GET("/:wiltID"),
 		)
 		a.Params(func() {
-			a.Param("wiltId", d.UUID, "ID of the work item link type")
+			a.Param("wiltID", d.UUID, "ID of the work item link type")
 		})
 		a.Response(d.MovedPermanently)
 	})
@@ -259,20 +259,20 @@ var _ = a.Resource("redirect_work_item_link_type", func() {
 
 	a.Action("delete", func() {
 		a.Routing(
-			a.DELETE("/:wiltId"),
+			a.DELETE("/:wiltID"),
 		)
 		a.Params(func() {
-			a.Param("wiltId", d.UUID, "wiltId")
+			a.Param("wiltID", d.UUID, "wiltID")
 		})
 		a.Response(d.MovedPermanently)
 	})
 
 	a.Action("update", func() {
 		a.Routing(
-			a.PATCH("/:wiltId"),
+			a.PATCH("/:wiltID"),
 		)
 		a.Params(func() {
-			a.Param("wiltId", d.UUID, "wiltId")
+			a.Param("wiltID", d.UUID, "wiltID")
 		})
 		a.Response(d.MovedPermanently)
 	})


### PR DESCRIPTION
Also renamed the URL parameter to `SpaceID` to make it more expressive when used in the controllers (especially for endpoints that are children of `/space`)

Fixes #1326

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
