### PR TITLE
Change internalservererror ctor

### DIFF
--- a/account/identity.go
+++ b/account/identity.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"context"
+
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport"
 	"github.com/almighty/almighty-core/log"
@@ -373,7 +374,7 @@ func (m *GormIdentityRepository) Search(ctx context.Context, q string, start int
 	value := Identity{}
 	columns, err := rows.Columns()
 	if err != nil {
-		return nil, 0, errors.NewInternalError(err.Error())
+		return nil, 0, errors.NewInternalError(err)
 	}
 
 	// need to set up a result for Scan() in order to extract total count.
@@ -396,12 +397,12 @@ func (m *GormIdentityRepository) Search(ctx context.Context, q string, start int
 		db.ScanRows(rows, &value.User)
 
 		if err = rows.Scan(columnValues...); err != nil {
-			return nil, 0, errors.NewInternalError(err.Error())
+			return nil, 0, errors.NewInternalError(err)
 		}
 
 		value.ID, err = uuid.FromString(identityID)
 		if err != nil {
-			return nil, 0, errors.NewInternalError(err.Error())
+			return nil, 0, errors.NewInternalError(err)
 		}
 
 		value.Username = identityUsername

--- a/account/identity.go
+++ b/account/identity.go
@@ -60,7 +60,7 @@ func (u NullUUID) Value() (driver.Value, error) {
 // One User account can have many Identities
 type Identity struct {
 	gormsupport.Lifecycle
-	// This is the ID PK field. For identities provided by Keyclaok this ID equals to the Keycloak. For other types of IDP (github, oso, etc) this ID is generated automaticaly
+	// This is the ID PK field. For identities provided by Keycloak this ID equals to the Keycloak. For other types of IDP (github, oso, etc) this ID is generated automaticaly
 	ID uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"`
 	// The username of the Identity
 	Username string

--- a/area/area.go
+++ b/area/area.go
@@ -1,7 +1,6 @@
 package area
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/almighty/almighty-core/errors"
@@ -13,6 +12,7 @@ import (
 	errs "github.com/pkg/errors"
 
 	"context"
+
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -102,7 +102,7 @@ func (m *GormAreaRepository) Load(ctx context.Context, id uuid.UUID) (*Area, err
 		return nil, errors.NewNotFoundError("Area", id.String())
 	}
 	if tx.Error != nil {
-		return nil, errors.NewInternalError(tx.Error.Error())
+		return nil, errors.NewInternalError(tx.Error)
 	}
 	return &obj, nil
 }
@@ -117,7 +117,7 @@ func (m *GormAreaRepository) LoadMultiple(ctx context.Context, ids []uuid.UUID) 
 	}
 	tx := m.db.Find(&objs)
 	if tx.Error != nil {
-		return nil, errors.NewInternalError(tx.Error.Error())
+		return nil, errors.NewInternalError(tx.Error)
 	}
 	return objs, nil
 }
@@ -132,7 +132,7 @@ func (m *GormAreaRepository) ListChildren(ctx context.Context, parentArea *Area)
 		return nil, errors.NewNotFoundError("Area", parentArea.ID.String())
 	}
 	if tx.Error != nil {
-		return nil, errors.NewInternalError(tx.Error.Error())
+		return nil, errors.NewInternalError(tx.Error)
 	}
 	return objs, nil
 }
@@ -145,7 +145,7 @@ func (m *GormAreaRepository) Root(ctx context.Context, spaceID uuid.UUID) (*Area
 	parentPathOfRootArea := path.Path{}
 	rootArea, err := m.Query(FilterBySpaceID(spaceID), FilterByPath(parentPathOfRootArea))
 	if len(rootArea) != 1 {
-		return nil, errors.NewInternalError(fmt.Sprintf("Single Root area not found for space %s", spaceID.String()))
+		return nil, errors.NewInternalError(errs.Errorf("Single Root area not found for space %s", spaceID))
 	}
 	if err != nil {
 		return nil, err

--- a/auth/authz.go
+++ b/auth/authz.go
@@ -196,7 +196,7 @@ func CreateResource(ctx context.Context, resource KeycloakResource, authzEndpoin
 		log.Error(ctx, map[string]interface{}{
 			"resource": resource,
 			"err":      err.Error(),
-		}, "Unable to marshal keyclaok resource struct")
+		}, "unable to marshal keyclaok resource struct")
 		return "", errors.NewInternalError(errs.Wrap(err, "unable to marshal keyclaok resource struct"))
 	}
 
@@ -204,7 +204,7 @@ func CreateResource(ctx context.Context, resource KeycloakResource, authzEndpoin
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to create http request")
+		}, "unable to create http request")
 		return "", errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Content-Type", "application/json")
@@ -214,7 +214,7 @@ func CreateResource(ctx context.Context, resource KeycloakResource, authzEndpoin
 		log.Error(ctx, map[string]interface{}{
 			"resource": resource,
 			"err":      err.Error(),
-		}, "Unable to create a Keycloak resource")
+		}, "unable to create a Keycloak resource")
 		return "", errors.NewInternalError(errs.Wrap(err, "unable to create a Keycloak resource"))
 	}
 	defer res.Body.Close()
@@ -223,7 +223,7 @@ func CreateResource(ctx context.Context, resource KeycloakResource, authzEndpoin
 			"resource":        resource,
 			"response_status": res.Status,
 			"response_body":   rest.ReadBody(res.Body),
-		}, "Unable to create a Keycloak resource")
+		}, "unable to create a Keycloak resource")
 		return "", errors.NewInternalError(errs.Errorf("unable to create a Keycloak resource. Response status: " + res.Status + ". Responce body: " + rest.ReadBody(res.Body)))
 	}
 	jsonString := rest.ReadBody(res.Body)
@@ -234,7 +234,7 @@ func CreateResource(ctx context.Context, resource KeycloakResource, authzEndpoin
 		log.Error(ctx, map[string]interface{}{
 			"resource":    resource,
 			"json_string": jsonString,
-		}, "Unable to unmarshal json with the create keycloak resource request result")
+		}, "unable to unmarshal json with the create keycloak resource request result")
 
 		return "", errors.NewInternalError(errs.Wrapf(err, "unable to unmarshal json with the create keycloak resource request result %s ", jsonString))
 	}
@@ -253,7 +253,7 @@ func GetClientID(ctx context.Context, clientsEndpoint string, publicClientID str
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to create http request")
+		}, "unable to create http request")
 		return "", errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Authorization", "Bearer "+protectionAPIToken)
@@ -262,7 +262,7 @@ func GetClientID(ctx context.Context, clientsEndpoint string, publicClientID str
 		log.Error(ctx, map[string]interface{}{
 			"public_client_id": publicClientID,
 			"err":              err.Error(),
-		}, "Unable to obtain keycloak client ID")
+		}, "unable to obtain keycloak client ID")
 		return "", errors.NewInternalError(errs.Wrap(err, "unable to obtain keycloak client ID"))
 	}
 	defer res.Body.Close()
@@ -271,8 +271,8 @@ func GetClientID(ctx context.Context, clientsEndpoint string, publicClientID str
 			"public_client_id": publicClientID,
 			"response_status":  res.Status,
 			"response_body":    rest.ReadBody(res.Body),
-		}, "Unable to obtain keycloak client ID")
-		return "", errors.NewInternalError(errs.New("Unable to obtain keycloak client ID. Response status: " + res.Status + ". Responce body: " + rest.ReadBody(res.Body)))
+		}, "unable to obtain keycloak client ID")
+		return "", errors.NewInternalError(errs.New("unable to obtain keycloak client ID. Response status: " + res.Status + ". Responce body: " + rest.ReadBody(res.Body)))
 	}
 	jsonString := rest.ReadBody(res.Body)
 
@@ -282,7 +282,7 @@ func GetClientID(ctx context.Context, clientsEndpoint string, publicClientID str
 		log.Error(ctx, map[string]interface{}{
 			"public_client_id": publicClientID,
 			"err":              err.Error(),
-		}, "Unable to unmarshal json with client ID")
+		}, "unable to unmarshal json with client ID")
 		return "", errors.NewInternalError(errs.Wrapf(err, "error when unmarshal json with client ID result %s ", jsonString))
 	}
 	for _, client := range r {
@@ -293,7 +293,7 @@ func GetClientID(ctx context.Context, clientsEndpoint string, publicClientID str
 	log.Error(ctx, map[string]interface{}{
 		"public_client_id": publicClientID,
 		"json":             jsonString,
-	}, "Unable to find client ID '"+publicClientID+"' among available IDs: "+jsonString)
+	}, "unable to find client ID '"+publicClientID+"' among available IDs: "+jsonString)
 	return "", errors.NewInternalError(errs.New("unable to find keycloak client ID"))
 }
 
@@ -304,7 +304,7 @@ func CreatePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 		log.Error(ctx, map[string]interface{}{
 			"policy": policy,
 			"err":    err.Error(),
-		}, "Unable to marshal keyclaok policy struct")
+		}, "unable to marshal keyclaok policy struct")
 		return "", errors.NewInternalError(errs.Wrap(err, "unable to marshal keyclaok policy struct"))
 	}
 
@@ -312,7 +312,7 @@ func CreatePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to create http request")
+		}, "unable to create http request")
 		return "", errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Content-Type", "application/json")
@@ -323,7 +323,7 @@ func CreatePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 			"client_id": clientID,
 			"policy":    policy,
 			"err":       err.Error(),
-		}, "Unable to create the Keycloak policy")
+		}, "unable to create the Keycloak policy")
 		return "", errors.NewInternalError(errs.Wrap(err, "unable to create the Keycloak policy"))
 	}
 	defer res.Body.Close()
@@ -333,7 +333,7 @@ func CreatePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 			"policy":          policy,
 			"response_status": res.Status,
 			"response_body":   rest.ReadBody(res.Body),
-		}, "Unable to update the Keycloak policy")
+		}, "unable to update the Keycloak policy")
 		return "", errors.NewInternalError(errs.New("unable to create the Keycloak policy. Response status: " + res.Status + ". Responce body: " + rest.ReadBody(res.Body)))
 	}
 	jsonString := rest.ReadBody(res.Body)
@@ -345,7 +345,7 @@ func CreatePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 			"client_id":   clientID,
 			"policy":      policy,
 			"json_string": jsonString,
-		}, "Unable to unmarshal json with the create keycloak policy request result")
+		}, "unable to unmarshal json with the create keycloak policy request result")
 		return "", errors.NewInternalError(errs.Wrapf(err, "error when unmarshal json with the create keycloak policy request result %s ", jsonString))
 	}
 
@@ -359,7 +359,7 @@ func CreatePermission(ctx context.Context, clientsEndpoint string, clientID stri
 		log.Error(ctx, map[string]interface{}{
 			"permission": permission,
 			"err":        err.Error(),
-		}, "Unable to marshal keyclaok permission struct")
+		}, "unable to marshal keyclaok permission struct")
 		return "", errors.NewInternalError(errs.Wrap(err, "unable to marshal keyclaok permission struct"))
 	}
 
@@ -367,7 +367,7 @@ func CreatePermission(ctx context.Context, clientsEndpoint string, clientID stri
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to create http request")
+		}, "unable to create http request")
 		return "", errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Content-Type", "application/json")
@@ -378,7 +378,7 @@ func CreatePermission(ctx context.Context, clientsEndpoint string, clientID stri
 			"client_id":  clientID,
 			"permission": permission,
 			"err":        err.Error(),
-		}, "Unable to create the Keycloak permission")
+		}, "unable to create the Keycloak permission")
 		return "", errors.NewInternalError(errs.Wrap(err, "unable to create the Keycloak permission"))
 	}
 	defer res.Body.Close()
@@ -388,8 +388,8 @@ func CreatePermission(ctx context.Context, clientsEndpoint string, clientID stri
 			"permission":      permission,
 			"response_status": res.Status,
 			"response_body":   rest.ReadBody(res.Body),
-		}, "Unable to update the Keycloak permission")
-		return "", errors.NewInternalError(errs.New("Unable to create the Keycloak permission. Response status: " + res.Status + ". Responce body: " + rest.ReadBody(res.Body)))
+		}, "unable to update the Keycloak permission")
+		return "", errors.NewInternalError(errs.New("unable to create the Keycloak permission. Response status: " + res.Status + ". Responce body: " + rest.ReadBody(res.Body)))
 	}
 	jsonString := rest.ReadBody(res.Body)
 
@@ -400,7 +400,7 @@ func CreatePermission(ctx context.Context, clientsEndpoint string, clientID stri
 			"client_id":   clientID,
 			"permission":  permission,
 			"json_string": jsonString,
-		}, "Unable to unmarshal json with the create keycloak permission request result")
+		}, "unable to unmarshal json with the create keycloak permission request result")
 		return "", errors.NewInternalError(errs.Wrapf(err, "error when unmarshal json with the create keycloak permission request result %s ", jsonString))
 	}
 
@@ -421,7 +421,7 @@ func DeleteResource(ctx context.Context, kcResourceID string, authzEndpoint stri
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to create http request")
+		}, "unable to create http request")
 		return errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Authorization", "Bearer "+protectionAPIToken)
@@ -430,7 +430,7 @@ func DeleteResource(ctx context.Context, kcResourceID string, authzEndpoint stri
 		log.Error(ctx, map[string]interface{}{
 			"kc_resource_id": kcResourceID,
 			"err":            err.Error(),
-		}, "Unable to delete the Keycloak resource")
+		}, "unable to delete the Keycloak resource")
 		return errors.NewInternalError(errs.Wrap(err, "unable to delete the Keycloak resource"))
 	}
 	defer res.Body.Close()
@@ -439,7 +439,7 @@ func DeleteResource(ctx context.Context, kcResourceID string, authzEndpoint stri
 			"kc_resource_id":  kcResourceID,
 			"response_status": res.Status,
 			"response_body":   rest.ReadBody(res.Body),
-		}, "Unable to delete the Keycloak resource")
+		}, "unable to delete the Keycloak resource")
 		return errors.NewInternalError(errs.New("unable to delete the Keycloak resource. Response status: " + res.Status + ". Responce body: " + rest.ReadBody(res.Body)))
 	}
 
@@ -460,7 +460,7 @@ func DeletePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to create http request")
+		}, "unable to create http request")
 		return errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Authorization", "Bearer "+protectionAPIToken)
@@ -469,7 +469,7 @@ func DeletePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 		log.Error(ctx, map[string]interface{}{
 			"policy_id": policyID,
 			"err":       err.Error(),
-		}, "Unable to delete the Keycloak policy")
+		}, "unable to delete the Keycloak policy")
 		return errors.NewInternalError(errs.Wrap(err, "unable to delete the Keycloak policy"))
 	}
 	defer res.Body.Close()
@@ -478,7 +478,7 @@ func DeletePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 			"policy_id":       policyID,
 			"response_status": res.Status,
 			"response_body":   rest.ReadBody(res.Body),
-		}, "Unable to delete the Keycloak policy")
+		}, "unable to delete the Keycloak policy")
 		return errors.NewInternalError(errs.New("unable to delete the Keycloak policy. Response status: " + res.Status + ". Responce body: " + rest.ReadBody(res.Body)))
 	}
 
@@ -499,7 +499,7 @@ func DeletePermission(ctx context.Context, clientsEndpoint string, clientID stri
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to create http request")
+		}, "unable to create http request")
 		return errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Authorization", "Bearer "+protectionAPIToken)
@@ -508,7 +508,7 @@ func DeletePermission(ctx context.Context, clientsEndpoint string, clientID stri
 		log.Error(ctx, map[string]interface{}{
 			"permission_id": permissionID,
 			"err":           err.Error(),
-		}, "Unable to delete the Keycloak permission")
+		}, "unable to delete the Keycloak permission")
 		return errors.NewInternalError(errs.Wrap(err, "unable to delete the Keycloak permission"))
 	}
 	defer res.Body.Close()
@@ -517,7 +517,7 @@ func DeletePermission(ctx context.Context, clientsEndpoint string, clientID stri
 			"permission_id":   permissionID,
 			"response_status": res.Status,
 			"response_body":   rest.ReadBody(res.Body),
-		}, "Unable to delete the Keycloak permission")
+		}, "unable to delete the Keycloak permission")
 		return errors.NewInternalError(errs.New("unable to delete the Keycloak permission. Response status: " + res.Status + ". Responce body: " + rest.ReadBody(res.Body)))
 	}
 
@@ -538,7 +538,7 @@ func GetPolicy(ctx context.Context, clientsEndpoint string, clientID string, pol
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to create http request")
+		}, "unable to create http request")
 		return nil, errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Authorization", "Bearer "+protectionAPIToken)
@@ -548,7 +548,7 @@ func GetPolicy(ctx context.Context, clientsEndpoint string, clientID string, pol
 			"client_id": clientID,
 			"policy_id": policyID,
 			"err":       err.Error(),
-		}, "Unable to obtain a Keycloak policy")
+		}, "unable to obtain a Keycloak policy")
 		return nil, errors.NewInternalError(errs.Wrap(err, "unable to obtain a Keycloak policy"))
 	}
 	defer res.Body.Close()
@@ -567,7 +567,7 @@ func GetPolicy(ctx context.Context, clientsEndpoint string, clientID string, pol
 			"policy_id":       policyID,
 			"response_status": res.Status,
 			"response_body":   rest.ReadBody(res.Body),
-		}, "Unable to obtain a Keycloak policy")
+		}, "unable to obtain a Keycloak policy")
 		return nil, errors.NewInternalError(errs.New("unable to obtain a Keycloak policy. Response status: " + res.Status + ". Responce body: " + rest.ReadBody(res.Body)))
 	}
 	jsonString := rest.ReadBody(res.Body)
@@ -579,7 +579,7 @@ func GetPolicy(ctx context.Context, clientsEndpoint string, clientID string, pol
 			"client_id":   clientID,
 			"policy_id":   policyID,
 			"json_string": jsonString,
-		}, "Unable to unmarshal json with the get keycloak policy request result")
+		}, "unable to unmarshal json with the get keycloak policy request result")
 		return nil, errors.NewInternalError(errs.Wrapf(err, "error when unmarshal json with get the keycloak policy request result %s ", jsonString))
 	}
 
@@ -597,7 +597,7 @@ func UpdatePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 		log.Error(ctx, map[string]interface{}{
 			"policy": policy,
 			"err":    err.Error(),
-		}, "Unable to marshal keyclaok policy struct")
+		}, "unable to marshal keyclaok policy struct")
 		return errors.NewInternalError(errs.Wrap(err, "unable to marshal keyclaok policy struct"))
 	}
 
@@ -605,7 +605,7 @@ func UpdatePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to create http request")
+		}, "unable to create http request")
 		return errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Content-Type", "application/json")
@@ -616,7 +616,7 @@ func UpdatePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 			"client_id": clientID,
 			"policy":    policy,
 			"err":       err.Error(),
-		}, "Unable to update the Keycloak policy")
+		}, "unable to update the Keycloak policy")
 		return errors.NewInternalError(errs.Wrap(err, "unable to update the Keycloak policy"))
 	}
 	defer res.Body.Close()
@@ -626,7 +626,7 @@ func UpdatePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 			"policy":          policy,
 			"response_status": res.Status,
 			"response_body":   rest.ReadBody(res.Body),
-		}, "Unable to update the Keycloak policy")
+		}, "unable to update the Keycloak policy")
 		return errors.NewInternalError(errs.New("unable to update the Keycloak policy. Response status: " + res.Status + ". Responce body: " + rest.ReadBody(res.Body)))
 	}
 
@@ -645,7 +645,7 @@ func GetEntitlement(ctx context.Context, entitlementEndpoint string, entitlement
 			log.Error(ctx, map[string]interface{}{
 				"entitlement_resource": entitlementResource,
 				"err": err.Error(),
-			}, "Unable to marshal keyclaok entitlement resource struct")
+			}, "unable to marshal keyclaok entitlement resource struct")
 			return nil, errors.NewInternalError(errs.Wrap(err, "unable to marshal keyclaok entitlement resource struct"))
 		}
 
@@ -657,7 +657,7 @@ func GetEntitlement(ctx context.Context, entitlementEndpoint string, entitlement
 	if reqErr != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": reqErr.Error(),
-		}, "Unable to create http request")
+		}, "unable to create http request")
 		return nil, errors.NewInternalError(errs.Wrap(reqErr, "unable to create http request"))
 	}
 
@@ -667,7 +667,7 @@ func GetEntitlement(ctx context.Context, entitlementEndpoint string, entitlement
 		log.Error(ctx, map[string]interface{}{
 			"entitlement_resource": entitlementResource,
 			"err": err.Error(),
-		}, "Unable to obtain entitlement resource")
+		}, "unable to obtain entitlement resource")
 		return nil, errors.NewInternalError(errs.Wrap(err, "unable to obtain entitlement resource"))
 	}
 	defer res.Body.Close()
@@ -681,7 +681,7 @@ func GetEntitlement(ctx context.Context, entitlementEndpoint string, entitlement
 			"entitlement_resource": entitlementResource,
 			"response_status":      res.Status,
 			"response_body":        rest.ReadBody(res.Body),
-		}, "Unable to update the Keycloak permission")
+		}, "unable to update the Keycloak permission")
 		return nil, errors.NewInternalError(errs.New("unable to obtain entitlement resource. Response status: " + res.Status + ". Responce body: " + rest.ReadBody(res.Body)))
 	}
 	jsonString := rest.ReadBody(res.Body)
@@ -692,7 +692,7 @@ func GetEntitlement(ctx context.Context, entitlementEndpoint string, entitlement
 		log.Error(ctx, map[string]interface{}{
 			"entitlement_resource": entitlementResource,
 			"json_string":          jsonString,
-		}, "Unable to unmarshal json with the obtain entitlement request result")
+		}, "unable to unmarshal json with the obtain entitlement request result")
 		return nil, errors.NewInternalError(errs.Wrapf(err, "error when unmarshal json with the obtain entitlement request result %s ", jsonString))
 	}
 
@@ -705,7 +705,7 @@ func GetUserInfo(ctx context.Context, userInfoEndpoint string, userAccessToken s
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to create http request")
+		}, "unable to create http request")
 		return nil, errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Authorization", "Bearer "+userAccessToken)
@@ -713,12 +713,12 @@ func GetUserInfo(ctx context.Context, userInfoEndpoint string, userAccessToken s
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to get user info from Keycloak")
+		}, "unable to get user info from Keycloak")
 		return nil, errors.NewInternalError(errs.Wrap(err, "unable to get user info from Keycloak"))
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		log.Error(ctx, map[string]interface{}{}, "Unable to get user info from Keycloak")
+		log.Error(ctx, map[string]interface{}{}, "unable to get user info from Keycloak")
 		return nil, errors.NewInternalError(errs.New("unable to get user info from Keycloak. Response status: " + res.Status + ". Responce body: " + rest.ReadBody(res.Body)))
 	}
 	jsonString := rest.ReadBody(res.Body)
@@ -738,7 +738,7 @@ func ValidateKeycloakUser(ctx context.Context, adminEndpoint string, userID, pro
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to create http request")
+		}, "unable to create http request")
 		return false, errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Authorization", "Bearer "+protectionAPIToken)
@@ -747,7 +747,7 @@ func ValidateKeycloakUser(ctx context.Context, adminEndpoint string, userID, pro
 		log.Error(ctx, map[string]interface{}{
 			"user_id": userID,
 			"err":     err.Error(),
-		}, "Unable to get user from Keycloak")
+		}, "unable to get user from Keycloak")
 		return false, errors.NewInternalError(errs.Wrap(err, "unable to get user from Keycloak"))
 	}
 	defer res.Body.Close()
@@ -759,7 +759,7 @@ func ValidateKeycloakUser(ctx context.Context, adminEndpoint string, userID, pro
 	default:
 		log.Error(ctx, map[string]interface{}{
 			"user_id": userID,
-		}, "Unable to get user from Keycloak")
+		}, "unable to get user from Keycloak")
 		return false, errors.NewInternalError(errs.New("unable to get user from Keycloak. Response status: " + res.Status + ". Responce body: " + rest.ReadBody(res.Body)))
 	}
 }

--- a/auth/authz.go
+++ b/auth/authz.go
@@ -42,7 +42,7 @@ type createResourceRequestResultPayload struct {
 	ID string `json:"_id"`
 }
 
-type cretePolicyRequestResultPayload struct {
+type createPolicyRequestResultPayload struct {
 	ID string `json:"id"`
 }
 
@@ -204,8 +204,8 @@ func CreateResource(ctx context.Context, resource KeycloakResource, authzEndpoin
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to crete http request")
-		return "", errors.NewInternalError(errs.Wrap(err, "unable to crete http request"))
+		}, "Unable to create http request")
+		return "", errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", "Bearer "+protectionAPIToken)
@@ -253,8 +253,8 @@ func GetClientID(ctx context.Context, clientsEndpoint string, publicClientID str
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to crete http request")
-		return "", errors.NewInternalError(errs.Wrap(err, "unable to crete http request"))
+		}, "Unable to create http request")
+		return "", errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Authorization", "Bearer "+protectionAPIToken)
 	res, err := http.DefaultClient.Do(req)
@@ -312,8 +312,8 @@ func CreatePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to crete http request")
-		return "", errors.NewInternalError(errs.Wrap(err, "unable to crete http request"))
+		}, "Unable to create http request")
+		return "", errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", "Bearer "+protectionAPIToken)
@@ -323,7 +323,7 @@ func CreatePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 			"client_id": clientID,
 			"policy":    policy,
 			"err":       err.Error(),
-		}, "Unable to crete the Keycloak policy")
+		}, "Unable to create the Keycloak policy")
 		return "", errors.NewInternalError(errs.Wrap(err, "unable to create the Keycloak policy"))
 	}
 	defer res.Body.Close()
@@ -338,7 +338,7 @@ func CreatePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 	}
 	jsonString := rest.ReadBody(res.Body)
 
-	var r cretePolicyRequestResultPayload
+	var r createPolicyRequestResultPayload
 	err = json.Unmarshal([]byte(jsonString), &r)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
@@ -367,7 +367,7 @@ func CreatePermission(ctx context.Context, clientsEndpoint string, clientID stri
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to crete http request")
+		}, "Unable to create http request")
 		return "", errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Content-Type", "application/json")
@@ -378,7 +378,7 @@ func CreatePermission(ctx context.Context, clientsEndpoint string, clientID stri
 			"client_id":  clientID,
 			"permission": permission,
 			"err":        err.Error(),
-		}, "Unable to crete the Keycloak permission")
+		}, "Unable to create the Keycloak permission")
 		return "", errors.NewInternalError(errs.Wrap(err, "unable to create the Keycloak permission"))
 	}
 	defer res.Body.Close()
@@ -393,7 +393,7 @@ func CreatePermission(ctx context.Context, clientsEndpoint string, clientID stri
 	}
 	jsonString := rest.ReadBody(res.Body)
 
-	var r cretePolicyRequestResultPayload
+	var r createPolicyRequestResultPayload
 	err = json.Unmarshal([]byte(jsonString), &r)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
@@ -421,8 +421,8 @@ func DeleteResource(ctx context.Context, kcResourceID string, authzEndpoint stri
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to crete http request")
-		return errors.NewInternalError(errs.Wrap(err, "unable to crete http request"))
+		}, "Unable to create http request")
+		return errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Authorization", "Bearer "+protectionAPIToken)
 	res, err := http.DefaultClient.Do(req)
@@ -460,8 +460,8 @@ func DeletePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to crete http request")
-		return errors.NewInternalError(errs.Wrap(err, "unable to crete http request"))
+		}, "Unable to create http request")
+		return errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Authorization", "Bearer "+protectionAPIToken)
 	res, err := http.DefaultClient.Do(req)
@@ -499,8 +499,8 @@ func DeletePermission(ctx context.Context, clientsEndpoint string, clientID stri
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to crete http request")
-		return errors.NewInternalError(errs.Wrap(err, "unable to crete http request"))
+		}, "Unable to create http request")
+		return errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Authorization", "Bearer "+protectionAPIToken)
 	res, err := http.DefaultClient.Do(req)
@@ -538,8 +538,8 @@ func GetPolicy(ctx context.Context, clientsEndpoint string, clientID string, pol
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to crete http request")
-		return nil, errors.NewInternalError(errs.Wrap(err, "unable to crete http request"))
+		}, "Unable to create http request")
+		return nil, errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Authorization", "Bearer "+protectionAPIToken)
 	res, err := http.DefaultClient.Do(req)
@@ -605,8 +605,8 @@ func UpdatePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to crete http request")
-		return errors.NewInternalError(errs.Wrap(err, "unable to crete http request"))
+		}, "Unable to create http request")
+		return errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", "Bearer "+protectionAPIToken)
@@ -657,8 +657,8 @@ func GetEntitlement(ctx context.Context, entitlementEndpoint string, entitlement
 	if reqErr != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": reqErr.Error(),
-		}, "Unable to crete http request")
-		return nil, errors.NewInternalError(errs.Wrap(reqErr, "unable to crete http request"))
+		}, "Unable to create http request")
+		return nil, errors.NewInternalError(errs.Wrap(reqErr, "unable to create http request"))
 	}
 
 	req.Header.Add("Authorization", "Bearer "+userAccesToken)
@@ -705,8 +705,8 @@ func GetUserInfo(ctx context.Context, userInfoEndpoint string, userAccessToken s
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to crete http request")
-		return nil, errors.NewInternalError(errs.Wrap(err, "unable to crete http request"))
+		}, "Unable to create http request")
+		return nil, errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Authorization", "Bearer "+userAccessToken)
 	res, err := http.DefaultClient.Do(req)
@@ -738,8 +738,8 @@ func ValidateKeycloakUser(ctx context.Context, adminEndpoint string, userID, pro
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
-		}, "Unable to crete http request")
-		return false, errors.NewInternalError(errs.Wrap(err, "unable to crete http request"))
+		}, "Unable to create http request")
+		return false, errors.NewInternalError(errs.Wrap(err, "unable to create http request"))
 	}
 	req.Header.Add("Authorization", "Bearer "+protectionAPIToken)
 	res, err := http.DefaultClient.Do(req)

--- a/auth/authz.go
+++ b/auth/authz.go
@@ -29,7 +29,7 @@ const (
 	PolicyDecisionStrategyUnanimous = "UNANIMOUS"
 )
 
-// KeycloakResource represents a keyclaok resource payload
+// KeycloakResource represents a keycloak resource payload
 type KeycloakResource struct {
 	Name   string    `json:"name"`
 	Owner  *string   `json:"owner,omitempty"`
@@ -51,7 +51,7 @@ type clientData struct {
 	ClientID string `json:"clientID"`
 }
 
-// KeycloakPolicy represents a keyclaok policy payload
+// KeycloakPolicy represents a keycloak policy payload
 type KeycloakPolicy struct {
 	ID               *string          `json:"id,omitempty"`
 	Name             string           `json:"name"`
@@ -61,7 +61,7 @@ type KeycloakPolicy struct {
 	Config           PolicyConfigData `json:"config"`
 }
 
-// PolicyConfigData represents a config in the keyclaok policy payload
+// PolicyConfigData represents a config in the keycloak policy payload
 type PolicyConfigData struct {
 	//"users":"[\"<ID>\",\"<ID>\"]"
 	UserIDs string `json:"users"`
@@ -115,7 +115,7 @@ func (p *KeycloakPolicy) RemoveUserFromPolicy(userID string) bool {
 	return true
 }
 
-// KeycloakPermission represents a keyclaok permission payload
+// KeycloakPermission represents a keycloak permission payload
 type KeycloakPermission struct {
 	ID               *string              `json:"id,omitempty"`
 	Name             string               `json:"name"`
@@ -125,7 +125,7 @@ type KeycloakPermission struct {
 	Config           PermissionConfigData `json:"config"`
 }
 
-// PermissionConfigData represents a config in the keyclaok permission payload
+// PermissionConfigData represents a config in the keycloak permission payload
 type PermissionConfigData struct {
 	Resources     string `json:"resources"`
 	ApplyPolicies string `json:"applyPolicies"`
@@ -196,8 +196,8 @@ func CreateResource(ctx context.Context, resource KeycloakResource, authzEndpoin
 		log.Error(ctx, map[string]interface{}{
 			"resource": resource,
 			"err":      err.Error(),
-		}, "unable to marshal keyclaok resource struct")
-		return "", errors.NewInternalError(errs.Wrap(err, "unable to marshal keyclaok resource struct"))
+		}, "unable to marshal keycloak resource struct")
+		return "", errors.NewInternalError(errs.Wrap(err, "unable to marshal keycloak resource struct"))
 	}
 
 	req, err := http.NewRequest("POST", authzEndpoint, strings.NewReader(string(b)))
@@ -304,8 +304,8 @@ func CreatePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 		log.Error(ctx, map[string]interface{}{
 			"policy": policy,
 			"err":    err.Error(),
-		}, "unable to marshal keyclaok policy struct")
-		return "", errors.NewInternalError(errs.Wrap(err, "unable to marshal keyclaok policy struct"))
+		}, "unable to marshal keycloak policy struct")
+		return "", errors.NewInternalError(errs.Wrap(err, "unable to marshal keycloak policy struct"))
 	}
 
 	req, err := http.NewRequest("POST", clientsEndpoint+"/"+clientID+"/authz/resource-server/policy", strings.NewReader(string(b)))
@@ -359,8 +359,8 @@ func CreatePermission(ctx context.Context, clientsEndpoint string, clientID stri
 		log.Error(ctx, map[string]interface{}{
 			"permission": permission,
 			"err":        err.Error(),
-		}, "unable to marshal keyclaok permission struct")
-		return "", errors.NewInternalError(errs.Wrap(err, "unable to marshal keyclaok permission struct"))
+		}, "unable to marshal keycloak permission struct")
+		return "", errors.NewInternalError(errs.Wrap(err, "unable to marshal keycloak permission struct"))
 	}
 
 	req, err := http.NewRequest("POST", clientsEndpoint+"/"+clientID+"/authz/resource-server/policy", strings.NewReader(string(b)))
@@ -597,8 +597,8 @@ func UpdatePolicy(ctx context.Context, clientsEndpoint string, clientID string, 
 		log.Error(ctx, map[string]interface{}{
 			"policy": policy,
 			"err":    err.Error(),
-		}, "unable to marshal keyclaok policy struct")
-		return errors.NewInternalError(errs.Wrap(err, "unable to marshal keyclaok policy struct"))
+		}, "unable to marshal keycloak policy struct")
+		return errors.NewInternalError(errs.Wrap(err, "unable to marshal keycloak policy struct"))
 	}
 
 	req, err := http.NewRequest("PUT", clientsEndpoint+"/"+clientID+"/authz/resource-server/policy/"+*policy.ID, strings.NewReader(string(b)))
@@ -645,8 +645,8 @@ func GetEntitlement(ctx context.Context, entitlementEndpoint string, entitlement
 			log.Error(ctx, map[string]interface{}{
 				"entitlement_resource": entitlementResource,
 				"err": err.Error(),
-			}, "unable to marshal keyclaok entitlement resource struct")
-			return nil, errors.NewInternalError(errs.Wrap(err, "unable to marshal keyclaok entitlement resource struct"))
+			}, "unable to marshal keycloak entitlement resource struct")
+			return nil, errors.NewInternalError(errs.Wrap(err, "unable to marshal keycloak entitlement resource struct"))
 		}
 
 		req, reqErr = http.NewRequest("POST", entitlementEndpoint, strings.NewReader(string(b)))
@@ -732,7 +732,7 @@ func GetUserInfo(ctx context.Context, userInfoEndpoint string, userAccessToken s
 	return &r, nil
 }
 
-// ValidateKeycloakUser returns true if the user exists in Keyclaok. Returns false if the user is not found
+// ValidateKeycloakUser returns true if the user exists in Keycloak. Returns false if the user is not found
 func ValidateKeycloakUser(ctx context.Context, adminEndpoint string, userID, protectionAPIToken string) (bool, error) {
 	req, err := http.NewRequest("GET", adminEndpoint+"/users/"+userID, nil)
 	if err != nil {

--- a/auth/resource.go
+++ b/auth/resource.go
@@ -45,7 +45,7 @@ func NewKeycloakResourceManager(config KeycloakConfiguration) *KeycloakResourceM
 	return &KeycloakResourceManager{config}
 }
 
-// CreateResource creates a keyclaok resource and associated permission and policy
+// CreateResource creates a keycloak resource and associated permission and policy
 func (m *KeycloakResourceManager) CreateResource(ctx context.Context, request *goa.RequestData, name string, rType string, uri *string, scopes *[]string, userID string) (*Resource, error) {
 	pat, err := getPat(request, m.configuration)
 	if err != nil {

--- a/auth/state.go
+++ b/auth/state.go
@@ -75,7 +75,7 @@ func (r *GormOauthStateReferenceRepository) Delete(ctx context.Context, ID uuid.
 		log.Error(ctx, map[string]interface{}{
 			"oauth_state_reference_id": ID.String(),
 		}, "unable to delete the oauth state reference")
-		return errors.NewInternalError(err.Error())
+		return errors.NewInternalError(err)
 	}
 	if tx.RowsAffected == 0 {
 		log.Error(ctx, map[string]interface{}{
@@ -96,7 +96,7 @@ func (r *GormOauthStateReferenceRepository) Create(ctx context.Context, referenc
 
 	tx := r.db.Create(reference)
 	if err := tx.Error; err != nil {
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 
 	log.Info(ctx, map[string]interface{}{
@@ -116,7 +116,7 @@ func (r *GormOauthStateReferenceRepository) Load(ctx context.Context, id uuid.UU
 		return nil, errors.NewNotFoundError("oauth state reference", id.String())
 	}
 	if tx.Error != nil {
-		return nil, errors.NewInternalError(tx.Error.Error())
+		return nil, errors.NewInternalError(tx.Error)
 	}
 	return &ref, nil
 }

--- a/codebase/codebase.go
+++ b/codebase/codebase.go
@@ -159,12 +159,12 @@ func (m *GormCodebaseRepository) Save(ctx context.Context, codebase *Codebase) (
 		return nil, errors.NewNotFoundError("codebase", codebase.ID.String())
 	}
 	if err := tx.Error; err != nil {
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 
 	tx = tx.Save(codebase)
 	if err := tx.Error; err != nil {
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 	log.Printf("updated codebase to %v\n", codebase)
 	return codebase, nil
@@ -199,7 +199,7 @@ func (m *GormCodebaseRepository) List(ctx context.Context, spaceID uuid.UUID, st
 	result := []*Codebase{}
 	columns, err := rows.Columns()
 	if err != nil {
-		return nil, 0, errors.NewInternalError(err.Error())
+		return nil, 0, errors.NewInternalError(err)
 	}
 
 	// need to set up a result for Scan() in order to extract total count.
@@ -219,7 +219,7 @@ func (m *GormCodebaseRepository) List(ctx context.Context, spaceID uuid.UUID, st
 		if first {
 			first = false
 			if err = rows.Scan(columnValues...); err != nil {
-				return nil, 0, errors.NewInternalError(err.Error())
+				return nil, 0, errors.NewInternalError(err)
 			}
 		}
 		result = append(result, value)
@@ -250,7 +250,7 @@ func (m *GormCodebaseRepository) Load(ctx context.Context, id uuid.UUID) (*Codeb
 		return nil, errors.NewNotFoundError("codebase", id.String())
 	}
 	if tx.Error != nil {
-		return nil, errors.NewInternalError(tx.Error.Error())
+		return nil, errors.NewInternalError(tx.Error)
 	}
 	return &obj, nil
 }

--- a/comment/comment_repository.go
+++ b/comment/comment_repository.go
@@ -84,7 +84,7 @@ func (m *GormCommentRepository) Save(ctx context.Context, comment *Comment, modi
 			"err":        err,
 		}, "comment search operation failed!")
 
-		return errors.NewInternalError(err.Error())
+		return errors.NewInternalError(err)
 	}
 	// make sure no comment is created with an empty 'markup' value
 	if comment.Markup == "" {
@@ -97,7 +97,7 @@ func (m *GormCommentRepository) Save(ctx context.Context, comment *Comment, modi
 			"err":        err,
 		}, "unable to save the comment!")
 
-		return errors.NewInternalError(err.Error())
+		return errors.NewInternalError(err)
 	}
 	// save a revision of the updated comment
 	if err := m.revisionRepository.Create(ctx, modifierID, RevisionTypeUpdate, *comment); err != nil {
@@ -123,7 +123,7 @@ func (m *GormCommentRepository) Delete(ctx context.Context, commentID uuid.UUID,
 		return errors.NewNotFoundError("comment", commentID.String())
 	}
 	if err := tx.Error; err != nil {
-		return errors.NewInternalError(err.Error())
+		return errors.NewInternalError(err)
 	}
 	// save a revision of the deleted comment
 	if err := m.revisionRepository.Create(ctx, suppressorID, RevisionTypeDelete, c); err != nil {
@@ -161,7 +161,7 @@ func (m *GormCommentRepository) List(ctx context.Context, parent string, start *
 	result := []Comment{}
 	columns, err := rows.Columns()
 	if err != nil {
-		return nil, 0, errors.NewInternalError(err.Error())
+		return nil, 0, errors.NewInternalError(err)
 	}
 
 	// need to set up a result for Scan() in order to extract total count.
@@ -181,7 +181,7 @@ func (m *GormCommentRepository) List(ctx context.Context, parent string, start *
 		if first {
 			first = false
 			if err = rows.Scan(columnValues...); err != nil {
-				return nil, 0, errors.NewInternalError(err.Error())
+				return nil, 0, errors.NewInternalError(err)
 			}
 		}
 		result = append(result, *value)
@@ -230,7 +230,7 @@ func (m *GormCommentRepository) Load(ctx context.Context, id uuid.UUID) (*Commen
 			"err":        tx.Error,
 		}, "unable to load the comment")
 
-		return nil, errors.NewInternalError(tx.Error.Error())
+		return nil, errors.NewInternalError(tx.Error)
 	}
 	return &obj, nil
 }

--- a/comment/comment_revision_repository.go
+++ b/comment/comment_revision_repository.go
@@ -3,13 +3,12 @@ package comment
 import (
 	"context"
 
-	"fmt"
-
 	"time"
 
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/log"
 	"github.com/jinzhu/gorm"
+	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -54,7 +53,7 @@ func (r *GormCommentRevisionRepository) Create(ctx context.Context, modifierID u
 	}
 
 	if err := tx.Create(&revision).Error; err != nil {
-		return errors.NewInternalError(fmt.Sprintf("failed to create new comment revision: %s", err.Error()))
+		return errors.NewInternalError(errs.Wrap(err, "failed to create new comment revision"))
 	}
 	log.Debug(ctx, map[string]interface{}{"comment_id": c.ID}, "comment revision occurrence created")
 	return nil
@@ -65,7 +64,7 @@ func (r *GormCommentRevisionRepository) List(ctx context.Context, commentID uuid
 	log.Debug(nil, map[string]interface{}{}, "List all revisions for comment with ID=%v", commentID.String())
 	revisions := make([]Revision, 0)
 	if err := r.db.Where("comment_id = ?", commentID.String()).Order("revision_time asc").Find(&revisions).Error; err != nil {
-		return nil, errors.NewInternalError(fmt.Sprintf("failed to retrieve comment revisions: %s", err.Error()))
+		return nil, errors.NewInternalError(errs.Wrap(err, "failed to retrieve comment revisions"))
 	}
 	return revisions, nil
 }

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -559,7 +559,7 @@ func (c *ConfigurationData) getKeycloakEndpoint(req *goa.RequestData, endpointVa
 		endpoint = fmt.Sprintf("%s/%s", c.v.GetString(varKeycloakURL), pathSufix)
 	} else {
 		if c.IsPostgresDeveloperModeEnabled() {
-			// Devmode is enabled. Calculate the URL endopoint using the devmode Keyclaok URL
+			// Devmode is enabled. Calculate the URL endopoint using the devmode Keycloak URL
 			endpoint = fmt.Sprintf("%s/%s", devModeKeycloakURL, pathSufix)
 		} else {
 			// Calculate relative URL based on request

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -417,7 +417,7 @@ func (c *ConfigurationData) GetKeycloakDomainPrefix() string {
 	return c.v.GetString(varKeycloakDomainPrefix)
 }
 
-// GetKeycloakRealm returns the keyclaok realm name
+// GetKeycloakRealm returns the keycloak realm name
 func (c *ConfigurationData) GetKeycloakRealm() string {
 	if c.v.IsSet(varKeycloakRealm) {
 		return c.v.GetString(varKeycloakRealm)
@@ -475,7 +475,7 @@ func (c *ConfigurationData) GetKeycloakEndpointUserInfo(req *goa.RequestData) (s
 	return c.getKeycloakOpenIDConnectEndpoint(req, varKeycloakEndpointUserinfo, "userinfo")
 }
 
-// GetKeycloakEndpointAdmin returns the <keyclaok>/realms/admin/<realm> endpoint
+// GetKeycloakEndpointAdmin returns the <keycloak>/realms/admin/<realm> endpoint
 // set via config file or environment variable.
 // If nothing set then in Dev environment the defualt endopoint will be returned.
 // In producion the endpoint will be calculated from the request by replacing the last domain/host name in the full host name.
@@ -485,7 +485,7 @@ func (c *ConfigurationData) GetKeycloakEndpointAdmin(req *goa.RequestData) (stri
 	return c.getKeycloakEndpoint(req, varKeycloakEndpointAdmin, "auth/admin/realms/"+c.GetKeycloakRealm())
 }
 
-// GetKeycloakEndpointAuthzResourceset returns the <keyclaok>/realms/<realm>/authz/protection/resource_set endpoint
+// GetKeycloakEndpointAuthzResourceset returns the <keycloak>/realms/<realm>/authz/protection/resource_set endpoint
 // set via config file or environment variable.
 // If nothing set then in Dev environment the defualt endopoint will be returned.
 // In producion the endpoint will be calculated from the request by replacing the last domain/host name in the full host name.
@@ -495,7 +495,7 @@ func (c *ConfigurationData) GetKeycloakEndpointAuthzResourceset(req *goa.Request
 	return c.getKeycloakEndpoint(req, varKeycloakEndpointAuthzResourceset, "auth/realms/"+c.GetKeycloakRealm()+"/authz/protection/resource_set")
 }
 
-// GetKeycloakEndpointClients returns the <keyclaok>/admin/realms/<realm>/clients endpoint
+// GetKeycloakEndpointClients returns the <keycloak>/admin/realms/<realm>/clients endpoint
 // set via config file or environment variable.
 // If nothing set then in Dev environment the defualt endopoint will be returned.
 // In producion the endpoint will be calculated from the request by replacing the last domain/host name in the full host name.
@@ -505,7 +505,7 @@ func (c *ConfigurationData) GetKeycloakEndpointClients(req *goa.RequestData) (st
 	return c.getKeycloakEndpoint(req, varKeycloakEndpointClients, "auth/admin/realms/"+c.GetKeycloakRealm()+"/clients")
 }
 
-// GetKeycloakEndpointEntitlement returns the <keyclaok>/realms/<realm>/authz/entitlement/<clientID> endpoint
+// GetKeycloakEndpointEntitlement returns the <keycloak>/realms/<realm>/authz/entitlement/<clientID> endpoint
 // set via config file or environment variable.
 // If nothing set then in Dev environment the defualt endopoint will be returned.
 // In producion the endpoint will be calculated from the request by replacing the last domain/host name in the full host name.
@@ -515,7 +515,7 @@ func (c *ConfigurationData) GetKeycloakEndpointEntitlement(req *goa.RequestData)
 	return c.getKeycloakEndpoint(req, varKeycloakEndpointEntitlement, "auth/realms/"+c.GetKeycloakRealm()+"/authz/entitlement/"+c.GetKeycloakClientID())
 }
 
-// GetKeycloakEndpointBroker returns the <keyclaok>/realms/<realm>/authz/entitlement/<clientID> endpoint
+// GetKeycloakEndpointBroker returns the <keycloak>/realms/<realm>/authz/entitlement/<clientID> endpoint
 // set via config file or environment variable.
 // If nothing set then in Dev environment the defualt endopoint will be returned.
 // In producion the endpoint will be calculated from the request by replacing the last domain/host name in the full host name.

--- a/controller/login.go
+++ b/controller/login.go
@@ -21,6 +21,7 @@ import (
 	"github.com/almighty/almighty-core/test"
 	"github.com/almighty/almighty-core/token"
 	"github.com/goadesign/goa"
+	errs "github.com/pkg/errors"
 )
 
 type loginConfiguration interface {
@@ -61,7 +62,7 @@ func (c *LoginController) Authorize(ctx *app.AuthorizeLoginContext) error {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "Unable to get Keycloak auth endpoint URL")
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("unable to get Keycloak auth endpoint URL. "+err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(errs.Wrap(err, "unable to get Keycloak auth endpoint URL")))
 	}
 
 	tokenEndpoint, err := c.configuration.GetKeycloakEndpointToken(ctx.RequestData)
@@ -69,7 +70,7 @@ func (c *LoginController) Authorize(ctx *app.AuthorizeLoginContext) error {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "Unable to get Keycloak token endpoint URL")
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("unable to get Keycloak token endpoint URL. "+err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(errs.Wrap(err, "unable to get Keycloak token endpoint URL")))
 	}
 
 	entitlementEndpoint, err := c.configuration.GetKeycloakEndpointEntitlement(ctx.RequestData)
@@ -77,7 +78,7 @@ func (c *LoginController) Authorize(ctx *app.AuthorizeLoginContext) error {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "Unable to get Keycloak entitlement endpoint URL")
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("unable to get Keycloak entitlement endpoint URL. "+err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(errs.Wrap(err, "unable to get Keycloak entitlement endpoint URL")))
 	}
 
 	brokerEndpoint, err := c.configuration.GetKeycloakEndpointBroker(ctx.RequestData)
@@ -85,18 +86,18 @@ func (c *LoginController) Authorize(ctx *app.AuthorizeLoginContext) error {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "Unable to get Keycloak broker endpoint URL")
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("unable to get Keycloak broker endpoint URL. "+err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(errs.Wrap(err, "unable to get Keycloak broker endpoint URL")))
 	}
 	profileEndpoint, err := c.configuration.GetKeycloakAccountEndpoint(ctx.RequestData)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "unable to get Keycloak account endpoint URL")
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(err))
 	}
 	whitelist, err := c.configuration.GetValidRedirectURLs(ctx.RequestData)
 	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(err))
 	}
 
 	oauth := &oauth2.Config{
@@ -124,7 +125,7 @@ func (c *LoginController) Refresh(ctx *app.RefreshLoginContext) error {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "Unable to get Keycloak token endpoint URL")
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("unable to get Keycloak token endpoint URL "+err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(errs.Wrap(err, "unable to get Keycloak token endpoint URL")))
 	}
 	res, err := client.PostForm(endpoint, url.Values{
 		"client_id":     {c.configuration.GetKeycloakClientID()},
@@ -133,7 +134,7 @@ func (c *LoginController) Refresh(ctx *app.RefreshLoginContext) error {
 		"grant_type":    {"refresh_token"},
 	})
 	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("Error when obtaining token "+err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(errs.Wrap(err, "error when obtaining token")))
 	}
 	defer res.Body.Close()
 	switch res.StatusCode {
@@ -144,7 +145,7 @@ func (c *LoginController) Refresh(ctx *app.RefreshLoginContext) error {
 	case 400:
 		return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError(res.Status+" "+rest.ReadBody(res.Body)))
 	default:
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(res.Status+" "+rest.ReadBody(res.Body)))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(errs.New(res.Status+" "+rest.ReadBody(res.Body))))
 	}
 
 	token, err := auth.ReadToken(res)
@@ -157,7 +158,7 @@ func (c *LoginController) Refresh(ctx *app.RefreshLoginContext) error {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "Unable to get Keycloak token endpoint URL")
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("unable to get Keycloak token endpoint URL "+err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(errs.Wrap(err, "unable to get Keycloak token endpoint URL")))
 	}
 
 	rpt, err := auth.GetEntitlement(ctx, entitlementEndpoint, nil, *token.AccessToken)
@@ -195,12 +196,12 @@ func (c *LoginController) Link(ctx *app.LinkLoginContext) error {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "Unable to get Keycloak broker endpoint URL")
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("unable to get Keycloak broker endpoint URL "+err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(errs.Wrap(err, "unable to get Keycloak broker endpoint URL")))
 	}
 	clientID := c.configuration.GetKeycloakClientID()
 	whitelist, err := c.configuration.GetValidRedirectURLs(ctx.RequestData)
 	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(err))
 	}
 
 	ctx.ResponseData.Header().Set("Cache-Control", "no-cache")
@@ -214,12 +215,12 @@ func (c *LoginController) Linksession(ctx *app.LinksessionLoginContext) error {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "Unable to get Keycloak broker endpoint URL")
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("unable to get Keycloak broker endpoint URL "+err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(errs.Wrap(err, "unable to get Keycloak broker endpoint URL")))
 	}
 	clientID := c.configuration.GetKeycloakClientID()
 	whitelist, err := c.configuration.GetValidRedirectURLs(ctx.RequestData)
 	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(err))
 	}
 
 	ctx.ResponseData.Header().Set("Cache-Control", "no-cache")
@@ -233,7 +234,7 @@ func (c *LoginController) Linkcallback(ctx *app.LinkcallbackLoginContext) error 
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "Unable to get Keycloak broker endpoint URL")
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("unable to get Keycloak broker endpoint URL "+err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(errs.Wrap(err, "unable to get Keycloak broker endpoint URL ")))
 	}
 	clientID := c.configuration.GetKeycloakClientID()
 
@@ -250,7 +251,7 @@ func (c *LoginController) Generate(ctx *app.GenerateLoginContext) error {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "unable to get Keycloak token endpoint URL")
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("unable to get Keycloak token endpoint URL "+err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(errs.Wrap(err, "unable to get Keycloak token endpoint URL")))
 	}
 
 	testuser, err := GenerateUserToken(ctx, tokenEndpoint, c.configuration, c.configuration.GetKeycloakTestUserName(), c.configuration.GetKeycloakTestUserSecret())
@@ -258,7 +259,7 @@ func (c *LoginController) Generate(ctx *app.GenerateLoginContext) error {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "unable to get Generate User token")
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("unable to generate test token "+err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(errs.Wrap(err, "unable to generate test token ")))
 	}
 	// Creates the testuser user and identity if they don't yet exist
 	profileEndpoint, err := c.configuration.GetKeycloakAccountEndpoint(ctx.RequestData)
@@ -266,7 +267,7 @@ func (c *LoginController) Generate(ctx *app.GenerateLoginContext) error {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "unable to get Keycloak account endpoint URL")
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(err))
 	}
 	c.auth.CreateOrUpdateKeycloakUser(*testuser.Token.AccessToken, ctx, profileEndpoint)
 	tokens = append(tokens, testuser)
@@ -276,7 +277,7 @@ func (c *LoginController) Generate(ctx *app.GenerateLoginContext) error {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "unable to get Keycloak token endpoint URL")
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("unable to generate test token "+err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(errs.Wrap(err, "unable to generate test token")))
 	}
 	// Creates the testuser2 user and identity if they don't yet exist
 	c.auth.CreateOrUpdateKeycloakUser(*testuser.Token.AccessToken, ctx, profileEndpoint)
@@ -292,7 +293,7 @@ func GenerateUserToken(ctx context.Context, tokenEndpoint string, configuration 
 		log.Error(ctx, map[string]interface{}{
 			"method": "Generate",
 		}, "Postgres developer mode not enabled")
-		return nil, errors.NewInternalError("Postgres developer mode is not enabled")
+		return nil, errors.NewInternalError(errs.New("postgres developer mode is not enabled"))
 	}
 
 	var scopes []account.Identity
@@ -309,7 +310,7 @@ func GenerateUserToken(ctx context.Context, tokenEndpoint string, configuration 
 		"grant_type":    {"password"},
 	})
 	if err != nil {
-		return nil, errors.NewInternalError("error when obtaining token " + err.Error())
+		return nil, errors.NewInternalError(errs.Wrap(err, "error when obtaining token"))
 	}
 	defer res.Body.Close()
 	token, err := auth.ReadToken(res)
@@ -318,7 +319,7 @@ func GenerateUserToken(ctx context.Context, tokenEndpoint string, configuration 
 			"token_endpoint": res,
 			"err":            err,
 		}, "Error when unmarshal json with access token")
-		return nil, errors.NewInternalError("error when unmarshal json with access token " + err.Error())
+		return nil, errors.NewInternalError(errs.Wrap(err, "error when unmarshal json with access token"))
 	}
 
 	return convertToken(*token), nil

--- a/controller/logout.go
+++ b/controller/logout.go
@@ -7,6 +7,7 @@ import (
 	"github.com/almighty/almighty-core/log"
 	"github.com/almighty/almighty-core/login"
 	"github.com/goadesign/goa"
+	errs "github.com/pkg/errors"
 )
 
 type logoutConfiguration interface {
@@ -33,11 +34,11 @@ func (c *LogoutController) Logout(ctx *app.LogoutLogoutContext) error {
 		log.Error(ctx, map[string]interface{}{
 			"err": err,
 		}, "Unable to get Keycloak logout endpoint URL")
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("unable to get Keycloak logout endpoint URL. "+err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(errs.Wrap(err, "unable to get Keycloak logout endpoint URL")))
 	}
 	whitelist, err := c.configuration.GetValidRedirectURLs(ctx.RequestData)
 	if err != nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(err.Error()))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(err))
 	}
 
 	ctx.ResponseData.Header().Set("Cache-Control", "no-cache")

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -168,7 +168,7 @@ func (c *WorkitemController) Update(ctx *app.UpdateWorkitemContext) error {
 	}
 	creator := wi.Fields[workitem.SystemCreator]
 	if creator == nil {
-		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError("work item doesn't have creator"))
+		return jsonapi.JSONErrorResponse(ctx, errors.NewInternalError(errs.New("work item doesn't have creator")))
 	}
 	authorized, err := authorizeWorkitemEditor(ctx, c.db, ctx.SpaceID, creator.(string), currentUserIdentityID.String())
 	if err != nil {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -22,8 +22,8 @@ func (err simpleError) Error() string {
 }
 
 // NewInternalError returns the custom defined error of type InternalError.
-func NewInternalError(msg string) InternalError {
-	return InternalError{simpleError{msg}}
+func NewInternalError(err error) InternalError {
+	return InternalError{err}
 }
 
 // NewUnauthorizedError returns the custom defined error of type UnauthorizedError.
@@ -38,7 +38,11 @@ func NewForbiddenError(msg string) ForbiddenError {
 
 // InternalError means that the operation failed for some internal, unexpected reason
 type InternalError struct {
-	simpleError
+	err error
+}
+
+func (ie InternalError) Error() string {
+	return ie.err.Error()
 }
 
 // UnauthorizedError means that the operation is unauthorized

--- a/errors/errors_blackbox_test.go
+++ b/errors/errors_blackbox_test.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/resource"
+	errs "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewInternalError(t *testing.T) {
 	t.Parallel()
 	resource.Require(t, resource.UnitTest)
-	err := errors.NewInternalError("System disk could not be read")
+	err := errors.NewInternalError(errs.New("system disk could not be read"))
 
 	// not sure what assertion to do here.
 	t.Log(err)

--- a/iteration/iteration.go
+++ b/iteration/iteration.go
@@ -10,6 +10,7 @@ import (
 	"github.com/almighty/almighty-core/path"
 
 	"context"
+
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	errs "github.com/pkg/errors"
@@ -88,7 +89,7 @@ func (m *GormIterationRepository) LoadMultiple(ctx context.Context, ids []uuid.U
 	}
 	tx := m.db.Find(&objs)
 	if tx.Error != nil {
-		return nil, errors.NewInternalError(tx.Error.Error())
+		return nil, errors.NewInternalError(tx.Error)
 	}
 	return objs, nil
 }
@@ -142,7 +143,7 @@ func (m *GormIterationRepository) Root(ctx context.Context, spaceID uuid.UUID) (
 			"space_id": spaceID,
 			"err":      tx.Error,
 		}, "unable to get the root iteration")
-		return nil, errors.NewInternalError(tx.Error.Error())
+		return nil, errors.NewInternalError(tx.Error)
 	}
 
 	return &itr, nil
@@ -165,7 +166,7 @@ func (m *GormIterationRepository) Load(ctx context.Context, id uuid.UUID) (*Iter
 			"iteration_id": id.String(),
 			"err":          tx.Error,
 		}, "unable to load the iteration")
-		return nil, errors.NewInternalError(tx.Error.Error())
+		return nil, errors.NewInternalError(tx.Error)
 	}
 	return &obj, nil
 }
@@ -187,7 +188,7 @@ func (m *GormIterationRepository) Save(ctx context.Context, i Iteration) (*Itera
 			"iteration_id": i.ID,
 			"err":          err,
 		}, "unknown error happened when searching the iteration")
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 	tx = tx.Save(&i)
 	if err := tx.Error; err != nil {
@@ -195,7 +196,7 @@ func (m *GormIterationRepository) Save(ctx context.Context, i Iteration) (*Itera
 			"iteration_id": i.ID,
 			"err":          err,
 		}, "unable to save the iterations")
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 	return &i, nil
 }

--- a/jsonapi/error_handler.go
+++ b/jsonapi/error_handler.go
@@ -67,7 +67,7 @@ func ErrorHandler(service *goa.Service, verbose bool) goa.Middleware {
 
 				if !verbose {
 					rw.Header().Set("Content-Type", goa.ErrorMediaIdentifier)
-					msg := errors.NewInternalError(fmt.Sprintf("%s [%s]", http.StatusText(http.StatusInternalServerError), reqID))
+					msg := errors.NewInternalError(errs.Errorf("%s [%s]", http.StatusText(http.StatusInternalServerError), reqID))
 					//respBody = goa.ErrInternal(msg)
 					respBody, status = ErrorToJSONAPIErrors(msg)
 					// Preserve the ID of the original error as that's what gets logged, the client

--- a/jsonapi/jsonapi_utility_blackbox_test.go
+++ b/jsonapi/jsonapi_utility_blackbox_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/jsonapi"
 	"github.com/almighty/almighty-core/resource"
+	errs "github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,7 +46,7 @@ func TestErrorToJSONAPIError(t *testing.T) {
 	require.Equal(t, strconv.Itoa(httpStatus), *jerr.Status)
 
 	// test internal server error
-	jerr, httpStatus = jsonapi.ErrorToJSONAPIError(errors.NewInternalError("foo"))
+	jerr, httpStatus = jsonapi.ErrorToJSONAPIError(errors.NewInternalError(errs.New("foo")))
 	require.Equal(t, http.StatusInternalServerError, httpStatus)
 	require.NotNil(t, jerr.Code)
 	require.NotNil(t, jerr.Status)

--- a/login/logout.go
+++ b/login/logout.go
@@ -10,7 +10,7 @@ import (
 	"github.com/goadesign/goa"
 )
 
-// KeycloakLogoutService represents a keyclaok logout service
+// KeycloakLogoutService represents a keycloak logout service
 type KeycloakLogoutService struct {
 }
 

--- a/login/profile.go
+++ b/login/profile.go
@@ -9,6 +9,7 @@ import (
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/log"
 	"github.com/almighty/almighty-core/rest"
+	errs "github.com/pkg/errors"
 )
 
 const ImageURLAttributeName = "imageURL"
@@ -79,12 +80,12 @@ func NewKeycloakUserProfileClient() *KeycloakUserProfileClient {
 func (userProfileClient *KeycloakUserProfileClient) Update(keycloakUserProfile *KeycloakUserProfile, accessToken string, keycloakProfileURL string) error {
 	body, err := json.Marshal(keycloakUserProfile)
 	if err != nil {
-		return errors.NewInternalError(err.Error())
+		return errors.NewInternalError(err)
 	}
 
 	req, err := http.NewRequest("POST", keycloakProfileURL, bytes.NewReader(body))
 	if err != nil {
-		return errors.NewInternalError(err.Error())
+		return errors.NewInternalError(err)
 	}
 	req.Header.Add("Authorization", "Bearer "+accessToken)
 	req.Header.Add("Content-Type", "application/json")
@@ -96,7 +97,7 @@ func (userProfileClient *KeycloakUserProfileClient) Update(keycloakUserProfile *
 			"keycloak_user_profile_url": keycloakProfileURL,
 			"err": err,
 		}, "Unable to update Keycloak user profile")
-		return errors.NewInternalError(err.Error())
+		return errors.NewInternalError(err)
 	} else if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -117,7 +118,7 @@ func (userProfileClient *KeycloakUserProfileClient) Update(keycloakUserProfile *
 			return errors.NewUnauthorizedError(rest.ReadBody(resp.Body))
 		}
 
-		return errors.NewInternalError(fmt.Sprintf("Received a non-200 response %s while updating keycloak user profile %s", resp.Status, keycloakProfileURL))
+		return errors.NewInternalError(errs.Errorf("received a non-200 response %s while updating keycloak user profile %s", resp.Status, keycloakProfileURL))
 	}
 	log.Info(nil, map[string]interface{}{
 		"response_status":           resp.Status,
@@ -135,7 +136,7 @@ func (userProfileClient *KeycloakUserProfileClient) Get(accessToken string, keyc
 
 	req, err := http.NewRequest("GET", keycloakProfileURL, nil)
 	if err != nil {
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 	req.Header.Add("Authorization", "Bearer "+accessToken)
 	req.Header.Add("Content-Type", "application/json")
@@ -148,7 +149,7 @@ func (userProfileClient *KeycloakUserProfileClient) Get(accessToken string, keyc
 			"keycloak_user_profile_url": keycloakProfileURL,
 			"err": err,
 		}, "Unable to fetch Keycloak user profile")
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	} else if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -162,7 +163,7 @@ func (userProfileClient *KeycloakUserProfileClient) Get(accessToken string, keyc
 		if resp.StatusCode == 400 {
 			return nil, errors.NewUnauthorizedError(rest.ReadBody(resp.Body))
 		}
-		return nil, errors.NewInternalError(fmt.Sprintf("Received a non-200 response %s while fetching keycloak user profile %s", resp.Status, keycloakProfileURL))
+		return nil, errors.NewInternalError(errs.Errorf("received a non-200 response %s while fetching keycloak user profile %s", resp.Status, keycloakProfileURL))
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(&keycloakUserProfileResponse)

--- a/login/profile_blackbox_test.go
+++ b/login/profile_blackbox_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/almighty/almighty-core/gormtestsupport"
 	"github.com/almighty/almighty-core/test"
 	"github.com/goadesign/goa"
+	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 
 	"github.com/almighty/almighty-core/login"
@@ -109,7 +110,7 @@ func (s *ProfileBlackBoxTest) generateAccessToken() (*string, error) {
 		"grant_type":    {"password"},
 	})
 	if err != nil {
-		return nil, errors.NewInternalError("error when obtaining token " + err.Error())
+		return nil, errors.NewInternalError(errs.Wrap(err, "error when obtaining token"))
 	}
 
 	token, err := auth.ReadToken(res)

--- a/login/service.go
+++ b/login/service.go
@@ -339,7 +339,7 @@ func (keycloak *KeycloakOAuthProvider) checkFederatedIdentity(ctx context.Contex
 		log.Error(ctx, map[string]interface{}{
 			"err": err.Error(),
 		}, "Unable to crete http request")
-		return false, er.NewInternalError("unable to crete http request " + err.Error())
+		return false, er.NewInternalError(errs.Wrap(err, "unable to crete http request"))
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 	res, err := http.DefaultClient.Do(req)
@@ -348,7 +348,7 @@ func (keycloak *KeycloakOAuthProvider) checkFederatedIdentity(ctx context.Contex
 			"provider": provider,
 			"err":      err.Error(),
 		}, "Unable to obtain a federated identity token")
-		return false, er.NewInternalError("Unable to obtain a federated identity token " + err.Error())
+		return false, er.NewInternalError(errs.Wrap(err, "unable to obtain a federated identity token"))
 	}
 	defer res.Body.Close()
 	return res.StatusCode == http.StatusOK, nil

--- a/login/service.go
+++ b/login/service.go
@@ -46,7 +46,7 @@ func NewKeycloakOAuthProvider(identities account.IdentityRepository, users accou
 	}
 }
 
-// KeycloakOAuthProvider represents a keyclaok IDP
+// KeycloakOAuthProvider represents a keycloak IDP
 type KeycloakOAuthProvider struct {
 	Identities   account.IdentityRepository
 	Users        account.UserRepository
@@ -620,7 +620,7 @@ func encodeToken(ctx context.Context, referrer *url.URL, outhToken *oauth2.Token
 	return nil
 }
 
-// CreateOrUpdateKeycloakUser creates a user and a keyclaok identity. If the user and identity already exist then update them.
+// CreateOrUpdateKeycloakUser creates a user and a keycloak identity. If the user and identity already exist then update them.
 func (keycloak *KeycloakOAuthProvider) CreateOrUpdateKeycloakUser(accessToken string, ctx context.Context, profileEndpoint string) (*account.Identity, *account.User, error) {
 	var identity *account.Identity
 	var user *account.User

--- a/login/service_blackbox_test.go
+++ b/login/service_blackbox_test.go
@@ -385,8 +385,8 @@ func (s *serviceBlackBoxTest) TestInvalidState() {
 	// The OAuth 'state' is sent as a query parameter by calling /api/login/authorize?code=_SOME_CODE_&state=_SOME_STATE_
 	// The request originates from Keycloak after a valid authorization by the end user.
 	// This is not where the redirection should happen on failure.
-	refererKeyclaokUrl := "https://keycloak-url.example.org/path-of-login"
-	req.Header.Add("referer", refererKeyclaokUrl)
+	refererKeycloakUrl := "https://keycloak-url.example.org/path-of-login"
+	req.Header.Add("referer", refererKeycloakUrl)
 
 	prms := url.Values{
 		"state": {},

--- a/resource/require.go
+++ b/resource/require.go
@@ -22,7 +22,7 @@ const (
 	// specify that test can be run that require a database.
 	Database = "ALMIGHTY_RESOURCE_DATABASE"
 	// Remote refers to the name of the environment variable that is used to
-	// specify that test can be run that require availability of some remote servers such as Keyclaok.
+	// specify that test can be run that require availability of some remote servers such as Keycloak.
 	Remote = "ALMIGHTY_RESOURCE_REMOTE"
 	// StSkipReasonValueFalse is the skip message for tests when an environment variable is present but evaluates to false.
 	StSkipReasonValueFalse = "Skipping test because environment variable %s evaluates to false: %s"

--- a/search/search_repository.go
+++ b/search/search_repository.go
@@ -292,7 +292,7 @@ func (r *GormSearchRepository) search(ctx context.Context, sqlSearchQueryParamet
 	value := workitem.WorkItemStorage{}
 	columns, err := rows.Columns()
 	if err != nil {
-		return nil, 0, errors.NewInternalError(err.Error())
+		return nil, 0, errors.NewInternalError(err)
 	}
 
 	// need to set up a result for Scan() in order to extract total count.
@@ -311,7 +311,7 @@ func (r *GormSearchRepository) search(ctx context.Context, sqlSearchQueryParamet
 		if first {
 			first = false
 			if err = rows.Scan(columnValues...); err != nil {
-				return nil, 0, errors.NewInternalError(err.Error())
+				return nil, 0, errors.NewInternalError(err)
 			}
 		}
 		result = append(result, value)
@@ -348,7 +348,7 @@ func (r *GormSearchRepository) SearchFullText(ctx context.Context, rawSearchStri
 		// FIXME: Against best practice http://go-database-sql.org/retrieving.html
 		wiType, err := r.wir.LoadTypeFromDB(ctx, value.Type)
 		if err != nil {
-			return nil, 0, errors.NewInternalError(err.Error())
+			return nil, 0, errors.NewInternalError(err)
 		}
 		wiModel, err := wiType.ConvertWorkItemStorageToModel(value)
 		if err != nil {

--- a/space/authz/authz.go
+++ b/space/authz/authz.go
@@ -51,7 +51,7 @@ func (m *KeycloakAuthzServiceManager) AuthzService() AuthzService {
 	return m.Service
 }
 
-// EntitlementEndpoint returns a keyclaok entitlement endpoint URL
+// EntitlementEndpoint returns a keycloak entitlement endpoint URL
 func (m *KeycloakAuthzServiceManager) EntitlementEndpoint() string {
 	return m.entitlementEndpoint
 }

--- a/space/space.go
+++ b/space/space.go
@@ -103,7 +103,7 @@ func (r *GormRepository) Load(ctx context.Context, ID uuid.UUID) (*Space, error)
 		return nil, errors.NewNotFoundError("space", ID.String())
 	}
 	if tx.Error != nil {
-		return nil, errors.NewInternalError(tx.Error.Error())
+		return nil, errors.NewInternalError(tx.Error)
 	}
 	return &res, nil
 }
@@ -124,7 +124,7 @@ func (r *GormRepository) Delete(ctx context.Context, ID uuid.UUID) error {
 		log.Error(ctx, map[string]interface{}{
 			"space_id": ID.String(),
 		}, "unable to delete the space")
-		return errors.NewInternalError(err.Error())
+		return errors.NewInternalError(err)
 	}
 	if tx.RowsAffected == 0 {
 		log.Error(ctx, map[string]interface{}{
@@ -148,7 +148,7 @@ func (r *GormRepository) Save(ctx context.Context, p *Space) (*Space, error) {
 		return nil, errors.NewNotFoundError("space", p.ID.String())
 	}
 	if err := tx.Error; err != nil {
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 	tx = tx.Where("Version = ?", oldVersion).Save(p)
 	if err := tx.Error; err != nil {
@@ -158,7 +158,7 @@ func (r *GormRepository) Save(ctx context.Context, p *Space) (*Space, error) {
 		if gormsupport.IsUniqueViolation(tx.Error, "spaces_name_idx") {
 			return nil, errors.NewBadParameterError("Name", p.Name).Expected("unique")
 		}
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 	if tx.RowsAffected == 0 {
 		return nil, errors.NewVersionConflictError("version conflict")
@@ -186,7 +186,7 @@ func (r *GormRepository) Create(ctx context.Context, space *Space) (*Space, erro
 		if gormsupport.IsUniqueViolation(tx.Error, "spaces_name_idx") {
 			return nil, errors.NewBadParameterError("Name", space.Name).Expected("unique")
 		}
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 
 	log.Info(ctx, map[string]interface{}{
@@ -230,7 +230,7 @@ func (r *GormRepository) listSpaceFromDB(ctx context.Context, q *string, userID 
 	result := []Space{}
 	columns, err := rows.Columns()
 	if err != nil {
-		return nil, 0, errors.NewInternalError(err.Error())
+		return nil, 0, errors.NewInternalError(err)
 	}
 
 	// need to set up a result for Scan() in order to extract total count.
@@ -250,7 +250,7 @@ func (r *GormRepository) listSpaceFromDB(ctx context.Context, q *string, userID 
 		if first {
 			first = false
 			if err = rows.Scan(columnValues...); err != nil {
-				return nil, 0, errors.NewInternalError(err.Error())
+				return nil, 0, errors.NewInternalError(err)
 			}
 		}
 		result = append(result, value)
@@ -311,7 +311,7 @@ func (r *GormRepository) LoadByOwnerAndName(ctx context.Context, userID *uuid.UU
 		return nil, errors.NewNotFoundError("space", *spaceName)
 	}
 	if tx.Error != nil {
-		return nil, errors.NewInternalError(tx.Error.Error())
+		return nil, errors.NewInternalError(tx.Error)
 	}
 	return &res, nil
 }

--- a/space/space_resource.go
+++ b/space/space_resource.go
@@ -79,7 +79,7 @@ func (r *GormResourceRepository) Load(ctx context.Context, ID uuid.UUID) (*Resou
 		return nil, errors.NewNotFoundError("space resource", ID.String())
 	}
 	if tx.Error != nil {
-		return nil, errors.NewInternalError(tx.Error.Error())
+		return nil, errors.NewInternalError(tx.Error)
 	}
 	return &res, nil
 }
@@ -100,7 +100,7 @@ func (r *GormResourceRepository) Delete(ctx context.Context, ID uuid.UUID) error
 		log.Error(ctx, map[string]interface{}{
 			"space_resource_id": ID.String(),
 		}, "unable to delete the space resource")
-		return errors.NewInternalError(err.Error())
+		return errors.NewInternalError(err)
 	}
 	if tx.RowsAffected == 0 {
 		log.Error(ctx, map[string]interface{}{
@@ -128,7 +128,7 @@ func (r *GormResourceRepository) Save(ctx context.Context, p *Resource) (*Resour
 			"space_resource_id": p.ID,
 			"err":               err,
 		}, "unknown error happened when searching the space resource")
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 	tx = tx.Save(&p)
 	if err := tx.Error; err != nil {
@@ -136,7 +136,7 @@ func (r *GormResourceRepository) Save(ctx context.Context, p *Resource) (*Resour
 			"space_resource_id": p.ID,
 			"err":               err,
 		}, "unable to save the space resource")
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 
 	log.Info(ctx, map[string]interface{}{
@@ -154,7 +154,7 @@ func (r *GormResourceRepository) Create(ctx context.Context, resource *Resource)
 
 	tx := r.db.Create(resource)
 	if err := tx.Error; err != nil {
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 
 	log.Info(ctx, map[string]interface{}{
@@ -174,7 +174,7 @@ func (r *GormResourceRepository) LoadBySpace(ctx context.Context, spaceID *uuid.
 		return nil, errors.NewNotFoundError("space resource", spaceID.String())
 	}
 	if tx.Error != nil {
-		return nil, errors.NewInternalError(tx.Error.Error())
+		return nil, errors.NewInternalError(tx.Error)
 	}
 	return &res, nil
 }

--- a/workitem/link/category_repository.go
+++ b/workitem/link/category_repository.go
@@ -36,7 +36,7 @@ func (r *GormWorkItemLinkCategoryRepository) Create(ctx context.Context, linkCat
 	}
 	db := r.db.Create(linkCat)
 	if db.Error != nil {
-		return nil, errors.NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error)
 	}
 	log.Info(ctx, map[string]interface{}{
 		"wilc_id": linkCat.ID,
@@ -59,7 +59,7 @@ func (r *GormWorkItemLinkCategoryRepository) Load(ctx context.Context, ID uuid.U
 		return nil, errors.NewNotFoundError("work item link category", ID.String())
 	}
 	if db.Error != nil {
-		return nil, errors.NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error)
 	}
 	return &result, nil
 }
@@ -86,7 +86,7 @@ func (r *GormWorkItemLinkCategoryRepository) Delete(ctx context.Context, ID uuid
 	}, "Work item link category to delete")
 	db := r.db.Delete(&cat)
 	if db.Error != nil {
-		return errors.NewInternalError(db.Error.Error())
+		return errors.NewInternalError(db.Error)
 	}
 	if db.RowsAffected == 0 {
 		return errors.NewNotFoundError("work item link category", ID.String())
@@ -111,7 +111,7 @@ func (r *GormWorkItemLinkCategoryRepository) Save(ctx context.Context, linkCat W
 			"wilc_id": linkCat.ID,
 			"err":     db.Error,
 		}, "unable to find work item link category")
-		return nil, errors.NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error)
 	}
 	if res.Version != linkCat.Version {
 		return nil, errors.NewVersionConflictError("version conflict")
@@ -128,7 +128,7 @@ func (r *GormWorkItemLinkCategoryRepository) Save(ctx context.Context, linkCat W
 			"wilc_id": newLinkCat.ID,
 			"err":     db.Error,
 		}, "unable to save work item link category repository")
-		return nil, errors.NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error)
 	}
 	log.Info(ctx, map[string]interface{}{
 		"wilc_id":         newLinkCat.ID,

--- a/workitem/link/link_repository.go
+++ b/workitem/link/link_repository.go
@@ -171,7 +171,7 @@ func (r *GormWorkItemLinkRepository) Create(ctx context.Context, sourceID, targe
 			// TODO(kwk): Make NewBadParameterError a variadic function to avoid this ugliness ;)
 			return nil, errors.NewBadParameterError("data.relationships.source_id + data.relationships.target_id + data.relationships.link_type_id", sourceID).Expected("unique")
 		}
-		return nil, errors.NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error)
 	}
 	// save a revision of the created work item link
 	if err := r.revisionRepo.Create(ctx, creatorID, RevisionTypeCreate, *link); err != nil {
@@ -195,7 +195,7 @@ func (r *GormWorkItemLinkRepository) Load(ctx context.Context, ID uuid.UUID) (*W
 		return nil, errors.NewNotFoundError("work item link", ID.String())
 	}
 	if db.Error != nil {
-		return nil, errors.NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error)
 	}
 	return &result, nil
 }
@@ -277,7 +277,7 @@ func (r *GormWorkItemLinkRepository) deleteLink(ctx context.Context, lnk WorkIte
 			"wil_id": lnk.ID,
 			"err":    tx.Error,
 		}, "unable to delete work item link")
-		return errors.NewInternalError(tx.Error.Error())
+		return errors.NewInternalError(tx.Error)
 	}
 	// save a revision of the deleted work item link
 	if err := r.revisionRepo.Create(ctx, suppressorID, RevisionTypeDelete, lnk); err != nil {
@@ -305,7 +305,7 @@ func (r *GormWorkItemLinkRepository) Save(ctx context.Context, linkToSave WorkIt
 			"wil_id": linkToSave.ID,
 			"err":    db.Error,
 		}, "unable to find work item link")
-		return nil, errors.NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error)
 	}
 	if existingLink.Version != linkToSave.Version {
 		return nil, errors.NewVersionConflictError("version conflict")
@@ -332,7 +332,7 @@ func (r *GormWorkItemLinkRepository) Save(ctx context.Context, linkToSave WorkIt
 			"wil_id": linkToSave.ID,
 			"err":    db.Error,
 		}, "unable to save work item link")
-		return nil, errors.NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error)
 	}
 	// save a revision of the modified work item link
 	if err := r.revisionRepo.Create(ctx, modifierID, RevisionTypeUpdate, linkToSave); err != nil {
@@ -373,11 +373,11 @@ func (r *GormWorkItemLinkRepository) ListWorkItemChildren(ctx context.Context, p
 	for index, value := range result {
 		wiType, err := r.workItemTypeRepo.LoadTypeFromDB(ctx, value.Type)
 		if err != nil {
-			return nil, errors.NewInternalError(err.Error())
+			return nil, errors.NewInternalError(err)
 		}
 		modelWI, err := workitem.ConvertWorkItemStorageToModel(wiType, &value)
 		if err != nil {
-			return nil, errors.NewInternalError(err.Error())
+			return nil, errors.NewInternalError(err)
 		}
 		res[index] = *modelWI
 	}

--- a/workitem/link/link_revision_repository.go
+++ b/workitem/link/link_revision_repository.go
@@ -3,13 +3,12 @@ package link
 import (
 	"context"
 
-	"fmt"
-
 	"time"
 
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/log"
 	"github.com/jinzhu/gorm"
+	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -50,7 +49,7 @@ func (r *GormWorkItemLinkRevisionRepository) Create(ctx context.Context, modifie
 		WorkItemLinkTypeID:   l.LinkTypeID,
 	}
 	if err := tx.Create(&revision).Error; err != nil {
-		return errors.NewInternalError(fmt.Sprintf("failed to create new work item link revision: %s", err.Error()))
+		return errors.NewInternalError(errs.Wrap(err, "failed to create new work item link revision"))
 	}
 	log.Debug(ctx, map[string]interface{}{"wil_id": l.ID}, "work item link revision occurrence created")
 	return nil
@@ -61,7 +60,7 @@ func (r *GormWorkItemLinkRevisionRepository) List(ctx context.Context, linkID uu
 	log.Debug(nil, map[string]interface{}{}, "List all revisions for work item link with ID=%v", linkID.String())
 	revisions := make([]Revision, 0)
 	if err := r.db.Where("work_item_link_id = ?", linkID.String()).Order("revision_time asc").Find(&revisions).Error; err != nil {
-		return nil, errors.NewInternalError(fmt.Sprintf("failed to retrieve work item link revisions: %s", err.Error()))
+		return nil, errors.NewInternalError(errs.Wrap(err, "failed to retrieve work item link revisions"))
 	}
 	return revisions, nil
 }

--- a/workitem/link/type_repository.go
+++ b/workitem/link/type_repository.go
@@ -53,7 +53,7 @@ func (r *GormWorkItemLinkTypeRepository) Create(ctx context.Context, linkType *W
 		return nil, errors.NewBadParameterError("work item link category", linkType.LinkCategoryID)
 	}
 	if db.Error != nil {
-		return nil, errors.NewInternalError(fmt.Sprintf("Failed to find work item link category: %s", db.Error.Error()))
+		return nil, errors.NewInternalError(errs.Wrap(db.Error, "failed to find work item link category"))
 	}
 	// Check space exists
 	space := space.Space{}
@@ -62,12 +62,12 @@ func (r *GormWorkItemLinkTypeRepository) Create(ctx context.Context, linkType *W
 		return nil, errors.NewBadParameterError("work item link space", linkType.SpaceID)
 	}
 	if db.Error != nil {
-		return nil, errors.NewInternalError(fmt.Sprintf("Failed to find work item link space: %s", db.Error.Error()))
+		return nil, errors.NewInternalError(errs.Wrap(db.Error, "failed to find work item link space"))
 	}
 
 	db = r.db.Create(linkType)
 	if db.Error != nil {
-		return nil, errors.NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error)
 	}
 	return linkType, nil
 }
@@ -87,7 +87,7 @@ func (r *GormWorkItemLinkTypeRepository) Load(ctx context.Context, ID uuid.UUID)
 		return nil, errors.NewNotFoundError("work item link type", ID.String())
 	}
 	if db.Error != nil {
-		return nil, errors.NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error)
 	}
 	return &modelLinkType, nil
 }
@@ -122,7 +122,7 @@ func (r *GormWorkItemLinkTypeRepository) Delete(ctx context.Context, spaceID uui
 
 	db := r.db.Delete(&cat)
 	if db.Error != nil {
-		return errors.NewInternalError(db.Error.Error())
+		return errors.NewInternalError(db.Error)
 	}
 	if db.RowsAffected == 0 {
 		return errors.NewNotFoundError("work item link type", ID.String())
@@ -146,7 +146,7 @@ func (r *GormWorkItemLinkTypeRepository) Save(ctx context.Context, modelToSave W
 			"wilt_id": modelToSave.ID,
 			"err":     db.Error,
 		}, "unable to find work item link type repository")
-		return nil, errors.NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error)
 	}
 	if existingModel.Version != modelToSave.Version {
 		return nil, errors.NewVersionConflictError("version conflict")
@@ -159,7 +159,7 @@ func (r *GormWorkItemLinkTypeRepository) Save(ctx context.Context, modelToSave W
 			"wilt":    existingModel,
 			"err":     db.Error,
 		}, "unable to save work item link type repository")
-		return nil, errors.NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error)
 	}
 	log.Info(ctx, map[string]interface{}{
 		"wilt_id": existingModel.ID,

--- a/workitem/workitem_repository.go
+++ b/workitem/workitem_repository.go
@@ -81,7 +81,7 @@ func (r *GormWorkItemRepository) LoadFromDB(ctx context.Context, workitemID stri
 		return nil, errors.NewNotFoundError("work item", workitemID)
 	}
 	if tx.Error != nil {
-		return nil, errors.NewInternalError(tx.Error.Error())
+		return nil, errors.NewInternalError(tx.Error)
 	}
 	return &res, nil
 }
@@ -95,7 +95,7 @@ func (r *GormWorkItemRepository) LoadByID(ctx context.Context, ID string) (*Work
 	}
 	wiType, err := r.witr.LoadTypeFromDB(ctx, res.Type)
 	if err != nil {
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 	return ConvertWorkItemStorageToModel(wiType, res)
 }
@@ -142,11 +142,11 @@ func (r *GormWorkItemRepository) loadWorkItemStorage(ctx context.Context, spaceI
 		return nil, nil, errors.NewNotFoundError("work item", workitemID)
 	}
 	if tx.Error != nil {
-		return nil, nil, errors.NewInternalError(tx.Error.Error())
+		return nil, nil, errors.NewInternalError(tx.Error)
 	}
 	wiType, err := r.witr.LoadTypeFromDB(ctx, wiStorage.Type)
 	if err != nil {
-		return nil, nil, errors.NewInternalError(err.Error())
+		return nil, nil, errors.NewInternalError(err)
 	}
 	return wiStorage, wiType, nil
 }
@@ -162,7 +162,7 @@ func (r *GormWorkItemRepository) LoadTopWorkitem(ctx context.Context) (*WorkItem
 	db = db.Where(query).First(&res)
 	wiType, err := r.witr.LoadTypeFromDB(ctx, res.Type)
 	if err != nil {
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 	return ConvertWorkItemStorageToModel(wiType, &res)
 }
@@ -178,7 +178,7 @@ func (r *GormWorkItemRepository) LoadBottomWorkitem(ctx context.Context) (*WorkI
 	db = db.Where(query).First(&res)
 	wiType, err := r.witr.LoadTypeFromDB(ctx, res.Type)
 	if err != nil {
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 	return ConvertWorkItemStorageToModel(wiType, &res)
 }
@@ -193,7 +193,7 @@ func (r *GormWorkItemRepository) LoadHighestOrder() (float64, error) {
 	db = db.Where(query).First(&res)
 	order, err := strconv.ParseFloat(fmt.Sprintf("%v", res.ExecutionOrder), 64)
 	if err != nil {
-		return 0, errors.NewInternalError(err.Error())
+		return 0, errors.NewInternalError(err)
 	}
 	return order, nil
 }
@@ -214,7 +214,7 @@ func (r *GormWorkItemRepository) Delete(ctx context.Context, spaceID uuid.UUID, 
 	// delete the work item
 	tx := r.db.Delete(workItem)
 	if err = tx.Error; err != nil {
-		return errors.NewInternalError(err.Error())
+		return errors.NewInternalError(err)
 	}
 	if tx.RowsAffected == 0 {
 		return errors.NewNotFoundError("work item", workitemID)
@@ -263,7 +263,7 @@ func (r *GormWorkItemRepository) FindSecondItem(order *float64, secondItemDirect
 		return &ItemID, nil, nil
 	}
 	if tx.Error != nil {
-		return nil, nil, errors.NewInternalError(tx.Error.Error())
+		return nil, nil, errors.NewInternalError(tx.Error)
 	}
 
 	ItemID := strconv.FormatUint(Item.ID, 10)
@@ -283,7 +283,7 @@ func (r *GormWorkItemRepository) FindFirstItem(id string) (*float64, error) {
 		return nil, errors.NewNotFoundError("work item", id)
 	}
 	if tx.Error != nil {
-		return nil, errors.NewInternalError(tx.Error.Error())
+		return nil, errors.NewInternalError(tx.Error)
 	}
 	return &Item.ExecutionOrder, nil
 }
@@ -306,7 +306,7 @@ func (r *GormWorkItemRepository) Reorder(ctx context.Context, direction Directio
 		return nil, errors.NewNotFoundError("work item", wi.ID)
 	}
 	if err := tx.Error; err != nil {
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 	if res.Version != wi.Version {
 		return nil, errors.NewVersionConflictError("version conflict")
@@ -405,7 +405,7 @@ func (r *GormWorkItemRepository) Reorder(ctx context.Context, direction Directio
 	}
 	tx = tx.Where("Version = ?", wi.Version).Save(&res)
 	if err := tx.Error; err != nil {
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 	if tx.RowsAffected == 0 {
 		return nil, errors.NewVersionConflictError("version conflict")
@@ -451,7 +451,7 @@ func (r *GormWorkItemRepository) Save(ctx context.Context, spaceID uuid.UUID, up
 			"version":  updatedWorkItem.Version,
 			"err":      err,
 		}, "unable to save new version of the work item")
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 	if tx.RowsAffected == 0 {
 		return nil, errors.NewVersionConflictError("version conflict")
@@ -479,7 +479,7 @@ func (r *GormWorkItemRepository) Create(ctx context.Context, spaceID uuid.UUID, 
 	// The order of workitems are spaced by a factor of 1000.
 	pos, err := r.LoadHighestOrder()
 	if err != nil {
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 	pos = pos + orderValue
 	wi := WorkItemStorage{
@@ -589,7 +589,7 @@ func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, spaceID uu
 	result := []WorkItemStorage{}
 	columns, err := rows.Columns()
 	if err != nil {
-		return nil, 0, errors.NewInternalError(err.Error())
+		return nil, 0, errors.NewInternalError(err)
 	}
 
 	// need to set up a result for Scan() in order to extract total count.
@@ -609,7 +609,7 @@ func (r *GormWorkItemRepository) listItemsFromDB(ctx context.Context, spaceID uu
 		if first {
 			first = false
 			if err = rows.Scan(columnValues...); err != nil {
-				return nil, 0, errors.NewInternalError(err.Error())
+				return nil, 0, errors.NewInternalError(err)
 			}
 		}
 		result = append(result, value)
@@ -640,11 +640,11 @@ func (r *GormWorkItemRepository) List(ctx context.Context, spaceID uuid.UUID, cr
 	for index, value := range result {
 		wiType, err := r.witr.LoadTypeFromDB(ctx, value.Type)
 		if err != nil {
-			return nil, 0, errors.NewInternalError(err.Error())
+			return nil, 0, errors.NewInternalError(err)
 		}
 		modelWI, err := ConvertWorkItemStorageToModel(wiType, &value)
 		if err != nil {
-			return nil, 0, errors.NewInternalError(err.Error())
+			return nil, 0, errors.NewInternalError(err)
 		}
 		res[index] = *modelWI
 	}
@@ -696,7 +696,7 @@ func (r *GormWorkItemRepository) GetCountsPerIteration(ctx context.Context, spac
 				on fields@> concat('{"system.iteration": "', iterations.id, '"}')::jsonb`).Where(`iterations.space_id = ?
 				and work_items.deleted_at IS NULL`, spaceID).Group(`IterationId`).Scan(&res)
 	if db.Error != nil {
-		return nil, errors.NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error)
 	}
 	countsMap := map[string]WICountsPerIteration{}
 	for _, iterationWithCount := range res {
@@ -718,7 +718,7 @@ func (r *GormWorkItemRepository) GetCountsForIteration(ctx context.Context, iter
 	db := r.db.Raw(query)
 	db.Scan(&res)
 	if db.Error != nil {
-		return nil, errors.NewInternalError(db.Error.Error())
+		return nil, errors.NewInternalError(db.Error)
 	}
 	countsMap := map[string]WICountsPerIteration{}
 	countsMap[iterationID.String()] = WICountsPerIteration{

--- a/workitem/workitem_revision_repository.go
+++ b/workitem/workitem_revision_repository.go
@@ -3,13 +3,12 @@ package workitem
 import (
 	"context"
 
-	"fmt"
-
 	"time"
 
 	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/log"
 	"github.com/jinzhu/gorm"
+	errs "github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -53,7 +52,7 @@ func (r *GormRevisionRepository) Create(ctx context.Context, modifierID uuid.UUI
 		workitemRevision.WorkItemFields = Fields{}
 	}
 	if err := tx.Create(&workitemRevision).Error; err != nil {
-		return errors.NewInternalError(fmt.Sprintf("failed to create new work item revision: %s", err.Error()))
+		return errors.NewInternalError(errs.Wrap(err, "failed to create new work item revisio"))
 	}
 	log.Debug(ctx, map[string]interface{}{"wi_id": workitem.ID}, "Work item revision occurrence created")
 	return nil
@@ -64,7 +63,7 @@ func (r *GormRevisionRepository) List(ctx context.Context, workitemID string) ([
 	log.Debug(nil, map[string]interface{}{}, "List all revisions for work item with ID=%v", workitemID)
 	revisions := make([]Revision, 0)
 	if err := r.db.Where("work_item_id = ?", workitemID).Order("revision_time asc").Find(&revisions).Error; err != nil {
-		return nil, errors.NewInternalError(fmt.Sprintf("failed to retrieve work item revisions: %s", err.Error()))
+		return nil, errors.NewInternalError(errs.Wrap(err, "failed to retrieve work item revisions"))
 	}
 	return revisions, nil
 }

--- a/workitem/workitem_revision_repository.go
+++ b/workitem/workitem_revision_repository.go
@@ -52,7 +52,7 @@ func (r *GormRevisionRepository) Create(ctx context.Context, modifierID uuid.UUI
 		workitemRevision.WorkItemFields = Fields{}
 	}
 	if err := tx.Create(&workitemRevision).Error; err != nil {
-		return errors.NewInternalError(errs.Wrap(err, "failed to create new work item revisio"))
+		return errors.NewInternalError(errs.Wrap(err, "failed to create new work item revision"))
 	}
 	log.Debug(ctx, map[string]interface{}{"wi_id": workitem.ID}, "Work item revision occurrence created")
 	return nil

--- a/workitem/workitemtype_repository.go
+++ b/workitem/workitemtype_repository.go
@@ -68,7 +68,7 @@ func (r *GormWorkItemTypeRepository) Load(ctx context.Context, spaceID uuid.UUID
 			return nil, errors.NewNotFoundError("work item type", id.String())
 		}
 		if err := db.Error; err != nil {
-			return nil, errors.NewInternalError(err.Error())
+			return nil, errors.NewInternalError(err)
 		}
 		cache.Put(res)
 	}
@@ -97,7 +97,7 @@ func (r *GormWorkItemTypeRepository) LoadTypeFromDB(ctx context.Context, id uuid
 			log.Error(ctx, map[string]interface{}{
 				"witID": id,
 			}, "work item type retrieval error", err.Error())
-			return nil, errors.NewInternalError(err.Error())
+			return nil, errors.NewInternalError(err)
 		}
 		cache.Put(res)
 	}
@@ -127,7 +127,7 @@ func (r *GormWorkItemTypeRepository) Create(ctx context.Context, spaceID uuid.UU
 			return nil, errors.NewBadParameterError("extendedTypeID", *extendedTypeID)
 		}
 		if err := db.Error; err != nil {
-			return nil, errors.NewInternalError(err.Error())
+			return nil, errors.NewInternalError(err)
 		}
 		// copy fields from extended type
 		for key, value := range extendedType.Fields {
@@ -156,7 +156,7 @@ func (r *GormWorkItemTypeRepository) Create(ctx context.Context, spaceID uuid.UU
 	}
 
 	if err := r.db.Create(&created).Error; err != nil {
-		return nil, errors.NewInternalError(err.Error())
+		return nil, errors.NewInternalError(err)
 	}
 
 	log.Debug(ctx, map[string]interface{}{"witID": created.ID}, "Work item type created successfully!")


### PR DESCRIPTION
I've changed the constructor `NewInternalServerError` to accept an `error` object instead of a `string`. The short term benefit is two fold in the future:

1. When somebody receives an `InternalServerError` she or he can inspect the cause of the error, e.g. by calling `errs.Cause(err)` (from the `github.com/pkg/errors` package) with the internal server error as the argument. This way we can find out if an internal server error was caused by postgres or is a path error and so forth.

2. We can use the error argument to `NewInternalServerError` to log the error. In the code now we have many places where a `NewInternalServerError` is returned and immediately before we log the error. If we can make sure that all the information to the log message are included within the error we can later remove the log from all the various places and instead just do the log call on error creation.

Maybe in the future we can make similar changes to the other errors as well. For now it is done just for the `InternalServerError`.