### PR TITLE
Rename generated methods about condition request support (#1417)

### DIFF
--- a/controller/area.go
+++ b/controller/area.go
@@ -129,7 +129,7 @@ func (c *AreaController) Show(ctx *app.ShowAreaContext) error {
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
-		return ctx.ConditionalEntity(*a, c.config.GetCacheControlAreas, func() error {
+		return ctx.ConditionalRequest(*a, c.config.GetCacheControlAreas, func() error {
 			res := &app.AreaSingle{}
 			res.Data = ConvertArea(appl, ctx.RequestData, *a, addResolvedPath)
 			return ctx.OK(res)

--- a/controller/collaborators_blackbox_test.go
+++ b/controller/collaborators_blackbox_test.go
@@ -255,7 +255,7 @@ func (rest *TestCollaboratorsREST) TestListCollaboratorsNotModifiedUsingIfNoneMa
 	rest.policy.AddUserToPolicy(rest.testIdentity1.ID.String())
 	rest.policy.AddUserToPolicy(rest.testIdentity2.ID.String())
 	// when
-	ifNoneMatch := app.GenerateEntitiesTag([]app.ConditionalResponseEntity{
+	ifNoneMatch := app.GenerateEntitiesTag([]app.ConditionalRequestEntity{
 		rest.testIdentity1.User,
 		rest.testIdentity2.User,
 	})

--- a/controller/comments.go
+++ b/controller/comments.go
@@ -48,7 +48,7 @@ func (c *CommentsController) Show(ctx *app.ShowCommentsContext) error {
 			jerrors, _ := jsonapi.ErrorToJSONAPIErrors(goa.ErrUnauthorized(err.Error()))
 			return ctx.NotFound(jerrors)
 		}
-		return ctx.ConditionalEntity(*cmt, c.config.GetCacheControlComments, func() error {
+		return ctx.ConditionalRequest(*cmt, c.config.GetCacheControlComments, func() error {
 			res := &app.CommentSingle{}
 			// This code should change if others type of parents than WI are allowed
 			includeParentWorkItem, err := CommentIncludeParentWorkItem(ctx, appl, cmt)

--- a/controller/filter.go
+++ b/controller/filter.go
@@ -80,7 +80,7 @@ func (c *FilterController) List(ctx *app.ListFilterContext) error {
 		Data: arr,
 	}
 	// compute an ETag based on the type and query of each filter
-	filterEtagData := make([]app.ConditionalResponseEntity, len(result.Data))
+	filterEtagData := make([]app.ConditionalRequestEntity, len(result.Data))
 	for i, filter := range result.Data {
 		filterEtagData[i] = FilterEtagData{
 			Type:  filter.Attributes.Type,

--- a/controller/iteration.go
+++ b/controller/iteration.go
@@ -119,7 +119,7 @@ func (c *IterationController) Show(ctx *app.ShowIterationContext) error {
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
-		return ctx.ConditionalEntity(*iter, c.config.GetCacheControlIterations, func() error {
+		return ctx.ConditionalRequest(*iter, c.config.GetCacheControlIterations, func() error {
 			wiCounts, err := appl.WorkItems().GetCountsForIteration(ctx, iter.ID)
 			if err != nil {
 				return jsonapi.JSONErrorResponse(ctx, err)

--- a/controller/planner_backlog_blackbox_test.go
+++ b/controller/planner_backlog_blackbox_test.go
@@ -132,7 +132,7 @@ func assertPlannerBacklogWorkItems(t *testing.T, workitems *app.WorkItemList, te
 }
 
 func generateWorkitemsTag(workitems *app.WorkItemList) string {
-	entities := make([]app.ConditionalResponseEntity, len(workitems.Data))
+	entities := make([]app.ConditionalRequestEntity, len(workitems.Data))
 	for i, wi := range workitems.Data {
 		entities[i] = workitem.WorkItem{
 			ID:      *wi.ID,

--- a/controller/space.go
+++ b/controller/space.go
@@ -252,7 +252,7 @@ func (c *SpaceController) Show(ctx *app.ShowSpaceContext) error {
 		if err != nil {
 			return err
 		}
-		entityErr := ctx.ConditionalEntity(*s, c.config.GetCacheControlSpaces, func() error {
+		entityErr := ctx.ConditionalRequest(*s, c.config.GetCacheControlSpaces, func() error {
 			spaceData, err := ConvertSpaceFromModel(ctx.Context, c.db, ctx.RequestData, *s)
 			if err != nil {
 				return err

--- a/controller/space_areas_blackbox_test.go
+++ b/controller/space_areas_blackbox_test.go
@@ -173,7 +173,7 @@ func (rest *TestSpaceAreaREST) TestListAreasNotModifiedUsingIfNoneMatchHeader() 
 	// given
 	parentArea, _, createdAreas := rest.setupAreas()
 	// when
-	ifNoneMatch := app.GenerateEntitiesTag([]app.ConditionalResponseEntity{
+	ifNoneMatch := app.GenerateEntitiesTag([]app.ConditionalRequestEntity{
 		createdAreas[0],
 		createdAreas[1],
 		createdAreas[2],

--- a/controller/space_blackbox_test.go
+++ b/controller/space_blackbox_test.go
@@ -677,7 +677,7 @@ func minimumRequiredUpdateSpace() *app.UpdateSpacePayload {
 }
 
 func generateSpacesTag(entities app.SpaceList) string {
-	modelEntities := make([]app.ConditionalResponseEntity, len(entities.Data))
+	modelEntities := make([]app.ConditionalRequestEntity, len(entities.Data))
 	for i, entityData := range entities.Data {
 		modelEntities[i] = ConvertSpaceToModel(*entityData)
 	}
@@ -688,8 +688,8 @@ func generateSpaceTag(entity app.SpaceSingle) string {
 	return app.GenerateEntityTag(ConvertSpaceToModel(*entity.Data))
 }
 
-func convertSpacesToConditionalEntities(spaceList app.SpaceList) []app.ConditionalResponseEntity {
-	conditionalSpaces := make([]app.ConditionalResponseEntity, len(spaceList.Data))
+func convertSpacesToConditionalEntities(spaceList app.SpaceList) []app.ConditionalRequestEntity {
+	conditionalSpaces := make([]app.ConditionalRequestEntity, len(spaceList.Data))
 	for i, spaceData := range spaceList.Data {
 		conditionalSpaces[i] = ConvertSpaceToModel(*spaceData)
 	}

--- a/controller/space_iterations_test.go
+++ b/controller/space_iterations_test.go
@@ -497,7 +497,7 @@ func assertIterations(t *testing.T, data []*app.Iteration, fatherIteration, chil
 }
 
 func generateIterationsTag(iterations app.IterationList) string {
-	modelEntities := make([]app.ConditionalResponseEntity, len(iterations.Data))
+	modelEntities := make([]app.ConditionalRequestEntity, len(iterations.Data))
 	for i, entity := range iterations.Data {
 		modelEntities[i] = iteration.Iteration{
 			ID: *entity.ID,

--- a/controller/user.go
+++ b/controller/user.go
@@ -64,7 +64,7 @@ func (c *UserController) Show(ctx *app.ShowUserContext) error {
 				return jsonapi.JSONErrorResponse(ctx, errors.Wrap(err, fmt.Sprintf("Can't load user with id %s", userID.UUID)))
 			}
 		}
-		return ctx.ConditionalEntity(*user, c.config.GetCacheControlUser, func() error {
+		return ctx.ConditionalRequest(*user, c.config.GetCacheControlUser, func() error {
 			if c.InitTenant != nil {
 				go func(ctx context.Context) {
 					c.InitTenant(ctx)

--- a/controller/users.go
+++ b/controller/users.go
@@ -71,7 +71,7 @@ func (c *UsersController) Show(ctx *app.ShowUsersContext) error {
 				return jsonapi.JSONErrorResponse(ctx, errors.NewBadParameterError(fmt.Sprintf("User ID %s not valid", userID.UUID), err))
 			}
 		}
-		return ctx.ConditionalEntity(*user, c.config.GetCacheControlUsers, func() error {
+		return ctx.ConditionalRequest(*user, c.config.GetCacheControlUsers, func() error {
 			return ctx.OK(ConvertToAppUser(ctx.RequestData, user, identity))
 		})
 	})

--- a/controller/users_blackbox_test.go
+++ b/controller/users_blackbox_test.go
@@ -952,7 +952,7 @@ func getUserUpdatedAt(appUser app.User) time.Time {
 }
 
 func (s *TestUsersSuite) generateUsersTag(allUsers app.UserArray) string {
-	entities := make([]app.ConditionalResponseEntity, len(allUsers.Data))
+	entities := make([]app.ConditionalRequestEntity, len(allUsers.Data))
 	for i, user := range allUsers.Data {
 		userID, err := uuid.FromString(*user.Attributes.UserID)
 		require.Nil(s.T(), err)

--- a/controller/work_item_comments_blackbox_test.go
+++ b/controller/work_item_comments_blackbox_test.go
@@ -231,7 +231,7 @@ func (rest *TestCommentREST) TestListCommentsByParentWorkItemNotModifiedUsingIfN
 	svc, ctrl := rest.UnSecuredController()
 	offset := "0"
 	limit := 3
-	ifNoneMatch := app.GenerateEntitiesTag([]app.ConditionalResponseEntity{
+	ifNoneMatch := app.GenerateEntitiesTag([]app.ConditionalRequestEntity{
 		comments[2],
 		comments[1],
 		comments[0],

--- a/controller/work_item_link.go
+++ b/controller/work_item_link.go
@@ -366,15 +366,6 @@ type showWorkItemLinkFuncs interface {
 	InternalServerError(r *app.JSONAPIErrors) error
 }
 
-func showWorkItemLink(modelLink link.WorkItemLink, ctx *workItemLinkContext, httpFuncs showWorkItemLinkFuncs) error {
-	// convert to rest representation
-	appLink := ConvertLinkFromModel(modelLink)
-	if err := enrichLinkSingle(ctx, &appLink); err != nil {
-		return jsonapi.JSONErrorResponse(httpFuncs, err)
-	}
-	return httpFuncs.OK(&appLink)
-}
-
 // Show runs the show action.
 func (c *WorkItemLinkController) Show(ctx *app.ShowWorkItemLinkContext) error {
 	return application.Transactional(c.db, func(appl application.Application) error {
@@ -382,9 +373,14 @@ func (c *WorkItemLinkController) Show(ctx *app.ShowWorkItemLinkContext) error {
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
-		return ctx.ConditionalEntity(*modelLink, c.config.GetCacheControlWorkItemLinks, func() error {
+		return ctx.ConditionalRequest(*modelLink, c.config.GetCacheControlWorkItemLinks, func() error {
 			linkCtx := newWorkItemLinkContext(ctx.Context, appl, c.db, ctx.RequestData, ctx.ResponseData, app.WorkItemLinkHref, nil)
-			return showWorkItemLink(*modelLink, linkCtx, ctx)
+			// convert to rest representation
+			appLink := ConvertLinkFromModel(*modelLink)
+			if err := enrichLinkSingle(linkCtx, &appLink); err != nil {
+				return jsonapi.JSONErrorResponse(ctx, err)
+			}
+			return ctx.OK(&appLink)
 		})
 	})
 }

--- a/controller/work_item_link_blackbox_test.go
+++ b/controller/work_item_link_blackbox_test.go
@@ -703,7 +703,7 @@ func (s *workItemLinkSuite) TestListWorkItemLinkNotModifiedUsingIfNoneMatchHeade
 	// when
 	modelLink1, _ := ConvertLinkToModel(*link1)
 	modelLink2, _ := ConvertLinkToModel(*link2)
-	ifNoneMatch := app.GenerateEntitiesTag([]app.ConditionalResponseEntity{modelLink1, modelLink2})
+	ifNoneMatch := app.GenerateEntitiesTag([]app.ConditionalRequestEntity{modelLink1, modelLink2})
 	res := test.ListWorkItemLinkNotModified(s.T(), s.svc.Context, s.svc, s.workItemLinkCtrl, nil, &ifNoneMatch)
 	// then
 	assertResponseHeaders(s.T(), res)

--- a/controller/work_item_link_type.go
+++ b/controller/work_item_link_type.go
@@ -218,7 +218,7 @@ func (c *WorkItemLinkTypeController) Show(ctx *app.ShowWorkItemLinkTypeContext) 
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
-		return ctx.ConditionalEntity(*modelLinkType, c.config.GetCacheControlWorkItemLinkTypes, func() error {
+		return ctx.ConditionalRequest(*modelLinkType, c.config.GetCacheControlWorkItemLinkTypes, func() error {
 			// Convert the created link type entry into a rest representation
 			appLinkType := ConvertWorkItemLinkTypeFromModel(ctx.RequestData, *modelLinkType)
 

--- a/controller/work_item_link_type_blackbox_test.go
+++ b/controller/work_item_link_type_blackbox_test.go
@@ -472,7 +472,7 @@ func (s *workItemLinkTypeSuite) TestListWorkItemLinkTypeNotModifiedUsingIfNoneMa
 	_, createdWorkItemLinkType := s.createWorkItemLinkTypes()
 	_, existingLinkTypes := test.ListWorkItemLinkTypeOK(s.T(), nil, nil, s.linkTypeCtrl, *createdWorkItemLinkType.Data.Relationships.Space.Data.ID, nil, nil)
 	// when fetching all work item link type in a give space
-	createdWorkItemLinkTypeModels := make([]app.ConditionalResponseEntity, len(existingLinkTypes.Data))
+	createdWorkItemLinkTypeModels := make([]app.ConditionalRequestEntity, len(existingLinkTypes.Data))
 	for i, linkTypeData := range existingLinkTypes.Data {
 		createdWorkItemLinkTypeModel, err := ConvertWorkItemLinkTypeToModel(
 			app.WorkItemLinkTypeSingle{

--- a/controller/workitem.go
+++ b/controller/workitem.go
@@ -319,7 +319,7 @@ func (c *WorkitemController) Show(ctx *app.ShowWorkitemContext) error {
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, errs.Wrap(err, fmt.Sprintf("Fail to load work item with id %v", ctx.WiID)))
 		}
-		return ctx.ConditionalEntity(*wi, c.config.GetCacheControlWorkItems, func() error {
+		return ctx.ConditionalRequest(*wi, c.config.GetCacheControlWorkItems, func() error {
 			wi2 := ConvertWorkItem(ctx.RequestData, *wi, comments, hasChildren)
 			resp := &app.WorkItemSingle{
 				Data: wi2,

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -2525,7 +2525,7 @@ func (s *WorkItemSuite) TestUpdateWorkitemForSpaceCollaborator() {
 	test.ReorderWorkitemForbidden(s.T(), svcNotAuthrized.Context, svcNotAuthrized, ctrlNotAuthrize, *space.ID, &payload4)
 }
 
-func convertWorkItemToConditionalResponseEntity(appWI app.WorkItemSingle) app.ConditionalResponseEntity {
+func convertWorkItemToConditionalResponseEntity(appWI app.WorkItemSingle) app.ConditionalRequestEntity {
 	return workitem.WorkItem{
 		ID:      *appWI.Data.ID,
 		Version: appWI.Data.Attributes["version"].(int),

--- a/controller/workitemtype.go
+++ b/controller/workitemtype.go
@@ -47,7 +47,7 @@ func (c *WorkitemtypeController) Show(ctx *app.ShowWorkitemtypeContext) error {
 		if err != nil {
 			return jsonapi.JSONErrorResponse(ctx, err)
 		}
-		return ctx.ConditionalEntity(*witModel, c.config.GetCacheControlWorkItemTypes, func() error {
+		return ctx.ConditionalRequest(*witModel, c.config.GetCacheControlWorkItemTypes, func() error {
 			witData := ConvertWorkItemTypeFromModel(ctx.RequestData, witModel)
 			wit := &app.WorkItemTypeSingle{Data: &witData}
 			return ctx.OK(wit)

--- a/controller/workitemtype_blackbox_test.go
+++ b/controller/workitemtype_blackbox_test.go
@@ -790,7 +790,7 @@ func convertWorkItemTypeToModel(data app.WorkItemTypeData) workitem.WorkItemType
 }
 
 func generateWorkItemTypesTag(entities app.WorkItemTypeList) string {
-	modelEntities := make([]app.ConditionalResponseEntity, len(entities.Data))
+	modelEntities := make([]app.ConditionalRequestEntity, len(entities.Data))
 	for i, entityData := range entities.Data {
 		modelEntities[i] = convertWorkItemTypeToModel(*entityData)
 	}
@@ -802,7 +802,7 @@ func generateWorkItemTypeTag(entity app.WorkItemTypeSingle) string {
 }
 
 func generateWorkItemLinkTypesTag(entities app.WorkItemLinkTypeList) string {
-	modelEntities := make([]app.ConditionalResponseEntity, len(entities.Data))
+	modelEntities := make([]app.ConditionalRequestEntity, len(entities.Data))
 	for i, entityData := range entities.Data {
 		e, _ := ConvertWorkItemLinkTypeToModel(app.WorkItemLinkTypeSingle{Data: entityData})
 		modelEntities[i] = e
@@ -815,8 +815,8 @@ func generateWorkItemLinkTypeTag(entity app.WorkItemLinkTypeSingle) string {
 	return app.GenerateEntityTag(e)
 }
 
-func convertWorkItemTypesToConditionalEntities(workItemTypeList app.WorkItemTypeList) []app.ConditionalResponseEntity {
-	conditionalWorkItemTypes := make([]app.ConditionalResponseEntity, len(workItemTypeList.Data))
+func convertWorkItemTypesToConditionalEntities(workItemTypeList app.WorkItemTypeList) []app.ConditionalRequestEntity {
+	conditionalWorkItemTypes := make([]app.ConditionalRequestEntity, len(workItemTypeList.Data))
 	for i, data := range workItemTypeList.Data {
 		conditionalWorkItemTypes[i] = convertWorkItemTypeToModel(*data)
 	}


### PR DESCRIPTION
Let's use some more common terms for the generate interfaces and methods that deal with support for conditional requests.
For instance:

- interface ConditionalResponseEntity -> ConditionalRequestEntity
- method ctx.ConditionalEntity(...) -> ctx.ConditionalRequest(...)

Fixes #1417

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

* Please describe what your change is about.
* What issues does it solve? (Use [autoreferencing for this](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests))
* If you are still working on the change please prefix the pull request title with "WIP"
