### PR TITLE
Fix remote tests after upgrading Keycloak

### DIFF
--- a/auth/authz_blackbox_test.go
+++ b/auth/authz_blackbox_test.go
@@ -441,6 +441,7 @@ func getUserID(t *testing.T, username string, usersecret string) string {
 	testToken, err := controller.GenerateUserToken(ctx, tokenEndpoint, configuration, username, usersecret)
 	require.Nil(t, err)
 	accessToken := testToken.Token.AccessToken
+	require.NotNil(t, accessToken)
 	userinfo, err := auth.GetUserInfo(ctx, userinfoEndpoint, *accessToken)
 	require.Nil(t, err)
 	userID := userinfo.Sub

--- a/auth/policy_blackbox_test.go
+++ b/auth/policy_blackbox_test.go
@@ -52,7 +52,8 @@ func (s *TestPolicySuite) TestGetPolicyOK() {
 
 func (s *TestPolicySuite) TestUpdatePolicyOK() {
 	policy, policyID := createPermissionWithPolicy(s)
-	policy.AddUserToPolicy(uuid.NewV4().String())
+	secondTestUserID := getUserID(s.T(), configuration.GetKeycloakTestUser2Name(), configuration.GetKeycloakTestUser2Secret())
+	policy.RemoveUserFromPolicy(secondTestUserID)
 	policy.ID = &policyID
 	r := &goa.RequestData{
 		Request: &http.Request{Host: "domain.io"},


### PR DESCRIPTION
We upgraded our KC to 3.2.0.CR1-SNAPSHOT in prod-preview and there are some minor changes which affect our remote tests. We can't now add unknown users to policies. KC will reject it.
