### PR TITLE
Ooe search api

### DIFF
--- a/search/search_repository_blackbox_test.go
+++ b/search/search_repository_blackbox_test.go
@@ -103,12 +103,15 @@ func (s *searchRepositoryBlackboxTest) TestRestrictByType() {
 	res, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType", nil, nil, nil)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), uint64(2), count)
+	assert.Equal(s.T(), res[0].Fields["system.order"], wi2.Fields["system.order"])
+	assert.Equal(s.T(), res[1].Fields["system.order"], wi1.Fields["system.order"])
 
 	res, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType type:"+sub1.ID.String(), nil, nil, nil)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), uint64(1), count)
 	if count == 1 {
 		assert.Equal(s.T(), wi1.ID, res[0].ID)
+		assert.Equal(s.T(), res[0].Fields["system.order"], wi1.Fields["system.order"])
 	}
 
 	res, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType type:"+sub2.ID.String(), nil, nil, nil)
@@ -116,19 +119,26 @@ func (s *searchRepositoryBlackboxTest) TestRestrictByType() {
 	assert.Equal(s.T(), uint64(1), count)
 	if count == 1 {
 		assert.Equal(s.T(), wi2.ID, res[0].ID)
+		assert.Equal(s.T(), res[0].Fields["system.order"], wi2.Fields["system.order"])
 	}
 
-	_, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType type:"+base.ID.String(), nil, nil, nil)
+	res, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType type:"+base.ID.String(), nil, nil, nil)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), uint64(2), count)
+	assert.Equal(s.T(), res[0].Fields["system.order"], wi2.Fields["system.order"])
+	assert.Equal(s.T(), res[1].Fields["system.order"], wi1.Fields["system.order"])
 
-	_, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType type:"+sub2.ID.String()+" type:"+sub1.ID.String(), nil, nil, nil)
+	res, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType type:"+sub2.ID.String()+" type:"+sub1.ID.String(), nil, nil, nil)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), uint64(2), count)
+	assert.Equal(s.T(), res[0].Fields["system.order"], wi2.Fields["system.order"])
+	assert.Equal(s.T(), res[1].Fields["system.order"], wi1.Fields["system.order"])
 
-	_, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType type:"+base.ID.String()+" type:"+sub1.ID.String(), nil, nil, nil)
+	res, count, err = s.searchRepo.SearchFullText(ctx, "TestRestrictByType type:"+base.ID.String()+" type:"+sub1.ID.String(), nil, nil, nil)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), uint64(2), count)
+	assert.Equal(s.T(), res[0].Fields["system.order"], wi2.Fields["system.order"])
+	assert.Equal(s.T(), res[1].Fields["system.order"], wi1.Fields["system.order"])
 
 	_, count, err = s.searchRepo.SearchFullText(ctx, "TRBTgorxi type:"+base.ID.String(), nil, nil, nil)
 	assert.Nil(s.T(), err)

--- a/workitem/workitemtype.go
+++ b/workitem/workitemtype.go
@@ -180,6 +180,7 @@ func (wit WorkItemType) ConvertWorkItemStorageToModel(workItem WorkItemStorage) 
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
+		result.Fields[SystemOrder] = workItem.ExecutionOrder
 	}
 
 	return &result, nil


### PR DESCRIPTION
* Fixes #1353
* Search api returns null value for system.order. This patch aims to fix the issue and return proper expected value of system.order for that workitem.