### PR TITLE
Rename space name duplicate to space_name-renamed

### DIFF
--- a/migration/sql-files/061-replace-index-space-name.sql
+++ b/migration/sql-files/061-replace-index-space-name.sql
@@ -1,4 +1,14 @@
 -- drop existing unique index
 DROP INDEX spaces_name_idx;
+-- rename duplicate spaces in existence and keep only one as it was
+UPDATE spaces SET name = CONCAT(lower(name), '-renamed')
+WHERE id IN (
+    SELECT id
+    FROM (
+        SELECT id, ROW_NUMBER() OVER (partition BY owner_id, lower(name) ORDER BY id) AS rnum
+        FROM spaces
+    ) t
+    WHERE t.rnum > 1
+);
 -- recreate unique index with original index and lowercase name, on two columns
 CREATE UNIQUE INDEX spaces_name_idx ON spaces (owner_id, lower(name)) WHERE deleted_at IS NULL;

--- a/migration/sql-test-files/061-add-duplicate-space-owner-name.sql
+++ b/migration/sql-test-files/061-add-duplicate-space-owner-name.sql
@@ -1,0 +1,8 @@
+--- added a duplicate space with the same owner and name than a previous one
+INSERT INTO
+   spaces (created_at, updated_at, id, version, name, description, owner_id)
+VALUES
+   (
+      now(), now(), '86af5178-9b41-469b-9096-57e5155c3f32', 0, 'test.Space.one', 'Space desc one', '01b291cd-9399-4f1a-8bbc-d1de66d76192'
+   )
+;


### PR DESCRIPTION
Fixed a problem in production due to duplicated space names when we lower case the space name
