### PR TITLE
WIP : [need help] Adding CORS Response headers in APIs

### DIFF
--- a/controller/space.go
+++ b/controller/space.go
@@ -241,6 +241,7 @@ func (c *SpaceController) List(ctx *app.ListSpaceContext) error {
 	if txnErr != nil {
 		return jsonapi.JSONErrorResponse(ctx, txnErr)
 	}
+	ctx.ResponseData.Header().Set("Access-Control-Allow-Origin", "*")
 	return ctx.OK(&response)
 }
 

--- a/design/api.go
+++ b/design/api.go
@@ -19,11 +19,20 @@ var _ = a.API("alm", func() {
 		a.Name("Apache License Version 2.0")
 		a.URL("http://www.apache.org/licenses/LICENSE-2.0")
 	})
-	a.Origin("/[.*almighty.io|localhost]/", func() {
-		a.Methods("GET", "POST", "PUT", "PATCH", "DELETE")
-		a.Headers("X-Request-Id", "Content-Type", "Authorization", "If-None-Match", "If-Modified-Since")
-		a.MaxAge(600)
+	a.Origin("/[.*openshift.io|localhost]/", func() {
+		a.Methods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
 		a.Credentials()
+		a.Headers(
+			"Access-Control-Allow-Origin",
+			"Access-Control-Allow-Credentials",
+			"Access-Control-Allow-Methods",
+			"Access-Control-Allow-Headers",
+			"X-Request-Id",
+			"Content-Type",
+			"Authorization",
+			"If-None-Match",
+			"If-Modified-Since")
+		a.MaxAge(600)
 	})
 
 	a.Trait("GenericLinksTrait", func() {
@@ -40,6 +49,7 @@ var _ = a.API("alm", func() {
 		a.Headers(func() {
 			a.Header("If-Modified-Since", d.String)
 			a.Header("If-None-Match", d.String)
+			a.Header("Access-Control-Allow-Origin", d.String)
 		})
 	})
 
@@ -56,6 +66,10 @@ var _ = a.API("alm", func() {
 			a.Header("Last-Modified", d.DateTime)
 			a.Header("ETag")
 			a.Header("Cache-Control")
+			a.Header("Access-Control-Request-Method")
+			a.Header("Access-Control-Request-Headers")
+			a.Header("Access-Control-Allow-Origin")
+			a.Header("Access-Control-Allow-Credentials")
 		})
 	})
 
@@ -66,6 +80,21 @@ var _ = a.API("alm", func() {
 			a.Header("Location", d.String, "href to created resource", func() {
 				a.Pattern(pattern)
 			})
+			a.Header("Access-Control-Request-Method")
+			a.Header("Access-Control-Request-Headers")
+			a.Header("Access-Control-Allow-Origin")
+			a.Header("Access-Control-Allow-Credentials")
+		})
+	})
+
+	a.ResponseTemplate(d.NotFound, func(pattern string) {
+		a.Description("Resource not found")
+		a.Status(404)
+		a.Headers(func() {
+			a.Header("Access-Control-Request-Method")
+			a.Header("Access-Control-Request-Headers")
+			a.Header("Access-Control-Allow-Origin")
+			a.Header("Access-Control-Allow-Credentials")
 		})
 	})
 })


### PR DESCRIPTION
**Problem statement:** 
UI needs to differentiate between response codes like 401, 404 etc.
UI is using angularJS/rxJS (and such frameworks) to make REST calls.
When responses are sent by the server, it has a status code, message everything set except few important headers.
When these headers are not present in response, it will not be parsed correctly by browser/framework so it produces output like-
``` {_body: ProgressEvent, status: 0, ok: false, statusText: "", headers: Headers…}```
Note the status code is 0, the reason behind this is the response is not having `cors` headers set.

**Solution:**
Add `cors` headers in the response.

**Try 1:**
As I understand, [Origin](https://goa.design/reference/goa/design/apidsl/#func-origin-a-name-apidsl-origin-a) is used for this purpose.
I did the same in https://github.com/almighty/almighty-core/commit/e3e83c2a314f2fef631c881b76cc021b72e9949b and GET requests are getting response headers added as expected in it. But other requests are not affected. Sounds odd but yes.
Also, [Credentials](https://goa.design/reference/goa/design/apidsl/#func-credentials-a-name-apidsl-credentials-a) seems to be taking care of our problem, we already have that in code.

**Try 2:**
Added the header to the response separately to each API via our code in the controller like this https://github.com/almighty/almighty-core/commit/e3e83c2a314f2fef631c881b76cc021b72e9949b.
This will work but I am not very okay with it. Each API in each controller will need a change somehow.

**Questions:**
1. Does the Try1 should be enough and I am missing something?
2. Any idea about how to handle URLs which are invalid? (e.g> `api/space/spaceID/hello-world`) this URL is not registered in the application and hence it will be 404 but how to set response header for such requests. Should this be handled at Nginx level?

@hectorj2f @xcoulon @kwk @sbose78 Please let me know your thoughts. Or point me in some direction.