### PR TITLE
Use "context" instead of "golang.org/x/net/context"

### DIFF
--- a/account/identity.go
+++ b/account/identity.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/log"
@@ -13,7 +14,6 @@ import (
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/account/identity_blackbox_test.go
+++ b/account/identity_blackbox_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/almighty/almighty-core/gormtestsupport"
 	"github.com/almighty/almighty-core/migration"
 
+	"context"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 type identityBlackBoxTest struct {

--- a/account/init_tenant.go
+++ b/account/init_tenant.go
@@ -3,7 +3,7 @@ package account
 import (
 	"net/http"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"net/url"
 

--- a/account/user.go
+++ b/account/user.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/almighty/almighty-core/workitem"
 
+	"context"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
-	"golang.org/x/net/context"
 )
 
 // In future, we could add support for FieldDefinitions the way we have for workitems.

--- a/account/user_blackbox_test.go
+++ b/account/user_blackbox_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/almighty/almighty-core/resource"
 	"github.com/almighty/almighty-core/workitem"
 
+	"context"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 type userBlackBoxTest struct {

--- a/application/repositories.go
+++ b/application/repositories.go
@@ -5,8 +5,8 @@ import (
 	"github.com/almighty/almighty-core/criteria"
 	"github.com/almighty/almighty-core/workitem"
 
+	"context"
 	uuid "github.com/satori/go.uuid"
-	"golang.org/x/net/context"
 )
 
 // TrackerRepository encapsulate storage & retrieval of tracker configuration

--- a/area/area.go
+++ b/area/area.go
@@ -12,8 +12,8 @@ import (
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
 
+	"context"
 	uuid "github.com/satori/go.uuid"
-	"golang.org/x/net/context"
 )
 
 const APIStringTypeAreas = "areas"

--- a/area/area_blackbox_test.go
+++ b/area/area_blackbox_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/area"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"

--- a/auth/state.go
+++ b/auth/state.go
@@ -6,9 +6,9 @@ import (
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/log"
 
+	"context"
 	"github.com/jinzhu/gorm"
 	uuid "github.com/satori/go.uuid"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/auth/state_blackbox_test.go
+++ b/auth/state_blackbox_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/almighty/almighty-core/gormtestsupport"
 	"github.com/almighty/almighty-core/migration"
 
+	"context"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 type stateBlackBoxTest struct {

--- a/codebase/codebase.go
+++ b/codebase/codebase.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"

--- a/codebase/codebase_test.go
+++ b/codebase/codebase_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/codebase"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"

--- a/comment/comment_repository_blackbox_test.go
+++ b/comment/comment_repository_blackbox_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/comment"

--- a/controller/area.go
+++ b/controller/area.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"

--- a/controller/area_blackbox_test.go
+++ b/controller/area_blackbox_test.go
@@ -22,12 +22,12 @@ import (
 	testsupport "github.com/almighty/almighty-core/test"
 	almtoken "github.com/almighty/almighty-core/token"
 
+	"context"
 	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 type TestAreaREST struct {

--- a/controller/iteration_test.go
+++ b/controller/iteration_test.go
@@ -24,13 +24,13 @@ import (
 	almtoken "github.com/almighty/almighty-core/token"
 	"github.com/almighty/almighty-core/workitem"
 
+	"context"
 	"github.com/almighty/almighty-core/path"
 	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 type TestIterationREST struct {

--- a/controller/login_test.go
+++ b/controller/login_test.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 	"golang.org/x/oauth2"
 
 	"github.com/almighty/almighty-core/account"

--- a/controller/planner_backlog_blackbox_test.go
+++ b/controller/planner_backlog_blackbox_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"

--- a/controller/planner_backlog_test.go
+++ b/controller/planner_backlog_test.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"

--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -28,12 +28,12 @@ import (
 	"github.com/almighty/almighty-core/workitem"
 	uuid "github.com/satori/go.uuid"
 
+	"context"
 	"github.com/goadesign/goa"
 	"github.com/goadesign/goa/goatest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 func TestRunSearchTests(t *testing.T) {

--- a/controller/search_spaces_blackbox_test.go
+++ b/controller/search_spaces_blackbox_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"context"
 	"github.com/goadesign/goa"
-	"golang.org/x/net/context"
 )
 
 type args struct {

--- a/controller/search_user_blackbox_test.go
+++ b/controller/search_user_blackbox_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"testing"
 
+	"context"
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
@@ -19,7 +20,6 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 func TestRunSearchUser(t *testing.T) {

--- a/controller/space_codebases_test.go
+++ b/controller/space_codebases_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"

--- a/controller/space_iterations_test.go
+++ b/controller/space_iterations_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"fmt"
 

--- a/controller/user.go
+++ b/controller/user.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"

--- a/controller/user_service.go
+++ b/controller/user_service.go
@@ -1,7 +1,7 @@
 package controller
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/goadesign/goa"

--- a/controller/user_test.go
+++ b/controller/user_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"net/http"
 

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -20,12 +20,12 @@ import (
 	testsupport "github.com/almighty/almighty-core/test"
 	almtoken "github.com/almighty/almighty-core/token"
 
+	"context"
 	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 func TestUsers(t *testing.T) {

--- a/controller/work_item_comments.go
+++ b/controller/work_item_comments.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/comment"
@@ -11,7 +12,6 @@ import (
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/goadesign/goa"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // WorkItemCommentsController implements the work-item-comments resource.

--- a/controller/work_item_comments_blackbox_test.go
+++ b/controller/work_item_comments_blackbox_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"

--- a/controller/work_item_link.go
+++ b/controller/work_item_link.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"strconv"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 3e9f1b6af7274e8d50e57500f92f1374c63cce5e765993d8649e03350936560c
-updated: 2017-04-17T23:07:16.622277679+02:00
+hash: 4e60579c951611d09edf3c73fb99c2eb63458902e1a4cec96ab612af12e5bea2
+updated: 2017-06-12T12:25:28.34192506+02:00
 imports:
 - name: bitbucket.org/pkg/inflect
   version: 8961c3750a47b8c0b3e118d52513b97adf85a7e8
@@ -22,7 +22,7 @@ imports:
 - name: github.com/dimfeld/httppath
   version: c8e499c3ef3c3e272ed8bdcc1ccf39f73c88debc
 - name: github.com/dimfeld/httptreemux
-  version: 86f7c217d9043ebc6adfd8e2ed04a0bb1e1db651
+  version: 13dde8a00d96b369e7398490fd8a3af9ca114b84
 - name: github.com/dnaeon/go-vcr
   version: 9d71b8a6df86e00127f96bc8dabc09856ab8afdb
   subpackages:
@@ -43,7 +43,7 @@ imports:
 - name: github.com/fzipp/gocyclo
   version: 6acd4345c835499920e8426c7e4e8d7a34f1bb83
 - name: github.com/goadesign/goa
-  version: be1e8b9a2614909d8805079ebd1c947778170c0e
+  version: 58f3177f36f2c50ee6119da92795e48bac6d6243
   vcs: git
   subpackages:
   - client

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
 - package: github.com/dgrijalva/jwt-go
   version: ^3.0.0
 - package: github.com/goadesign/goa
-  version: ^1.1.0
+  version: ^1.2.0
   vcs: git
   subpackages:
   - client

--- a/gormtestsupport/db_test_suite.go
+++ b/gormtestsupport/db_test_suite.go
@@ -10,10 +10,10 @@ import (
 	"github.com/almighty/almighty-core/resource"
 	"github.com/almighty/almighty-core/workitem"
 
+	"context"
 	"github.com/jinzhu/gorm"
 	_ "github.com/lib/pq" // need to import postgres driver
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 var _ suite.SetupAllSuite = &DBTestSuite{}

--- a/iteration/iteration.go
+++ b/iteration/iteration.go
@@ -9,11 +9,11 @@ import (
 	"github.com/almighty/almighty-core/log"
 	"github.com/almighty/almighty-core/path"
 
+	"context"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
-	"golang.org/x/net/context"
 )
 
 // Defines "type" string to be used while validating jsonapi spec based payload

--- a/iteration/iteration_test.go
+++ b/iteration/iteration_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"strconv"
 

--- a/jsonapi/error_handler.go
+++ b/jsonapi/error_handler.go
@@ -7,11 +7,11 @@ import (
 	"io"
 	"net/http"
 
+	"context"
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/log"
 	"github.com/goadesign/goa"
 	errs "github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/log/context.go
+++ b/log/context.go
@@ -1,7 +1,7 @@
 package log
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	tokencontext "github.com/almighty/almighty-core/login/tokencontext"
 

--- a/log/log.go
+++ b/log/log.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/almighty/almighty-core/configuration"
 
+	"context"
 	log "github.com/Sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const defaultPackageName = "github.com/almighty/almighty-core/"

--- a/log/log_request.go
+++ b/log/log_request.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/goadesign/goa"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 type middlewareKey int

--- a/login/service.go
+++ b/login/service.go
@@ -16,6 +16,7 @@ import (
 
 	errs "github.com/pkg/errors"
 
+	"context"
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"
@@ -31,7 +32,6 @@ import (
 	"github.com/goadesign/goa"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	uuid "github.com/satori/go.uuid"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 

--- a/login/service_blackbox_test.go
+++ b/login/service_blackbox_test.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 	"golang.org/x/oauth2"
 
 	"github.com/almighty/almighty-core/account"

--- a/login/tokencontext/token_context.go
+++ b/login/tokencontext/token_context.go
@@ -3,7 +3,7 @@
 package tokencontext
 
 import (
-	"golang.org/x/net/context"
+	"context"
 )
 
 type contextTMKey int

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/jinzhu/gorm"
 	_ "github.com/lib/pq"

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -15,12 +15,12 @@ import (
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/almighty/almighty-core/workitem/link"
 
+	"context"
 	"github.com/goadesign/goa"
 	"github.com/goadesign/goa/client"
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
-	"golang.org/x/net/context"
 )
 
 // AdvisoryLockID is a random number that should be used within the application

--- a/remoteworkitem/scheduler.go
+++ b/remoteworkitem/scheduler.go
@@ -4,11 +4,11 @@ import (
 	"github.com/almighty/almighty-core/log"
 	"github.com/almighty/almighty-core/models"
 
+	"context"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
 	"github.com/robfig/cron"
 	uuid "github.com/satori/go.uuid"
-	"golang.org/x/net/context"
 )
 
 // TrackerSchedule capture all configuration

--- a/remoteworkitem/tracker_repository.go
+++ b/remoteworkitem/tracker_repository.go
@@ -5,13 +5,13 @@ import (
 
 	"fmt"
 
+	"context"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/criteria"
 	"github.com/almighty/almighty-core/log"
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	govalidator "gopkg.in/asaskevich/govalidator.v4"
 )
 

--- a/remoteworkitem/tracker_repository_blackbox_test.go
+++ b/remoteworkitem/tracker_repository_blackbox_test.go
@@ -3,6 +3,7 @@ package remoteworkitem_test
 import (
 	"testing"
 
+	"context"
 	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/gormtestsupport"
@@ -10,7 +11,6 @@ import (
 	"github.com/almighty/almighty-core/remoteworkitem"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 type trackerRepoBlackBoxTest struct {

--- a/remoteworkitem/tracker_repository_test.go
+++ b/remoteworkitem/tracker_repository_test.go
@@ -3,7 +3,7 @@ package remoteworkitem
 import (
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/application"

--- a/remoteworkitem/trackeritem_repository.go
+++ b/remoteworkitem/trackeritem_repository.go
@@ -3,7 +3,7 @@ package remoteworkitem
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/criteria"

--- a/remoteworkitem/trackeritem_repository_test.go
+++ b/remoteworkitem/trackeritem_repository_test.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"

--- a/remoteworkitem/trackerquery_repository.go
+++ b/remoteworkitem/trackerquery_repository.go
@@ -8,11 +8,11 @@ import (
 	"github.com/almighty/almighty-core/log"
 	"github.com/almighty/almighty-core/rest"
 
+	"context"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
-	"golang.org/x/net/context"
 )
 
 // GormTrackerQueryRepository implements TrackerRepository using gorm

--- a/remoteworkitem/trackerquery_repository_blackbox_test.go
+++ b/remoteworkitem/trackerquery_repository_blackbox_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/almighty/almighty-core/remoteworkitem"
 	"github.com/almighty/almighty-core/space"
 
+	"context"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 type trackerQueryRepoBlackBoxTest struct {

--- a/remoteworkitem/trackerquery_repository_test.go
+++ b/remoteworkitem/trackerquery_repository_test.go
@@ -5,8 +5,8 @@ import (
 	"net/url"
 	"testing"
 
+	"context"
 	"github.com/almighty/almighty-core/application"
-	"golang.org/x/net/context"
 
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/gormtestsupport"

--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"strings"
 

--- a/search/search_repository_blackbox_test.go
+++ b/search/search_repository_blackbox_test.go
@@ -14,12 +14,12 @@ import (
 	testsupport "github.com/almighty/almighty-core/test"
 	"github.com/almighty/almighty-core/workitem"
 
+	"context"
 	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 func TestRunSearchRepositoryBlackboxTest(t *testing.T) {

--- a/search/search_repository_whitebox_test.go
+++ b/search/search_repository_whitebox_test.go
@@ -18,6 +18,7 @@ import (
 	testsupport "github.com/almighty/almighty-core/test"
 	"github.com/almighty/almighty-core/workitem"
 
+	"context"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	_ "github.com/lib/pq"
@@ -26,7 +27,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 func TestRunSearchRepositoryWhiteboxTest(t *testing.T) {

--- a/space/authz/authz.go
+++ b/space/authz/authz.go
@@ -16,11 +16,11 @@ import (
 	"github.com/almighty/almighty-core/space"
 	"github.com/almighty/almighty-core/token"
 
+	contx "context"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	uuid "github.com/satori/go.uuid"
-	contx "golang.org/x/net/context"
 )
 
 // TokenPayload represents an rpt token

--- a/space/authz/authz_test.go
+++ b/space/authz/authz_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	netcontext "context"
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/area"
@@ -180,23 +179,23 @@ func (a *app) Codebases() codebase.Repository {
 	return nil
 }
 
-func (r *resourceRepo) Create(ctx netcontext.Context, s *space.Resource) (*space.Resource, error) {
+func (r *resourceRepo) Create(ctx context.Context, s *space.Resource) (*space.Resource, error) {
 	return nil, nil
 }
 
-func (r *resourceRepo) Save(ctx netcontext.Context, s *space.Resource) (*space.Resource, error) {
+func (r *resourceRepo) Save(ctx context.Context, s *space.Resource) (*space.Resource, error) {
 	return nil, nil
 }
 
-func (r *resourceRepo) Load(ctx netcontext.Context, ID uuid.UUID) (*space.Resource, error) {
+func (r *resourceRepo) Load(ctx context.Context, ID uuid.UUID) (*space.Resource, error) {
 	return nil, nil
 }
 
-func (r *resourceRepo) Delete(ctx netcontext.Context, ID uuid.UUID) error {
+func (r *resourceRepo) Delete(ctx context.Context, ID uuid.UUID) error {
 	return nil
 }
 
-func (r *resourceRepo) LoadBySpace(ctx netcontext.Context, spaceID *uuid.UUID) (*space.Resource, error) {
+func (r *resourceRepo) LoadBySpace(ctx context.Context, spaceID *uuid.UUID) (*space.Resource, error) {
 	resource := &space.Resource{}
 	past := time.Now().Unix() - 1000
 	resource.UpdatedAt = time.Unix(past, 0)

--- a/space/authz/authz_test.go
+++ b/space/authz/authz_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	netcontext "context"
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/application"
 	"github.com/almighty/almighty-core/area"
@@ -23,7 +24,6 @@ import (
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	netcontext "golang.org/x/net/context"
 )
 
 var (

--- a/space/space.go
+++ b/space/space.go
@@ -9,10 +9,10 @@ import (
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/log"
 
+	"context"
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/space/space_resource.go
+++ b/space/space_resource.go
@@ -6,9 +6,9 @@ import (
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/log"
 
+	"context"
 	"github.com/jinzhu/gorm"
 	uuid "github.com/satori/go.uuid"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/space/space_resource_test.go
+++ b/space/space_resource_test.go
@@ -3,6 +3,7 @@ package space_test
 import (
 	"testing"
 
+	"context"
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/gormtestsupport"
@@ -12,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 var testResourceID string = uuid.NewV4().String()

--- a/space/space_test.go
+++ b/space/space_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"context"
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/gormtestsupport"
@@ -13,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 var testSpace string = uuid.NewV4().String()

--- a/test/work_item_repository.go
+++ b/test/work_item_repository.go
@@ -4,10 +4,10 @@ package test
 import (
 	"sync"
 
+	"context"
 	"github.com/almighty/almighty-core/criteria"
 	"github.com/almighty/almighty-core/workitem"
 	uuid "github.com/satori/go.uuid"
-	"golang.org/x/net/context"
 )
 
 type WorkItemRepository struct {

--- a/token/token.go
+++ b/token/token.go
@@ -3,12 +3,12 @@ package token
 import (
 	"crypto/rsa"
 
+	"context"
 	"github.com/almighty/almighty-core/account"
 	jwt "github.com/dgrijalva/jwt-go"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
-	"golang.org/x/net/context"
 )
 
 // Manager generate and find auth token information

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/resource"

--- a/workitem/link/category_repository.go
+++ b/workitem/link/category_repository.go
@@ -1,7 +1,7 @@
 package link
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/log"

--- a/workitem/link/link_repository.go
+++ b/workitem/link/link_repository.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"

--- a/workitem/link/type_repository.go
+++ b/workitem/link/type_repository.go
@@ -3,7 +3,7 @@ package link
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/log"

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -3,7 +3,7 @@ package workitem
 import (
 	"strconv"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"fmt"
 

--- a/workitem/workitem_repository_blackbox_test.go
+++ b/workitem/workitem_repository_blackbox_test.go
@@ -16,12 +16,12 @@ import (
 	testsupport "github.com/almighty/almighty-core/test"
 	"github.com/almighty/almighty-core/workitem"
 
+	"context"
 	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 type workItemRepoBlackBoxTest struct {

--- a/workitem/workitemtype_repository.go
+++ b/workitem/workitemtype_repository.go
@@ -3,7 +3,7 @@ package workitem
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/log"

--- a/workitem/workitemtype_repository_blackbox_test.go
+++ b/workitem/workitemtype_repository_blackbox_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/almighty/almighty-core/space"
 	"github.com/almighty/almighty-core/workitem"
 
+	"context"
 	"github.com/goadesign/goa"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 type workItemTypeRepoBlackBoxTest struct {


### PR DESCRIPTION
https://golang.org/doc/go1.7#context:

> Go 1.7 moves the golang.org/x/net/context package into the standard library as context. This allows the use of contexts for cancelation, timeouts, and passing request-scoped data in other standard library packages, including net, net/http, and os/exec, as noted below.

> For more information about contexts, see the package documentation and the Go blog post “Go Concurrent Patterns: Context.”

Requires #1357 to be fixed first.
