### PR TITLE
Work item link still counted after soft-deletion (#1411)

### DIFF
--- a/workitem/link/link_repository.go
+++ b/workitem/link/link_repository.go
@@ -456,7 +456,7 @@ func (r *GormWorkItemLinkRepository) WorkItemHasChildren(ctx context.Context, pa
 		SELECT EXISTS (
 			SELECT 1 FROM %[1]s WHERE id in (
 				SELECT target_id FROM %[2]s
-				WHERE source_id = $1 AND link_type_id IN (
+				WHERE source_id = $1 AND deleted_at IS NULL AND link_type_id IN (
 					SELECT id FROM %[3]s WHERE forward_name = 'parent of'
 				)
 			)

--- a/workitem/link/link_repository_blackbox_test.go
+++ b/workitem/link/link_repository_blackbox_test.go
@@ -106,28 +106,6 @@ func (s *linkRepoBlackBoxTest) createWorkitem(wiType uuid.UUID, title, state str
 		}, s.testIdentity.ID)
 }
 
-func (s *linkRepoBlackBoxTest) TestExistsLink() {
-	// create a parent and a child workitem, then link them together
-	// create 2 workitems for linking
-	parent, err := s.createWorkitem(workitem.SystemBug, "Parent", workitem.SystemStateNew)
-	require.Nil(s.T(), err)
-	parentID, err := strconv.ParseUint(parent.ID, 10, 64)
-	require.Nil(s.T(), err)
-	// create 3 workitems for linking as children to parent workitem
-	child, err := s.createWorkitem(workitem.SystemBug, "Child", workitem.SystemStateNew)
-	require.Nil(s.T(), err)
-	childID, err := strconv.ParseUint(child.ID, 10, 64)
-	require.Nil(s.T(), err)
-	s.T().Log(fmt.Sprintf("creating link with treelinktype.ID=%v", s.testTreeLinkTypeID))
-	wil, err := s.workitemLinkRepo.Create(s.ctx, parentID, childID, s.testTreeLinkTypeID, s.testIdentity.ID)
-	require.Nil(s.T(), err)
-	// when
-	exists, err := s.workitemLinkRepo.Exists(s.ctx, wil.ID.String())
-	// then
-	require.Nil(s.T(), err)
-	require.True(s.T(), exists)
-}
-
 // This creates a parent-child link between two workitems -> parent1 and Child. It tests that when there is an attempt to create another parent (parent2) of child, it should throw an error.
 func (s *linkRepoBlackBoxTest) TestDisallowMultipleParents() {
 	// create 3 workitems for linking
@@ -149,6 +127,28 @@ func (s *linkRepoBlackBoxTest) TestDisallowMultipleParents() {
 	_, err = s.workitemLinkRepo.Create(s.ctx, parent2ID, childID, s.testTreeLinkTypeID, s.testIdentity.ID)
 	// then
 	require.NotNil(s.T(), err)
+}
+
+func (s *linkRepoBlackBoxTest) TestExistsLink() {
+	// create a parent and a child workitem, then link them together
+	// create 2 workitems for linking
+	parent, err := s.createWorkitem(workitem.SystemBug, "Parent", workitem.SystemStateNew)
+	require.Nil(s.T(), err)
+	parentID, err := strconv.ParseUint(parent.ID, 10, 64)
+	require.Nil(s.T(), err)
+	// create 3 workitems for linking as children to parent workitem
+	child, err := s.createWorkitem(workitem.SystemBug, "Child", workitem.SystemStateNew)
+	require.Nil(s.T(), err)
+	childID, err := strconv.ParseUint(child.ID, 10, 64)
+	require.Nil(s.T(), err)
+	s.T().Log(fmt.Sprintf("creating link with treelinktype.ID=%v", s.testTreeLinkTypeID))
+	wil, err := s.workitemLinkRepo.Create(s.ctx, parentID, childID, s.testTreeLinkTypeID, s.testIdentity.ID)
+	require.Nil(s.T(), err)
+	// when
+	exists, err := s.workitemLinkRepo.Exists(s.ctx, wil.ID.String())
+	// then
+	require.Nil(s.T(), err)
+	require.True(s.T(), exists)
 }
 
 // TestCountChildWorkitems tests total number of workitem children returned by list is equal to the total number of workitem children created

--- a/workitem/link/link_repository_blackbox_test.go
+++ b/workitem/link/link_repository_blackbox_test.go
@@ -2,11 +2,11 @@ package link_test
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"testing"
 
 	"github.com/almighty/almighty-core/account"
-	"github.com/almighty/almighty-core/errors"
 	"github.com/almighty/almighty-core/gormsupport/cleaner"
 	"github.com/almighty/almighty-core/gormtestsupport"
 	"github.com/almighty/almighty-core/migration"
@@ -15,20 +15,23 @@ import (
 	testsupport "github.com/almighty/almighty-core/test"
 	"github.com/almighty/almighty-core/workitem"
 	"github.com/almighty/almighty-core/workitem/link"
-
 	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
 type linkRepoBlackBoxTest struct {
 	gormtestsupport.DBTestSuite
-	repo               link.WorkItemLinkRepository
-	clean              func()
-	ctx                context.Context
-	testSpace          uuid.UUID
-	testIdentity       account.Identity
-	testTreeLinkTypeID uuid.UUID
+	workitemLinkRepo         link.WorkItemLinkRepository
+	workitemLinkTypeRepo     link.WorkItemLinkTypeRepository
+	workitemLinkCategoryRepo link.WorkItemLinkCategoryRepository
+	workitemRepo             workitem.WorkItemRepository
+	clean                    func()
+	ctx                      context.Context
+	testSpace                uuid.UUID
+	testIdentity             account.Identity
+	testTreeLinkTypeID       uuid.UUID
 }
 
 // SetupSuite overrides the DBTestSuite's function but calls it before doing anything else
@@ -46,7 +49,10 @@ func TestRunLinkRepoBlackBoxTest(t *testing.T) {
 }
 
 func (s *linkRepoBlackBoxTest) SetupTest() {
-	s.repo = link.NewWorkItemLinkRepository(s.DB)
+	s.workitemRepo = workitem.NewWorkItemRepository(s.DB)
+	s.workitemLinkRepo = link.NewWorkItemLinkRepository(s.DB)
+	s.workitemLinkTypeRepo = link.NewWorkItemLinkTypeRepository(s.DB)
+	s.workitemLinkCategoryRepo = link.NewWorkItemLinkCategoryRepository(s.DB)
 	s.clean = cleaner.DeleteCreatedEntities(s.DB)
 	testIdentity, err := testsupport.CreateTestIdentity(s.DB, "jdoe1", "test")
 	s.testIdentity = testIdentity
@@ -60,220 +66,18 @@ func (s *linkRepoBlackBoxTest) SetupTest() {
 	})
 	s.testSpace = testSpace.ID
 	require.Nil(s.T(), err)
-}
-
-func (s *linkRepoBlackBoxTest) TearDownTest() {
-	s.clean()
-}
-
-// This creates a parent-child link between two workitems -> Parent1 and Child. It tests that when there is an attempt to create another parent (Parent2) of child, it should throw an error.
-func (s *linkRepoBlackBoxTest) TestDisallowMultipleParents() {
-	// create 3 workitems for linking
-	workitemRepository := workitem.NewWorkItemRepository(s.DB)
-	Parent1, err := workitemRepository.Create(
-		s.ctx, s.testSpace, workitem.SystemBug,
-		map[string]interface{}{
-			workitem.SystemTitle: "Parent 1",
-			workitem.SystemState: workitem.SystemStateNew,
-		}, s.testIdentity.ID)
-	require.Nil(s.T(), err)
-	Parent1ID, err := strconv.ParseUint(Parent1.ID, 10, 64)
-
-	Parent2, err := workitemRepository.Create(
-		s.ctx, s.testSpace, workitem.SystemBug,
-		map[string]interface{}{
-			workitem.SystemTitle: "Parent 2",
-			workitem.SystemState: workitem.SystemStateNew,
-		}, s.testIdentity.ID)
-	require.Nil(s.T(), err)
-	Parent2ID, err := strconv.ParseUint(Parent2.ID, 10, 64)
-
-	Child, err := workitemRepository.Create(
-		s.ctx, s.testSpace, workitem.SystemBug,
-		map[string]interface{}{
-			workitem.SystemTitle: "Child",
-			workitem.SystemState: workitem.SystemStateNew,
-		}, s.testIdentity.ID)
-	require.Nil(s.T(), err)
-	ChildID, err := strconv.ParseUint(Child.ID, 10, 64)
-	require.Nil(s.T(), err)
 
 	// Create a work item link category
-	linkCategoryRepository := link.NewWorkItemLinkCategoryRepository(s.DB)
 	categoryName := "test" + uuid.NewV4().String()
 	categoryDescription := "Test Link Category"
 	linkCategoryModel1 := link.WorkItemLinkCategory{
 		Name:        categoryName,
 		Description: &categoryDescription,
 	}
-	linkCategory, err := linkCategoryRepository.Create(s.ctx, &linkCategoryModel1)
+	linkCategory, err := s.workitemLinkCategoryRepo.Create(s.ctx, &linkCategoryModel1)
 	require.Nil(s.T(), err)
 
 	// create tree topology link type
-	linkTypeRepository := link.NewWorkItemLinkTypeRepository(s.DB)
-	linkTypeModel1 := link.WorkItemLinkType{
-		Name:           "TestTreeLinkType",
-		SourceTypeID:   workitem.SystemBug,
-		TargetTypeID:   workitem.SystemBug,
-		ForwardName:    "foo",
-		ReverseName:    "foo",
-		Topology:       "tree",
-		LinkCategoryID: linkCategory.ID,
-		SpaceID:        s.testSpace,
-	}
-	TestTreeLinkType, err := linkTypeRepository.Create(s.ctx, &linkTypeModel1)
-	require.Nil(s.T(), err)
-	s.testTreeLinkTypeID = TestTreeLinkType.ID
-
-	// create a work item link
-	linkRepository := link.NewWorkItemLinkRepository(s.DB)
-	linkTest, err := linkRepository.Create(s.ctx, Parent1ID, ChildID, s.testTreeLinkTypeID, s.testIdentity.ID)
-	require.Nil(s.T(), err)
-
-	var exists bool
-	exists, err = linkRepository.Exists(s.ctx, linkTest.ID.String())
-	require.Nil(s.T(), err)
-	require.True(s.T(), exists)
-
-	_, err = linkRepository.Create(s.ctx, Parent2ID, ChildID, s.testTreeLinkTypeID, s.testIdentity.ID)
-	require.NotNil(s.T(), err)
-}
-
-func (s *linkRepoBlackBoxTest) TestExistsLink() {
-	t := s.T()
-	resource.Require(t, resource.Database)
-
-	t.Run("link exists", func(t *testing.T) {
-		// given
-		// create 3 workitems for linking
-		workitemRepository := workitem.NewWorkItemRepository(s.DB)
-		Parent1, err := workitemRepository.Create(
-			s.ctx, s.testSpace, workitem.SystemBug,
-			map[string]interface{}{
-				workitem.SystemTitle: "Parent 1",
-				workitem.SystemState: workitem.SystemStateNew,
-			}, s.testIdentity.ID)
-		require.Nil(s.T(), err)
-		Parent1ID, err := strconv.ParseUint(Parent1.ID, 10, 64)
-
-		Child, err := workitemRepository.Create(
-			s.ctx, s.testSpace, workitem.SystemBug,
-			map[string]interface{}{
-				workitem.SystemTitle: "Child",
-				workitem.SystemState: workitem.SystemStateNew,
-			}, s.testIdentity.ID)
-		require.Nil(s.T(), err)
-		ChildID, err := strconv.ParseUint(Child.ID, 10, 64)
-		require.Nil(s.T(), err)
-
-		// Create a work item link category
-		linkCategoryRepository := link.NewWorkItemLinkCategoryRepository(s.DB)
-		categoryName := "test exists" + uuid.NewV4().String()
-		categoryDescription := "Test Exists Link Category"
-		linkCategoryModel1 := link.WorkItemLinkCategory{
-			Name:        categoryName,
-			Description: &categoryDescription,
-		}
-		linkCategory, err := linkCategoryRepository.Create(s.ctx, &linkCategoryModel1)
-		require.Nil(s.T(), err)
-
-		// create tree topology link type
-		linkTypeRepository := link.NewWorkItemLinkTypeRepository(s.DB)
-		linkTypeModel1 := link.WorkItemLinkType{
-			Name:           "TestExistsLinkType",
-			SourceTypeID:   workitem.SystemBug,
-			TargetTypeID:   workitem.SystemBug,
-			ForwardName:    "foo",
-			ReverseName:    "foo",
-			Topology:       "tree",
-			LinkCategoryID: linkCategory.ID,
-			SpaceID:        s.testSpace,
-		}
-		TestTreeLinkType, err := linkTypeRepository.Create(s.ctx, &linkTypeModel1)
-		require.Nil(s.T(), err)
-		s.testTreeLinkTypeID = TestTreeLinkType.ID
-
-		// create a work item link
-		linkRepository := link.NewWorkItemLinkRepository(s.DB)
-		linkTest, err := linkRepository.Create(s.ctx, Parent1ID, ChildID, s.testTreeLinkTypeID, s.testIdentity.ID)
-		require.Nil(s.T(), err)
-
-		var exists bool
-		exists, err = linkRepository.Exists(s.ctx, linkTest.ID.String())
-		require.Nil(s.T(), err)
-		require.True(s.T(), exists)
-	})
-
-	t.Run("link doesn't exist", func(t *testing.T) {
-		// then
-		linkRepository := link.NewWorkItemLinkRepository(s.DB)
-		// when
-		exists, err := linkRepository.Exists(s.ctx, uuid.NewV4().String())
-		// then
-		require.IsType(t, errors.NotFoundError{}, err)
-		require.False(t, exists)
-	})
-
-}
-
-// TestCountChildWorkitems tests total number of workitem children returned by list is equal to the total number of workitem children created
-// and total number of workitem children in a page are equal to the "limit" specified
-func (s *linkRepoBlackBoxTest) TestCountChildWorkitems() {
-	workitemRepository := workitem.NewWorkItemRepository(s.DB)
-
-	// create a parent workitem
-	parent, err := workitemRepository.Create(
-		s.ctx, s.testSpace, workitem.SystemBug,
-		map[string]interface{}{
-			workitem.SystemTitle: "Parent",
-			workitem.SystemState: workitem.SystemStateNew,
-		}, s.testIdentity.ID)
-	require.Nil(s.T(), err)
-	parentID, err := strconv.ParseUint(parent.ID, 10, 64)
-
-	// create 3 workitems for linking as children to parent workitem
-	child1, err := workitemRepository.Create(
-		s.ctx, s.testSpace, workitem.SystemBug,
-		map[string]interface{}{
-			workitem.SystemTitle: "Child 1",
-			workitem.SystemState: workitem.SystemStateNew,
-		}, s.testIdentity.ID)
-	require.Nil(s.T(), err)
-	child1ID, err := strconv.ParseUint(child1.ID, 10, 64)
-
-	child2, err := workitemRepository.Create(
-		s.ctx, s.testSpace, workitem.SystemBug,
-		map[string]interface{}{
-			workitem.SystemTitle: "Child 2",
-			workitem.SystemState: workitem.SystemStateNew,
-		}, s.testIdentity.ID)
-	require.Nil(s.T(), err)
-	child2ID, err := strconv.ParseUint(child2.ID, 10, 64)
-	require.Nil(s.T(), err)
-
-	child3, err := workitemRepository.Create(
-		s.ctx, s.testSpace, workitem.SystemBug,
-		map[string]interface{}{
-			workitem.SystemTitle: "Child 3",
-			workitem.SystemState: workitem.SystemStateNew,
-		}, s.testIdentity.ID)
-	require.Nil(s.T(), err)
-	child3ID, err := strconv.ParseUint(child3.ID, 10, 64)
-	require.Nil(s.T(), err)
-
-	// Create a work item link category
-	linkCategoryRepository := link.NewWorkItemLinkCategoryRepository(s.DB)
-	categoryName := "test" + uuid.NewV4().String()
-	categoryDescription := "Test Link Category"
-	linkCategoryModel1 := link.WorkItemLinkCategory{
-		Name:        categoryName,
-		Description: &categoryDescription,
-	}
-	linkCategory, err := linkCategoryRepository.Create(s.ctx, &linkCategoryModel1)
-	require.Nil(s.T(), err)
-
-	// create tree topology link type
-	linkTypeRepository := link.NewWorkItemLinkTypeRepository(s.DB)
 	linkTypeModel1 := link.WorkItemLinkType{
 		Name:           "Parent child item",
 		SourceTypeID:   workitem.SystemBug,
@@ -284,25 +88,133 @@ func (s *linkRepoBlackBoxTest) TestCountChildWorkitems() {
 		LinkCategoryID: linkCategory.ID,
 		SpaceID:        s.testSpace,
 	}
-	TestTreeLinkType, err := linkTypeRepository.Create(s.ctx, &linkTypeModel1)
+	TestTreeLinkType, err := s.workitemLinkTypeRepo.Create(s.ctx, &linkTypeModel1)
 	require.Nil(s.T(), err)
 	s.testTreeLinkTypeID = TestTreeLinkType.ID
+}
+
+func (s *linkRepoBlackBoxTest) TearDownTest() {
+	s.clean()
+}
+
+func (s *linkRepoBlackBoxTest) createWorkitem(wiType uuid.UUID, title, state string) (*workitem.WorkItem, error) {
+	return s.workitemRepo.Create(
+		s.ctx, s.testSpace, wiType,
+		map[string]interface{}{
+			workitem.SystemTitle: title,
+			workitem.SystemState: state,
+		}, s.testIdentity.ID)
+}
+
+func (s *linkRepoBlackBoxTest) TestExistsLink() {
+	// create a parent and a child workitem, then link them together
+	// create 2 workitems for linking
+	parent, err := s.createWorkitem(workitem.SystemBug, "Parent", workitem.SystemStateNew)
+	require.Nil(s.T(), err)
+	parentID, err := strconv.ParseUint(parent.ID, 10, 64)
+	require.Nil(s.T(), err)
+	// create 3 workitems for linking as children to parent workitem
+	child, err := s.createWorkitem(workitem.SystemBug, "Child", workitem.SystemStateNew)
+	require.Nil(s.T(), err)
+	childID, err := strconv.ParseUint(child.ID, 10, 64)
+	require.Nil(s.T(), err)
+	s.T().Log(fmt.Sprintf("creating link with treelinktype.ID=%v", s.testTreeLinkTypeID))
+	wil, err := s.workitemLinkRepo.Create(s.ctx, parentID, childID, s.testTreeLinkTypeID, s.testIdentity.ID)
+	require.Nil(s.T(), err)
+	// when
+	exists, err := s.workitemLinkRepo.Exists(s.ctx, wil.ID.String())
+	// then
+	require.Nil(s.T(), err)
+	require.True(s.T(), exists)
+}
+
+// This creates a parent-child link between two workitems -> parent1 and Child. It tests that when there is an attempt to create another parent (parent2) of child, it should throw an error.
+func (s *linkRepoBlackBoxTest) TestDisallowMultipleParents() {
+	// create 3 workitems for linking
+	parent1, err := s.createWorkitem(workitem.SystemBug, "Parent 1", workitem.SystemStateNew)
+	require.Nil(s.T(), err)
+	parent1ID, err := strconv.ParseUint(parent1.ID, 10, 64)
+	parent2, err := s.createWorkitem(workitem.SystemBug, "Parent 2", workitem.SystemStateNew)
+	require.Nil(s.T(), err)
+	parent2ID, err := strconv.ParseUint(parent2.ID, 10, 64)
+	require.Nil(s.T(), err)
+	child, err := s.createWorkitem(workitem.SystemBug, "Child", workitem.SystemStateNew)
+	require.Nil(s.T(), err)
+	childID, err := strconv.ParseUint(child.ID, 10, 64)
+	require.Nil(s.T(), err)
+	// create a work item link
+	_, err = s.workitemLinkRepo.Create(s.ctx, parent1ID, childID, s.testTreeLinkTypeID, s.testIdentity.ID)
+	require.Nil(s.T(), err)
+	// when
+	_, err = s.workitemLinkRepo.Create(s.ctx, parent2ID, childID, s.testTreeLinkTypeID, s.testIdentity.ID)
+	// then
+	require.NotNil(s.T(), err)
+}
+
+// TestCountChildWorkitems tests total number of workitem children returned by list is equal to the total number of workitem children created
+// and total number of workitem children in a page are equal to the "limit" specified
+func (s *linkRepoBlackBoxTest) TestCountChildWorkitems() {
+	// create a parent workitem
+	parent, err := s.createWorkitem(workitem.SystemBug, "Parent", workitem.SystemStateNew)
+	require.Nil(s.T(), err)
+	parentID, err := strconv.ParseUint(parent.ID, 10, 64)
+	require.Nil(s.T(), err)
+	// create 3 workitems for linking as children to parent workitem
+	child1, err := s.createWorkitem(workitem.SystemBug, "Child 1", workitem.SystemStateNew)
+	require.Nil(s.T(), err)
+	child1ID, err := strconv.ParseUint(child1.ID, 10, 64)
+	require.Nil(s.T(), err)
+	child2, err := s.createWorkitem(workitem.SystemBug, "Child 2", workitem.SystemStateNew)
+	require.Nil(s.T(), err)
+	child2ID, err := strconv.ParseUint(child2.ID, 10, 64)
+	require.Nil(s.T(), err)
+	child3, err := s.createWorkitem(workitem.SystemBug, "Child 3", workitem.SystemStateNew)
+	require.Nil(s.T(), err)
+	child3ID, err := strconv.ParseUint(child3.ID, 10, 64)
+	require.Nil(s.T(), err)
 
 	// link the children workitems to parent
-	linkRepository := link.NewWorkItemLinkRepository(s.DB)
-	_, err = linkRepository.Create(s.ctx, parentID, child1ID, s.testTreeLinkTypeID, s.testIdentity.ID)
+	_, err = s.workitemLinkRepo.Create(s.ctx, parentID, child1ID, s.testTreeLinkTypeID, s.testIdentity.ID)
 	require.Nil(s.T(), err)
 
-	_, err = linkRepository.Create(s.ctx, parentID, child2ID, s.testTreeLinkTypeID, s.testIdentity.ID)
+	_, err = s.workitemLinkRepo.Create(s.ctx, parentID, child2ID, s.testTreeLinkTypeID, s.testIdentity.ID)
 	require.Nil(s.T(), err)
 
-	_, err = linkRepository.Create(s.ctx, parentID, child3ID, s.testTreeLinkTypeID, s.testIdentity.ID)
+	_, err = s.workitemLinkRepo.Create(s.ctx, parentID, child3ID, s.testTreeLinkTypeID, s.testIdentity.ID)
 	require.Nil(s.T(), err)
 
 	offset := 0
 	limit := 1
-	res, count, err := linkRepository.ListWorkItemChildren(s.ctx, parent.ID, &offset, &limit)
+	res, count, err := s.workitemLinkRepo.ListWorkItemChildren(s.ctx, parent.ID, &offset, &limit)
 	require.Nil(s.T(), err)
 	require.Len(s.T(), res, 1)
 	require.Equal(s.T(), 3, int(count))
+}
+
+func (s *linkRepoBlackBoxTest) TestWorkItemHasNoChildAfterDeletion() {
+	// given
+	// create 2 workitems for linking
+	parent, err := s.createWorkitem(workitem.SystemBug, "Parent", workitem.SystemStateNew)
+	require.Nil(s.T(), err)
+	parentID, err := strconv.ParseUint(parent.ID, 10, 64)
+	require.Nil(s.T(), err)
+	// create 3 workitems for linking as children to parent workitem
+	child, err := s.createWorkitem(workitem.SystemBug, "Child", workitem.SystemStateNew)
+	require.Nil(s.T(), err)
+	childID, err := strconv.ParseUint(child.ID, 10, 64)
+	require.Nil(s.T(), err)
+
+	// create a work item link...
+	s.T().Log(fmt.Sprintf("creating link with treelinktype.ID=%v", s.testTreeLinkTypeID))
+	wil, err := s.workitemLinkRepo.Create(s.ctx, parentID, childID, s.testTreeLinkTypeID, s.testIdentity.ID)
+	require.Nil(s.T(), err)
+	// ... and remove it
+	err = s.workitemLinkRepo.Delete(s.ctx, wil.ID, s.testIdentity.ID)
+	require.Nil(s.T(), err)
+
+	// when
+	hasChildren, err := s.workitemLinkRepo.WorkItemHasChildren(s.ctx, parent.ID)
+	// then
+	assert.Nil(s.T(), err)
+	assert.False(s.T(), hasChildren)
 }


### PR DESCRIPTION
Fixing bug where link would still be counted even after soft-deletion
Also refactored the `workitem/link/link_repository_blackbox_test.go` to make
it more readable (using helper methods to create work items and initializing all
needed data during the setup)

Fixes #1411

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>