### PR TITLE
Make `parentExists` filter sticky on WI links

### DIFF
--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -110,6 +110,11 @@ func (c *WorkitemController) List(ctx *app.ListWorkitemContext) error {
 		exp = criteria.And(exp, criteria.Equals(criteria.Field(workitem.SystemState), criteria.Literal(string(*ctx.FilterWorkitemstate))))
 		additionalQuery = append(additionalQuery, "filter[workitemstate]="+*ctx.FilterWorkitemstate)
 	}
+	if ctx.FilterParentexists != nil {
+		// no need to build expression: it is taken care in wi.List call
+		// we need additionalQuery to make sticky filters in URL links
+		additionalQuery = append(additionalQuery, "filter[parentexists]="+strconv.FormatBool(*ctx.FilterParentexists))
+	}
 
 	offset, limit := computePagingLimits(ctx.PageOffset, ctx.PageLimit)
 	return application.Transactional(c.db, func(tx application.Application) error {

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -2543,6 +2543,11 @@ func (s *workItemChildSuite) TestWorkItemListFilterByNoParents() {
 		_, result := test.ListWorkitemOK(t, nil, nil, s.workItemCtrl, s.userSpaceID, nil, nil, nil, nil, pe, nil, nil, nil, nil, nil, nil)
 		// then
 		assert.Len(t, result.Data, 3)
+		assert.Nil(t, result.Links.Prev)
+		assert.Nil(t, result.Links.Next)
+		shouldNotContain := "filter[parentexists]"
+		assert.NotContains(t, *result.Links.First, shouldNotContain)
+		assert.NotContains(t, *result.Links.Last, shouldNotContain)
 	})
 
 	s.T().Run("with parentexists value set to false", func(t *testing.T) {
@@ -2552,6 +2557,11 @@ func (s *workItemChildSuite) TestWorkItemListFilterByNoParents() {
 		_, result2 := test.ListWorkitemOK(t, nil, nil, s.workItemCtrl, s.userSpaceID, nil, nil, nil, nil, &pe, nil, nil, nil, nil, nil, nil)
 		// then
 		assert.Len(t, result2.Data, 1)
+		assert.Nil(t, result2.Links.Prev)
+		assert.Nil(t, result2.Links.Next)
+		shouldContain := "filter[parentexists]=" + strconv.FormatBool(pe)
+		assert.Contains(t, *result2.Links.First, shouldContain)
+		assert.Contains(t, *result2.Links.Last, shouldContain)
 	})
 
 	s.T().Run("with parentexists value set to true", func(t *testing.T) {
@@ -2561,6 +2571,11 @@ func (s *workItemChildSuite) TestWorkItemListFilterByNoParents() {
 		_, result2 := test.ListWorkitemOK(t, nil, nil, s.workItemCtrl, s.userSpaceID, nil, nil, nil, nil, &pe, nil, nil, nil, nil, nil, nil)
 		// then
 		assert.Len(t, result2.Data, 3)
+		assert.Nil(t, result2.Links.Prev)
+		assert.Nil(t, result2.Links.Next)
+		shouldContain := "filter[parentexists]=" + strconv.FormatBool(pe)
+		assert.Contains(t, *result2.Links.First, shouldContain)
+		assert.Contains(t, *result2.Links.Last, shouldContain)
 	})
 
 }


### PR DESCRIPTION
Fixes https://github.com/almighty/almighty-core/issues/1393
Include parentExist filter in the response.Links URLs
Tests are updated.

Old response links for the request : `http://localhost:8080/api/spaces/{{userSpaceID}}/workitems?filter[parentexists]=false`
```
 "links": {
    "filters": "http://localhost:8080/api/filters",
    "first": "http://localhost:8080/api/spaces/3365d380-62ae-47af-96e7-228b2dcbf401/workitems?page[offset]=0&page[limit]=20",
    "last": "http://localhost:8080/api/spaces/3365d380-62ae-47af-96e7-228b2dcbf401/workitems?page[offset]=0&page[limit]=0"
  }
```

Above response links do not have `parentExists` filter sticked to it.

New response links for the request : `http://localhost:8080/api/spaces/{{userSpaceID}}/workitems?filter[parentexists]=false`
```
"links": {
    "filters": "http://localhost:8080/api/filters",
    "first": "http://localhost:8080/api/spaces/3365d380-62ae-47af-96e7-228b2dcbf401/workitems?page[offset]=0&page[limit]=20&filter[parentexists]=false",
    "last": "http://localhost:8080/api/spaces/3365d380-62ae-47af-96e7-228b2dcbf401/workitems?page[offset]=0&page[limit]=0&filter[parentexists]=false"
  }```

