### PR TITLE
Add update-client Make target

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -812,6 +812,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "843238741f4e88d78a8acaa703af920f93880a14b119627c75831c56a6e20393"
+  inputs-digest = "284ad58436782380c1524b9794fbca2cc798fbdeab89818fdd22a063398d9e19"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
The `update-client` make target builds the fabric8-wit client and compares it with the fabric8-wit-client 
 repository. If there are updates, there will be a tmp/client-repo/ that has a new commit with all the 
 changes that went into the upstream project. The client lib is only updated when there were changes to  the design code in the upstream project.

There's no automation yet to push the updated lib back to github but it can easily be integrated.

To test this PR try running `make update-client` locally and inspect the `tmp/client-repo/` directory with `git log`. It should contain an updated version of the repo with client code in it. Once that code is push to the https://github.com/fabric8-services/fabric8-wit-client repo, the client code will only be updated upon changes to the `design` directory because only that affects the client code atm.

See #2063
