### PR TITLE
Add new property to the config map for auth_notapproved_redirect

### DIFF
--- a/openshift/core.config.yaml
+++ b/openshift/core.config.yaml
@@ -29,3 +29,4 @@ objects:
     chestarter.url: http://che-starter:10000
     redirect.valid: ".*"
     openshift.tenant.masterurl: https://openshift.local/
+    auth_notapproved_redirect: ""


### PR DESCRIPTION
Our current template uses a property that doesn't exist in the config map, that will fail the pod on starting.

FYI: @vpavlin 
