### PR TITLE
 Update username on re-login

### DIFF
--- a/login/service.go
+++ b/login/service.go
@@ -666,29 +666,38 @@ func (keycloak *KeycloakOAuthProvider) CreateOrUpdateKeycloakUser(accessToken st
 		}
 		user = new(account.User)
 		identity = &account.Identity{}
-		fillUser(claims, user, identity)
-		err = application.Transactional(keycloak.db, func(appl application.Application) error {
-			err := appl.Users().Create(ctx, user)
-			if err != nil {
-				return err
-			}
-
-			identity.ID = keycloakIdentityID
-			identity.ProviderType = account.KeycloakIDP
-			identity.UserID = account.NullUUID{UUID: user.ID, Valid: true}
-			identity.User = *user
-
-			err = appl.Identities().Create(ctx, identity)
-			return err
-		})
+		isChanged, err := fillUser(claims, user, identity)
 		if err != nil {
 			log.Error(ctx, map[string]interface{}{
 				"keycloak_identity_id": keycloakIdentityID,
-				"username":             claims.Username,
-				"err":                  err,
+				"err": err,
 			}, "unable to create user/identity")
-			return nil, nil, errors.New("Cant' create user/identity " + err.Error())
+			return nil, nil, errors.New("Cant' update user/identity from claims" + err.Error())
+		} else if isChanged {
+			err = application.Transactional(keycloak.db, func(appl application.Application) error {
+				err := appl.Users().Create(ctx, user)
+				if err != nil {
+					return err
+				}
+
+				identity.ID = keycloakIdentityID
+				identity.ProviderType = account.KeycloakIDP
+				identity.UserID = account.NullUUID{UUID: user.ID, Valid: true}
+				identity.User = *user
+
+				err = appl.Identities().Create(ctx, identity)
+				return err
+			})
+			if err != nil {
+				log.Error(ctx, map[string]interface{}{
+					"keycloak_identity_id": keycloakIdentityID,
+					"username":             claims.Username,
+					"err":                  err,
+				}, "unable to create user/identity")
+				return nil, nil, errors.New("Cant' create user/identity " + err.Error())
+			}
 		}
+
 	} else {
 		identity = &identities[0]
 		user = &identity.User
@@ -700,33 +709,41 @@ func (keycloak *KeycloakOAuthProvider) CreateOrUpdateKeycloakUser(accessToken st
 		}
 		// let's update the existing user with the fullname, email and avatar from Keycloak,
 		// in case the user changed them since the last time he/she logged in
-		fillUser(claims, user, identity)
-		err = application.Transactional(keycloak.db, func(appl application.Application) error {
-			err = appl.Users().Save(ctx, user)
-			if err != nil {
-				log.Error(ctx, map[string]interface{}{
-					"user_id": user.ID,
-					"err":     err,
-				}, "unable to update user")
-				return errors.New("Cant' update user " + err.Error())
-			}
-			err = appl.Identities().Save(ctx, identity)
-			if err != nil {
-				log.Error(ctx, map[string]interface{}{
-					"user_id": identity.ID,
-					"err":     err,
-				}, "unable to update identity")
-				return errors.New("Cant' update identity " + err.Error())
-			}
-			return err
-		})
+		isChanged, err := fillUser(claims, user, identity)
 		if err != nil {
 			log.Error(ctx, map[string]interface{}{
 				"keycloak_identity_id": keycloakIdentityID,
-				"username":             claims.Username,
-				"err":                  err,
-			}, "unable to update user/identity")
-			return nil, nil, errors.New("Cant' update user/identity " + err.Error())
+				"err": err,
+			}, "unable to create user/identity")
+			return nil, nil, errors.New("Cant' update user/identity from claims" + err.Error())
+		} else if isChanged {
+			err = application.Transactional(keycloak.db, func(appl application.Application) error {
+				err = appl.Users().Save(ctx, user)
+				if err != nil {
+					log.Error(ctx, map[string]interface{}{
+						"user_id": user.ID,
+						"err":     err,
+					}, "unable to update user")
+					return errors.New("Cant' update user " + err.Error())
+				}
+				err = appl.Identities().Save(ctx, identity)
+				if err != nil {
+					log.Error(ctx, map[string]interface{}{
+						"user_id": identity.ID,
+						"err":     err,
+					}, "unable to update identity")
+					return errors.New("Cant' update identity " + err.Error())
+				}
+				return err
+			})
+			if err != nil {
+				log.Error(ctx, map[string]interface{}{
+					"keycloak_identity_id": keycloakIdentityID,
+					"username":             claims.Username,
+					"err":                  err,
+				}, "unable to update user/identity")
+				return nil, nil, errors.New("Cant' update user/identity " + err.Error())
+			}
 		}
 	}
 	return identity, user, nil
@@ -826,7 +843,13 @@ func checkClaims(claims *keycloakTokenClaims) error {
 	return nil
 }
 
-func fillUser(claims *keycloakTokenClaims, user *account.User, identity *account.Identity) error {
+func fillUser(claims *keycloakTokenClaims, user *account.User, identity *account.Identity) (bool, error) {
+	isChanged := false
+	if user.FullName != claims.Name || user.Email != claims.Email || user.Company != claims.Company || identity.Username != claims.Username || user.ImageURL == "" {
+		isChanged = true
+	} else {
+		return isChanged, nil
+	}
 	user.FullName = claims.Name
 	user.Email = claims.Email
 	user.Company = claims.Company
@@ -838,11 +861,12 @@ func fillUser(claims *keycloakTokenClaims, user *account.User, identity *account
 				"user_full_name": user.FullName,
 				"err":            err,
 			}, "error when generating gravatar")
-			return errors.New("Error when generating gravatar " + err.Error())
+			// if there is an error, we will qualify the identity/user as unchanged.
+			return false, errors.New("Error when generating gravatar " + err.Error())
 		}
 		user.ImageURL = image
 	}
-	return nil
+	return isChanged, nil
 }
 
 // ContextIdentity returns the identity's ID found in given context

--- a/login/service.go
+++ b/login/service.go
@@ -672,12 +672,12 @@ func (keycloak *KeycloakOAuthProvider) CreateOrUpdateKeycloakUser(accessToken st
 			if err != nil {
 				return err
 			}
-			identity = &account.Identity{
-				ID:           keycloakIdentityID,
-				Username:     claims.Username,
-				ProviderType: account.KeycloakIDP,
-				UserID:       account.NullUUID{UUID: user.ID, Valid: true},
-				User:         *user}
+
+			identity.ID = keycloakIdentityID
+			identity.ProviderType = account.KeycloakIDP
+			identity.UserID = account.NullUUID{UUID: user.ID, Valid: true}
+			identity.User = *user
+
 			err = appl.Identities().Create(ctx, identity)
 			return err
 		})

--- a/login/service.go
+++ b/login/service.go
@@ -709,6 +709,15 @@ func (keycloak *KeycloakOAuthProvider) CreateOrUpdateKeycloakUser(accessToken st
 			}, "unable to update user")
 			return nil, nil, errors.New("Cant' update user " + err.Error())
 		}
+		err = keycloak.Identities.Save(ctx, identity)
+		if err != nil {
+			log.Error(ctx, map[string]interface{}{
+				"user_id": identity.ID,
+				"err":     err,
+			}, "unable to update identity")
+			return nil, nil, errors.New("Cant' update identity " + err.Error())
+		}
+
 	}
 	return identity, user, nil
 }

--- a/login/service.go
+++ b/login/service.go
@@ -725,8 +725,8 @@ func (keycloak *KeycloakOAuthProvider) CreateOrUpdateKeycloakUser(accessToken st
 				"keycloak_identity_id": keycloakIdentityID,
 				"username":             claims.Username,
 				"err":                  err,
-			}, "unable to create user/identity")
-			return nil, nil, errors.New("Cant' create user/identity " + err.Error())
+			}, "unable to update user/identity")
+			return nil, nil, errors.New("Cant' update user/identity " + err.Error())
 		}
 	}
 	return identity, user, nil

--- a/login/service.go
+++ b/login/service.go
@@ -672,7 +672,7 @@ func (keycloak *KeycloakOAuthProvider) CreateOrUpdateKeycloakUser(accessToken st
 				"keycloak_identity_id": keycloakIdentityID,
 				"err": err,
 			}, "unable to create user/identity")
-			return nil, nil, errors.New("Cant' update user/identity from claims" + err.Error())
+			return nil, nil, errors.New("failed to update user/identity from claims" + err.Error())
 		}
 		err = application.Transactional(keycloak.db, func(appl application.Application) error {
 			err := appl.Users().Create(ctx, user)
@@ -694,7 +694,7 @@ func (keycloak *KeycloakOAuthProvider) CreateOrUpdateKeycloakUser(accessToken st
 				"username":             claims.Username,
 				"err":                  err,
 			}, "unable to create user/identity")
-			return nil, nil, errors.New("Cant' create user/identity " + err.Error())
+			return nil, nil, errors.New("failed to create user/identity " + err.Error())
 		}
 
 	} else {
@@ -714,7 +714,7 @@ func (keycloak *KeycloakOAuthProvider) CreateOrUpdateKeycloakUser(accessToken st
 				"keycloak_identity_id": keycloakIdentityID,
 				"err": err,
 			}, "unable to create user/identity")
-			return nil, nil, errors.New("Cant' update user/identity from claims" + err.Error())
+			return nil, nil, errors.New("failed to update user/identity from claims" + err.Error())
 		} else if isChanged {
 			err = application.Transactional(keycloak.db, func(appl application.Application) error {
 				err = appl.Users().Save(ctx, user)
@@ -723,7 +723,7 @@ func (keycloak *KeycloakOAuthProvider) CreateOrUpdateKeycloakUser(accessToken st
 						"user_id": user.ID,
 						"err":     err,
 					}, "unable to update user")
-					return errors.New("Cant' update user " + err.Error())
+					return errors.New("failed to update user " + err.Error())
 				}
 				err = appl.Identities().Save(ctx, identity)
 				if err != nil {
@@ -731,7 +731,7 @@ func (keycloak *KeycloakOAuthProvider) CreateOrUpdateKeycloakUser(accessToken st
 						"user_id": identity.ID,
 						"err":     err,
 					}, "unable to update identity")
-					return errors.New("Cant' update identity " + err.Error())
+					return errors.New("failed to update identity " + err.Error())
 				}
 				return err
 			})
@@ -741,7 +741,7 @@ func (keycloak *KeycloakOAuthProvider) CreateOrUpdateKeycloakUser(accessToken st
 					"username":             claims.Username,
 					"err":                  err,
 				}, "unable to update user/identity")
-				return nil, nil, errors.New("Cant' update user/identity " + err.Error())
+				return nil, nil, errors.New("failed to update user/identity " + err.Error())
 			}
 		}
 	}

--- a/login/service_whitebox_test.go
+++ b/login/service_whitebox_test.go
@@ -275,8 +275,9 @@ func TestFillUserDoesntOverwriteExistingImageURL(t *testing.T) {
 	user := &account.User{FullName: "Vasya Pupkin", Company: "Red Hat", Email: "vpupkin@mail.io", ImageURL: "http://vpupkin.io/image.jpg"}
 	identity := &account.Identity{Username: "vaysa"}
 	claims := &keycloakTokenClaims{Username: "new username", Name: "new name", Company: "new company", Email: "new email"}
-	err := fillUser(claims, user, identity)
+	isChanged, err := fillUser(claims, user, identity)
 	require.Nil(t, err)
+	require.True(t, isChanged)
 	assert.Equal(t, "new name", user.FullName)
 	assert.Equal(t, "new company", user.Company)
 	assert.Equal(t, "new email", user.Email)

--- a/login/service_whitebox_test.go
+++ b/login/service_whitebox_test.go
@@ -273,12 +273,14 @@ func TestFillUserDoesntOverwriteExistingImageURL(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 
 	user := &account.User{FullName: "Vasya Pupkin", Company: "Red Hat", Email: "vpupkin@mail.io", ImageURL: "http://vpupkin.io/image.jpg"}
-	claims := &keycloakTokenClaims{Name: "new name", Company: "new company", Email: "new email"}
-	err := fillUser(claims, user)
+	identity := &account.Identity{Username: "vaysa"}
+	claims := &keycloakTokenClaims{Username: "new username", Name: "new name", Company: "new company", Email: "new email"}
+	err := fillUser(claims, user, identity)
 	require.Nil(t, err)
 	assert.Equal(t, "new name", user.FullName)
 	assert.Equal(t, "new company", user.Company)
 	assert.Equal(t, "new email", user.Email)
+	assert.Equal(t, "new username", identity.Username)
 	assert.Equal(t, "http://vpupkin.io/image.jpg", user.ImageURL)
 }
 


### PR DESCRIPTION
fixes https://github.com/almighty/almighty-core/issues/1366 
related to https://github.com/fabric8io/fabric8-ui/issues/1442

- tested on sso.prod-preview
- updated username in kc.
- re-logged in ( localhost )
- new username showed up as required.