### PR TITLE
Add "regenerate" make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,10 @@ migrate-database: $(BINARY_SERVER_BIN)
 ## Generate GOA sources. Only necessary after clean of if changed `design` folder.
 generate: app/controllers.go assets/js/client.js bindata_assetfs.go migration/sqlbindata.go
 
+.PHONY: regenerate
+## Runs the "clean-generated" and the "generate" target
+regenerate: clean-generated generate 
+
 .PHONY: dev
 dev: prebuild-check deps generate $(FRESH_BIN)
 	docker-compose up -d db


### PR DESCRIPTION
Many times when switching between development branches you need to update the generated code and clean it up before. This little change adds a `regenerate` make target to do exactly that:

1. clean the generated code
2. generate it again