### PR TITLE
Disable sentry

### DIFF
--- a/jsonapi/jsonapi_utility.go
+++ b/jsonapi/jsonapi_utility.go
@@ -11,7 +11,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/app"
 	"github.com/fabric8-services/fabric8-wit/errors"
 	"github.com/fabric8-services/fabric8-wit/log"
-	"github.com/fabric8-services/fabric8-wit/sentry"
 
 	"github.com/goadesign/goa"
 	errs "github.com/pkg/errors"
@@ -174,7 +173,7 @@ func JSONErrorResponse(ctx InternalServerErrorContext, err error) error {
 			return ctx.Conflict(jsonErr)
 		}
 	}
-	sentry.Sentry().CaptureError(ctx, err)
+	// sentry.Sentry().CaptureError(ctx, err)
 	return ctx.InternalServerError(jsonErr)
 }
 

--- a/main.go
+++ b/main.go
@@ -30,7 +30,6 @@ import (
 	"github.com/fabric8-services/fabric8-wit/notification"
 	"github.com/fabric8-services/fabric8-wit/remoteworkitem"
 	"github.com/fabric8-services/fabric8-wit/rest"
-	"github.com/fabric8-services/fabric8-wit/sentry"
 	"github.com/fabric8-services/fabric8-wit/space/authz"
 	"github.com/fabric8-services/fabric8-wit/swagger"
 	"github.com/fabric8-services/fabric8-wit/token"
@@ -88,16 +87,16 @@ func main() {
 	log.InitializeLogger(config.IsLogJSON(), config.GetLogLevel())
 
 	// Initialize sentry client
-	haltSentry, err := sentry.InitializeSentryClient(
-		sentry.WithRelease(controller.Commit),
-		sentry.WithEnvironment(config.GetEnvironment()),
-	)
-	if err != nil {
-		log.Panic(nil, map[string]interface{}{
-			"err": err,
-		}, "failed to setup the sentry client")
-	}
-	defer haltSentry()
+	// haltSentry, err := sentry.InitializeSentryClient(
+	// 	sentry.WithRelease(controller.Commit),
+	// 	sentry.WithEnvironment(config.GetEnvironment()),
+	// )
+	// if err != nil {
+	// 	log.Panic(nil, map[string]interface{}{
+	// 		"err": err,
+	// 	}, "failed to setup the sentry client")
+	// }
+	// defer haltSentry()
 
 	printUserInfo()
 


### PR DESCRIPTION
Our sentry service is moving to another location. Let's disable it for now. We might want to migrate to the new server later.