### PR TITLE
SpaceCodebasesController.Create saves StackId

### DIFF
--- a/controller/space_codebases.go
+++ b/controller/space_codebases.go
@@ -54,7 +54,7 @@ func (c *SpaceCodebasesController) Create(ctx *app.CreateSpaceCodebasesContext) 
 			SpaceID: ctx.SpaceID,
 			Type:    *reqIter.Attributes.Type,
 			URL:     *reqIter.Attributes.URL,
-			//TODO: We don't have the StackID here.
+			StackID: *reqIter.Attributes.StackID,
 		}
 		err = appl.Codebases().Create(ctx, &newCodeBase)
 		if err != nil {


### PR DESCRIPTION
* Please describe what your change is about.
StackId is not saved in DB when creating a space codebase

* What issues does it solve? (Use [autoreferencing for this](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests))

Fixes https://github.com/almighty/almighty-core/issues/1430

